### PR TITLE
Add Copying / Filtering facilities to `dotnet new eqxetl`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ The `Unreleased` section name is replaced by the expected version of next releas
 
 - `dotnet new eqxprojector` now uses `Jet.ConfluentKafka.FSharp 1.0.0-rc1` (which uses `Confluent.Kafka 1.0.0-RC2`, `librdkafka 1.0.0`)
 - Target `Equinox`.* v `2.0.0-preview3`
+- `dotnet new eqxetl` now supports command-line category white/blacklist [#18](https://github.com/jet/dotnet-templates/pull/18)
+- `dotnet new eqxetl` now supports command-line selection of an `aux` collection in either the `source` or destination collections [#18](https://github.com/jet/dotnet-templates/pull/18)
 
 ### Removed
 ### Fixed

--- a/equinox-etl/Etl/Program.fs
+++ b/equinox-etl/Etl/Program.fs
@@ -23,76 +23,82 @@ module CmdParser =
     [<NoEquality; NoComparison>]
     type Parameters =
         | [<MainCommand; ExactlyOnce>] ConsumerGroupName of string
-        | [<AltCommandLine "-v"; Unique>] Verbose
-        | [<AltCommandLine "-vc"; Unique>] ChangeFeedVerbose
-        | [<AltCommandLine "-s"; Unique>] LeaseCollectionSuffix of string
+        | [<AltCommandLine "-as"; Unique>] LeaseCollectionSource of string
+        | [<AltCommandLine "-ad"; Unique>] LeaseCollectionDestination of string
         | [<AltCommandLine "-i"; Unique>] ForceStartFromHere
         | [<AltCommandLine "-m"; Unique>] BatchSize of int
         | [<AltCommandLine "-l"; Unique>] LagFreqS of float
+        | [<AltCommandLine "-v"; Unique>] Verbose
+        | [<AltCommandLine "-vc"; Unique>] ChangeFeedVerbose
         | [<CliPrefix(CliPrefix.None); Unique(*ExactlyOnce is not supported*); Last>] Source of ParseResults<SourceParameters>
         interface IArgParserTemplate with
             member a.Usage =
                 match a with
                 | ConsumerGroupName _ ->    "Projector consumer group name."
-                | LeaseCollectionSuffix _ ->"specify Collection Name suffix for Leases collection, relative to `cosmos` arguments (default: `-aux`)."
                 | ForceStartFromHere _ ->   "(iff the Consumer Name is fresh) - force skip to present Position. Default: Never skip an event."
                 | BatchSize _ ->            "maximum item count to request from feed. Default: 1000"
+                | LeaseCollectionSource _ ->"specify Collection Name for Leases collection, within `source` connection/database (default: `source`'s `collection` + `-aux`)."
+                | LeaseCollectionDestination _ ->"specify Collection Name for Leases collection, within [destination] `cosmos` connection/database (default: defined relative to `source`'s `collection`)."
                 | LagFreqS _ ->             "specify frequency to dump lag stats. Default: off"
                 | Verbose ->                "request Verbose Logging. Default: off"
                 | ChangeFeedVerbose ->      "request Verbose Logging from ChangeFeedProcessor. Default: off"
                 | Source _ ->               "CosmosDb input parameters."
     and Arguments(a : ParseResults<Parameters>) =
         member __.LeaseId =             a.GetResult ConsumerGroupName
-
-        member __.Verbose =             a.Contains Verbose
-
-        member __.Suffix =              a.GetResult(LeaseCollectionSuffix,"-aux")
-        member __.ChangeFeedVerbose =   a.Contains ChangeFeedVerbose
+        member __.StartFromHere =       a.Contains ForceStartFromHere
         member __.BatchSize =           a.GetResult(BatchSize,1000)
         member __.LagFrequency =        a.TryGetResult LagFreqS |> Option.map TimeSpan.FromSeconds
-        member __.AuxCollectionName =   __.Destination.Collection + __.Suffix
-        member __.StartFromHere =       a.Contains ForceStartFromHere
 
-        member val Source = SourceArguments(a.GetResult Source)
+        member __.Verbose =             a.Contains Verbose
+        member __.ChangeFeedVerbose =   a.Contains ChangeFeedVerbose
+
+        member val Source : SourceArguments = SourceArguments(a.GetResult Source)
         member __.Destination : DestinationArguments = __.Source.Destination
         member x.BuildChangeFeedParams() =
-            Log.Information("Processing {leaseId} in {auxCollName} in batches of {batchSize}", x.LeaseId, x.AuxCollectionName, x.BatchSize)
+            let disco, db =
+                match a.TryGetResult LeaseCollectionSource, a.TryGetResult LeaseCollectionDestination with
+                | None, None -> x.Source.Discovery, { database = x.Source.Database; collection = x.Source.Collection + "-aux" }
+                | Some sc, None -> x.Source.Discovery, { database = x.Source.Database; collection = sc }
+                | None, Some dc -> x.Destination.Discovery, { database = x.Destination.Database; collection = dc }
+                | Some _, Some _ -> raise (MissingArg "LeaseCollectionSource and LeaseCollectionDestination are mutually exclusive - can only store in one database")
+            Log.Information("Processing {leaseId} in {db} in batches of {batchSize}", x.LeaseId, db, x.BatchSize)
             if x.StartFromHere then Log.Warning("(If new projector group) Skipping projection of all existing events.")
             x.LagFrequency |> Option.iter (fun s -> Log.Information("Dumping lag stats at {lagS:n0}s intervals", s.TotalSeconds)) 
-            x.Destination.Discovery, { database = x.Destination.Database; collection = x.AuxCollectionName}, x.LeaseId, x.StartFromHere, x.BatchSize, x.LagFrequency
+            disco, db, x.LeaseId, x.StartFromHere, x.BatchSize, x.LagFrequency
     and [<NoEquality; NoComparison>] SourceParameters =
         | [<AltCommandLine "-m">] SourceConnectionMode of Equinox.Cosmos.ConnectionMode
         | [<AltCommandLine "-o">] SourceTimeout of float
         | [<AltCommandLine "-r">] SourceRetries of int
         | [<AltCommandLine "-rt">] SourceRetriesWaitTime of int
-        | [<AltCommandLine "-s"; Unique(*Mandatory is not supported*)>] SourceConnection of string
-        | [<AltCommandLine "-d"; Unique(*Mandatory is not supported*)>] SourceDatabase of string
+        | [<AltCommandLine "-s">] SourceConnection of string
+        | [<AltCommandLine "-d">] SourceDatabase of string
         | [<AltCommandLine "-c"; Unique(*Mandatory is not supported*)>] SourceCollection of string
         | [<CliPrefix(CliPrefix.None); Unique(*ExactlyOnce is not supported*); Last>] Cosmos of ParseResults<DestinationParameters>
         interface IArgParserTemplate with
             member a.Usage =
                 match a with
+                | SourceConnection _ ->     "specify a connection string for a Cosmos account (defaults: envvar:EQUINOX_COSMOS_CONNECTION)."
+                | SourceDatabase _ ->       "specify a database name for Cosmos account (defaults: envvar:EQUINOX_COSMOS_DATABASE)."
+                | SourceCollection _ ->     "specify a collection name within `SourceDatabase`."
                 | SourceTimeout _ ->        "specify operation timeout in seconds (default: 5)."
                 | SourceRetries _ ->        "specify operation retries (default: 1)."
                 | SourceRetriesWaitTime _ ->"specify max wait-time for retry when being throttled by Cosmos in seconds (default: 5)"
-                | SourceConnection _ ->     "specify a connection string for a Cosmos account."
                 | SourceConnectionMode _ -> "override the connection mode (default: DirectTcp)."
-                | SourceDatabase _ ->       "specify a database name for Cosmos account (defaults: envvar:EQUINOX_COSMOS_DATABASE, test)."
-                | SourceCollection _ ->     "specify a collection name for Cosmos account (defaults: envvar:EQUINOX_COSMOS_COLLECTION, test)."
                 | Cosmos _ ->               "CosmosDb destination parameters."
     and SourceArguments(a : ParseResults<SourceParameters>) =
         member val Destination =        DestinationArguments(a.GetResult Cosmos)
-        member __.Mode =                a.GetResult(SourceConnectionMode,Equinox.Cosmos.ConnectionMode.DirectTcp)
-        member __.Connection =          a.GetResult SourceConnection
-        member __.Database =            a.GetResult SourceDatabase
+        member __.Mode =                a.GetResult(SourceConnectionMode, Equinox.Cosmos.ConnectionMode.DirectTcp)
+        member __.Discovery =           Discovery.FromConnectionString __.Connection
+        member __.Connection =          match a.TryGetResult SourceConnection   with Some x -> x | None -> envBackstop "Connection" "EQUINOX_COSMOS_CONNECTION"
+        member __.Database =            match a.TryGetResult SourceDatabase     with Some x -> x | None -> envBackstop "Database"   "EQUINOX_COSMOS_DATABASE"
         member __.Collection =          a.GetResult SourceCollection
 
-        member __.Timeout =             a.GetResult(SourceTimeout,5.) |> TimeSpan.FromSeconds
+        member __.Timeout =             a.GetResult(SourceTimeout, 5.) |> TimeSpan.FromSeconds
         member __.Retries =             a.GetResult(SourceRetries, 1)
         member __.MaxRetryWaitTime =    a.GetResult(SourceRetriesWaitTime, 5)
 
         member x.BuildConnectionDetails() =
-            let (Discovery.UriAndKey (endpointUri,_)) as discovery = Discovery.FromConnectionString x.Connection
+            let (Discovery.UriAndKey (endpointUri,_)) as discovery = x.Discovery
             Log.Information("Source CosmosDb {mode} {endpointUri} Database {database} Collection {collection}",
                 x.Mode, endpointUri, x.Database, x.Collection)
             Log.Information("Source CosmosDb timeout {timeout}s; Throttling retries {retries}, max wait {maxRetryWaitTime}s",
@@ -110,21 +116,21 @@ module CmdParser =
         interface IArgParserTemplate with
             member a.Usage =
                 match a with
-                | Connection _ ->           "specify a connection string for a Cosmos account (defaults: envvar:EQUINOX_COSMOS_CONNECTION)."
-                | Database _ ->             "specify a database name for Cosmos account (defaults: envvar:EQUINOX_COSMOS_DATABASE)."
-                | Collection _ ->           "specify a collection name for Cosmos account (defaults: envvar:EQUINOX_COSMOS_COLLECTION)."
+                | Connection _ ->           "specify a connection string for a Cosmos account (default: envvar:EQUINOX_COSMOS_CONNECTION)."
+                | Database _ ->             "specify a database name for Cosmos account (default: envvar:EQUINOX_COSMOS_DATABASE)."
+                | Collection _ ->           "specify a collection name for Cosmos account (default: envvar:EQUINOX_COSMOS_COLLECTION)."
                 | Timeout _ ->              "specify operation timeout in seconds (default: 5)."
                 | Retries _ ->              "specify operation retries (default: 1)."
                 | RetriesWaitTime _ ->      "specify max wait-time for retry when being throttled by Cosmos in seconds (default: 5)"
                 | ConnectionMode _ ->       "override the connection mode (default: DirectTcp)."
     and DestinationArguments(a : ParseResults<DestinationParameters>) =
-        member __.Mode =                a.GetResult(ConnectionMode,Equinox.Cosmos.ConnectionMode.DirectTcp)
+        member __.Mode =                a.GetResult(ConnectionMode, Equinox.Cosmos.ConnectionMode.DirectTcp)
+        member __.Discovery =           Discovery.FromConnectionString __.Connection
         member __.Connection =          match a.TryGetResult Connection  with Some x -> x | None -> envBackstop "Connection" "EQUINOX_COSMOS_CONNECTION"
         member __.Database =            match a.TryGetResult Database    with Some x -> x | None -> envBackstop "Database"   "EQUINOX_COSMOS_DATABASE"
         member __.Collection =          match a.TryGetResult Collection  with Some x -> x | None -> envBackstop "Collection" "EQUINOX_COSMOS_COLLECTION"
-        member __.Discovery =           Discovery.FromConnectionString __.Connection
 
-        member __.Timeout =             a.GetResult(Timeout,5.) |> TimeSpan.FromSeconds
+        member __.Timeout =             a.GetResult(Timeout, 5.) |> TimeSpan.FromSeconds
         member __.Retries =             a.GetResult(Retries, 1)
         member __.MaxRetryWaitTime =    a.GetResult(RetriesWaitTime, 5)
 
@@ -378,11 +384,13 @@ let transformV0 (v0SchemaDocument: Document) : Ingester.Batch seq = seq {
     let streamName = if parsed.Stream.Contains '-' then parsed.Stream else "Prefixed-"+parsed.Stream
     yield { stream = streamName; span = { index = parsed.Index; events = [| parsed |] } } }
 //#else
-let transform (changeFeedDocument: Document) : Ingester.Batch seq = seq {
-    (* TODO MAKE THIS DO YOUR BIDDING *)
-    for e in DocumentParser.enumEvents changeFeedDocument ->
-        let streamName = "Cloned-" + e.Stream
-        { stream = streamName; span = { index = e.Index; events = [| e |] } }
+let transformOrFilter (changeFeedDocument: Document) : Ingester.Batch seq = seq {
+    for e in DocumentParser.enumEvents changeFeedDocument do
+        match e.Stream.Split([|'-'|],2).[0] with
+        | "PickTicket" ->
+            // NB the index needs to be contiguous with existing events - IOW filtering needs to be at stream (and not event) level
+            yield { stream = e.Stream; span = { index = e.Index; events = [| e |] } }
+        | _ -> ()
 }
 //#endif
 
@@ -399,7 +407,7 @@ let main argv =
 #if marveleqx
         let createSyncHandler () = createRangeSyncHandler log target transformV0
 #else
-        let createSyncHandler () = createRangeSyncHandler log target transform
+        let createSyncHandler () = createRangeSyncHandler log target transformOrFilter
 #endif
 //#if Testing
         let createSyncHandler () = createRangeSyncHandler log target transformV0

--- a/equinox-etl/README.md
+++ b/equinox-etl/README.md
@@ -3,12 +3,16 @@
 This project was generated using:
 
 //#if marveleqx
+
     dotnet new -i Equinox.Templates # just once, to install/update in the local templates store
     dotnet new eqxetl -m # -m - include Marvel V0 import logic
+
 //#else
+
     dotnet new -i Equinox.Templates # just once, to install/update in the local templates store
     # add -m to include Marvel V0 import logic
     dotnet new eqxetl # use --help to see options
+
 //#endif
 
 ## Usage instructions
@@ -41,9 +45,9 @@ This project was generated using:
         # `cosmos` specifies the destination (if you have specified 3x EQUINOX_COSMOS_* environment vars, no arguments are needed)
         # `source -s connection -d database -c collection` specifies the input datasource
 
-        $env:EQUINOX_COSMOS_CONNECTION_SOURCE="AccountEndpoint=https://....;AccountKey=....=;" # or use -s
-        $env:EQUINOX_COSMOS_DATABASE_SOURCE="input-database" # or use -d
-        $env:EQUINOX_COSMOS_COLLECTION_SOURCE="input_collection" # or use - c
+        $env:EQUINOX_COSMOS_CONNECTION_SOURCE="AccountEndpoint=https://....;AccountKey=....=;" # or use -s # or defaults to EQUINOX_COSMOS_CONNECTION
+        $env:EQUINOX_COSMOS_DATABASE_SOURCE="input-database" # or use -d # or defaults to EQUINOX_COSMOS_DATABASE
+        $env:EQUINOX_COSMOS_COLLECTION_SOURCE="input_collection" # or use -c # NB DOES NOT HAVE A DEFAULT VALUE
 
         dotnet run -p Etl -- defaultEtl `
             source -s $env:EQUINOX_COSMOS_CONNECTION_SOURCE -d $env:EQUINOX_COSMOS_DATABASE_SOURCE -c $env:EQUINOX_COSMOS_COLLECTION_SOURCE `


### PR DESCRIPTION
This polishes the ETL template to enable clean usage for the following synchronization needs:
- [x] Straight copying of all events
- [x] Filtering specified categories (`-x`)
- [x] Copying only specified categories (`-i`)
- [x] Being able to maintain the `aux` collection in either the `source` (`-as` and/or default) or destination (`cosmos`) container (`-ad`)
- [x] Cleaner argument processing for cases where you're syncing within the same database (`EQUINOX_COSMOS_CONNECTION` and `EQUINOX_COSMOS_DATABASE` apply to both source and destination)