### PR TITLE
Add state logging to Streams examples

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,8 +16,8 @@ The `Unreleased` section name is replaced by the expected version of next releas
 
 ### Changed
 
-- `eqxtestbed`, `eqxweb`, `eqxwebcs` now target `Equinox 2.0.0-preview9`
-- `eqxprojector` `-k` now targets `Jet.ConfluentKafka.FSharp` + `Propulsion.Kafka` v `1.0.1-rc2` [#24](https://github.com/jet/dotnet-templates/pull/24)
+- `eqxtestbed`, `eqxweb`, `eqxwebcs` now target `Equinox 2.0.0-rc1`
+- `eqxprojector` `-k` now targets `Jet.ConfluentKafka.FSharp` + `Propulsion.Kafka` v `1.0.1-rc3` [#24](https://github.com/jet/dotnet-templates/pull/24)
 - `eqxsync` now targets `Propulsion.Cosmos`,`Propulsion.EventStore` v `1.0.1-rc2` [#24](https://github.com/jet/dotnet-templates/pull/24)
 
 ### Removed

--- a/equinox-projector/Consumer/Codec.fs
+++ b/equinox-projector/Consumer/Codec.fs
@@ -1,0 +1,41 @@
+﻿namespace ProjectorTemplate.Consumer.Codec
+
+open Serilog
+open System
+
+[<AutoOpen>]
+module Codec =
+    let parse(x : Propulsion.Streams.IEvent<'T>) =
+        { new Equinox.Codec.IEvent<_> with
+            member __.EventType = x.EventType
+            member __.Data = x.Data
+            member __.Meta = x.Meta
+            member __.Timestamp = x.Timestamp }
+    let tryDecode (codec : Equinox.Codec.IUnionEncoder<_,_>) (log : ILogger) (stream : string) (x : Equinox.Codec.IEvent<byte[]>) =
+        match codec.TryDecode x with
+        | None ->
+            if log.IsEnabled Serilog.Events.LogEventLevel.Debug then
+                log.ForContext("event", System.Text.Encoding.UTF8.GetString(x.Data), true)
+                    .Debug("Codec {type} Could not decode {eventType} in {stream}", codec.GetType().FullName, x.EventType, stream)
+            None
+        | x -> x
+
+    type Propulsion.Streams.StreamSpan<'T> with
+        // Enumerate the events we've been presented from this stream
+        member __.Events : (Equinox.Codec.IEvent<_>) [] =
+            __.events |> Array.map parse
+
+    // Enumerate the events in this message
+    type Propulsion.Codec.NewtonsoftJson.RenderedSpan with
+        member __.Events =
+            __.e |> Array.map parse
+
+[<AutoOpen>]
+module StreamNameParser = 
+    let private catSeparators = [|'-';'_'|]
+    let private split (streamName : string) = streamName.Split(catSeparators, 2, StringSplitOptions.RemoveEmptyEntries)
+    let category (streamName : string) = let fragments = split streamName in fragments.[0]
+    let (|Category|Unknown|) (streamName : string) =
+        match split streamName with
+        | [| category; id |] -> Category (category, id)
+        | _ -> Unknown streamName

--- a/equinox-projector/Consumer/Consumer.fsproj
+++ b/equinox-projector/Consumer/Consumer.fsproj
@@ -8,6 +8,7 @@
 
   <ItemGroup>
     <Compile Include="Infrastructure.fs" />
+    <Compile Include="Codec.fs" />
     <Compile Include="Examples.fs" />
     <Compile Include="Program.fs" />
   </ItemGroup>
@@ -16,7 +17,7 @@
     <PackageReference Include="Argu" Version="5.4.0" />
     <PackageReference Include="Destructurama.FSharp.NetCore" Version="1.0.14" />
     <PackageReference Include="Equinox.Codec" Version="2.0.0-preview9" />
-    <PackageReference Include="Propulsion.Kafka" Version="1.0.1-rc2" />
+    <PackageReference Include="Propulsion.Kafka" Version="1.0.1-rc3" />
     <PackageReference Include="Serilog.Sinks.Console" Version="3.1.1" />
   </ItemGroup>
 

--- a/equinox-projector/Consumer/Examples.fs
+++ b/equinox-projector/Consumer/Examples.fs
@@ -1,6 +1,7 @@
 ﻿namespace ProjectorTemplate.Consumer
 
 open Newtonsoft.Json
+open ProjectorTemplate.Consumer.Codec
 open Serilog
 open System
 open System.Collections.Concurrent
@@ -18,8 +19,9 @@ type CatStats() =
     member __.Clear() = partitions.Clear()
     member __.StatsDescending = partitions |> Seq.map (|KeyValue|) |> Seq.sortBy (fun (_,s) -> -s)
 
-[<AutoOpen>]
-module EventParser =
+/// When processing streamwise, he handler is passed deduplicates spans of events per stream, with a guarantee of max 1
+/// in-flight request per stream
+module Streams =
 
     type SkuId = string
 
@@ -40,8 +42,12 @@ module EventParser =
             | Removed of Removed
             /// Addition of a collection of skus to the list
             | Added of Added
+            /// Clearing of the list
+            | Cleared
             interface TypeShape.UnionContract.IUnionContract
         let codec = Equinox.Codec.NewtonsoftJson.Json.Create<Event>(settings)
+        let tryDecode = tryDecode codec
+        let [<Literal>] CategoryId = "SavedForLater"
 
     // NB - these schemas reflect the actual storage formats and hence need to be versioned with care
     module Favorites =
@@ -53,139 +59,189 @@ module EventParser =
             | Unfavorited       of Unfavorited
             interface TypeShape.UnionContract.IUnionContract
         let codec = Equinox.Codec.NewtonsoftJson.Json.Create<Event>(settings)
-    
-    let tryDecode (log : ILogger) (stream : string) (codec : Equinox.Codec.IUnionEncoder<_,_>) (x : Equinox.Codec.IEvent<byte[]>) =
-        match codec.TryDecode x with
-        | None ->
-            if log.IsEnabled Serilog.Events.LogEventLevel.Debug then
-                log.ForContext("event", System.Text.Encoding.UTF8.GetString(x.Data), true)
-                    .Debug("Codec {type} Could not decode {eventType} in {stream}", codec.GetType().FullName, x.EventType, stream);
-            None
-        | Some e -> Some e
+        let tryDecode = tryDecode codec
+        let [<Literal>] CategoryId = "Favorites"
 
-type Message = Faves of Favorites.Event | Saves of SavedForLater.Event | Category of name : string * count : int | Unclassified of messageKey : string 
+    type Stat = Faves of int | Saves of int | OtherCategory of string * int | OtherMessage of string
 
-type EquinoxEvent =
-    static member Parse (x: Propulsion.Kafka.Codec.RenderedEvent) =
-        { new Equinox.Codec.IEvent<_> with
-            member __.EventType = x.c
-            member __.Data = x.d
-            member __.Meta = x.m
-            member __.Timestamp = x.t }
-    static member Parse (x: Propulsion.Streams.IEvent<_>) =
-        { new Equinox.Codec.IEvent<_> with
-            member __.EventType = x.EventType
-            member __.Data = x.Data
-            member __.Meta = x.Meta
-            member __.Timestamp = x.Timestamp }
+    // Maintains a denormalized view cache per stream (in-memory, unbounded). TODO: keep in a persistent store
+    type InMemoryHandler() =
+        let log = Log.ForContext<InMemoryHandler>()
 
-type EquinoxSpan =
-    static member EnumCodecEvents (x: Propulsion.Kafka.Codec.RenderedSpan) : seq<Equinox.Codec.IEvent<_>> =
-       x.e |> Seq.map EquinoxEvent.Parse
-    static member EnumCodecEvents (x: Propulsion.Streams.StreamSpan<_>) : seq<Equinox.Codec.IEvent<_>> =
-       x.events |> Seq.map EquinoxEvent.Parse
+        // events are handled concurrently across streams. Only a single Handle call will be in progress at any time per stream
+        let faves,saves = ConcurrentDictionary<string, HashSet<_>>(), ConcurrentDictionary<string,string list>()
 
-// Example of filtering our relevant Events from the Kafka stream
-// NB if the percentage of relevant events is low, one may wish to adjust the projector to project only a subset
-type MessageInterpreter() =
-    let log = Log.ForContext<MessageInterpreter>()
+        let (|FavoritesEvents|SavedForLaterEvents|OtherCategory|UnknownMessage|) (streamName, span : Propulsion.Streams.StreamSpan<byte[]>) =
+            // The StreamProjector mechanism trims any events that have already been handled based on the in-memory state
+            let map f = span.Events |> Array.choose (f log streamName)
+            match category streamName with
+            | Category (Favorites.CategoryId, id) ->
+                let s = match faves.TryGetValue id with true, value -> value | false, _ -> new HashSet<string>()
+                FavoritesEvents (id, s, map Favorites.tryDecode)
+            | Category (SavedForLater.CategoryId, id) ->
+                let s = match saves.TryGetValue id with true, value -> value | false, _ -> []
+                SavedForLaterEvents (id, s, map SavedForLater.tryDecode)
+            | Category (categoryName, _) -> OtherCategory (categoryName, Array.length span.events)
+            | Unknown streamName -> UnknownMessage streamName
 
-    /// Handles various category / eventType / payload types as produced by Equinox.Tool
-    member __.Interpret(streamName, events) = seq {
-        let tryExtractCategory (stream : string) = stream.Split([|'-'|], 2, StringSplitOptions.RemoveEmptyEntries)
-        match tryExtractCategory streamName with
-        | [| "Favorites"; _ |] -> yield! events |> Seq.choose (tryDecode log streamName Favorites.codec >> Option.map Faves)
-        | [| "SavedForLater"; _ |] -> yield! events |> Seq.choose (tryDecode log streamName SavedForLater.codec >> Option.map Saves)
-        | [| category; _ |] -> yield Category (category, Seq.length events)
-        | _ -> yield Unclassified streamName }
+        // each event is guaranteed to only be supplied once by virtue of having been passed through the Streams Scheduler
+        member __.Handle(streamName : string, span : Propulsion.Streams.StreamSpan<_>) = async {
+            match streamName, span with
+            | OtherCategory (cat,count) -> return OtherCategory (cat, count)
+            | UnknownMessage messageKey -> return OtherMessage messageKey
+            | FavoritesEvents (id, s, xs) -> 
+                let folder (s : HashSet<_>) = function
+                    | Favorites.Favorited e -> s.Add(e.skuId) |> ignore; s
+                    | Favorites.Unfavorited e -> s.Remove(e.skuId) |> ignore; s
+                faves.[id] <- Array.fold folder s xs
+                return Faves xs.Length
+            | SavedForLaterEvents (id, s, xs) ->
+                let remove (skus : string seq) (s : _ list) =
+                    let removing = (HashSet skus).Contains
+                    s |> List.where (not << removing)
+                let add skus (s : _ list) =
+                    List.append (List.ofArray skus) s
+                let folder s = function
+                    | SavedForLater.Cleared -> []
+                    | SavedForLater.Added e -> add e.skus s
+                    | SavedForLater.Removed e -> remove e.skus s
+                    | SavedForLater.Merged e -> s |> remove [| for x in e.items -> x.skuId |] |> add [| for x in e.items -> x.skuId |]
+                saves.[id] <- (s,xs) ||> Array.fold folder
+                return Saves xs.Length
+        }
 
-    member __.EnumStreamEvents(KeyValue (streamName : string, spanJson)) : seq<Propulsion.Streams.StreamEvent<_>> =
+        // Dump stats relating to how much information is being held - note it's likely for requests to be in flighht during the call
+        member __.DumpState(log : ILogger) =
+            log.Information(" Favorited {total}/{users}", faves.Values |> Seq.sumBy (fun x -> x.Count), faves.Count)
+            log.Information(" SavedForLater {total}/{users}", saves.Values |> Seq.sumBy (fun x -> x.Length), saves.Count)
+
+    type Stats(log, ?statsInterval, ?stateInterval) =
+        inherit Propulsion.Kafka.StreamsConsumerStats<Stat>(log, defaultArg statsInterval (TimeSpan.FromMinutes 1.), defaultArg stateInterval (TimeSpan.FromMinutes 5.))
+
+        let mutable faves, saves = 0, 0
+        let otherCats, otherKeys = Propulsion.Streams.Internal.CatStats(), Propulsion.Streams.Internal.CatStats()
+
+        override __.HandleOk res = res |> function
+            | Faves count -> faves <- faves + count
+            | Saves count -> saves <- saves + count
+            | OtherCategory (cat,count) -> otherCats.Ingest(cat, int64 count)
+            | OtherMessage messageKey -> otherKeys.Ingest messageKey
+
+        // Dump stats relating to the nature of the message processing throughput
+        override __.DumpStats () =
+            if faves <> 0 || saves <> 0 then
+                log.Information(" Processed Faves {faves} Saves {s}", faves, saves)
+                faves <- 0; saves <- 0
+            if otherCats.Any || otherKeys.Any then
+                log.Information(" Ignored Categories {ignoredCats} Streams {ignoredStreams}",
+                    Seq.truncate 5 otherCats.StatsDescending, Seq.truncate 5 otherKeys.StatsDescending)
+                otherCats.Clear(); otherKeys.Clear()
+
+    let private enumStreamEvents(KeyValue (streamName : string, spanJson)) : seq<Propulsion.Streams.StreamEvent<_>> =
         if streamName.StartsWith("#serial") then Seq.empty else
+        let span = JsonConvert.DeserializeObject<Propulsion.Codec.NewtonsoftJson.RenderedSpan>(spanJson)
+        Propulsion.Codec.NewtonsoftJson.RenderedSpan.enumStreamEvents span
 
-        let span = JsonConvert.DeserializeObject<Propulsion.Kafka.Codec.RenderedSpan>(spanJson)
-        Propulsion.Kafka.Codec.RenderedSpan.enumStreamEvents span
+    let start (config : Jet.ConfluentKafka.FSharp.KafkaConsumerConfig, degreeOfParallelism : int) =
+        let log, handler = Log.ForContext<InMemoryHandler>(), InMemoryHandler()
+        let stats = Stats(log, TimeSpan.FromSeconds 30., TimeSpan.FromMinutes 5.)
+        Propulsion.Kafka.StreamsConsumer.Start(
+            log, config, degreeOfParallelism,
+            enumStreamEvents, handler.Handle, stats, category,
+            logExternalState=handler.DumpState)
 
-    /// Handles various category / eventType / payload types as produced by Equinox.Tool
-    member __.TryDecode(streamName, spanJson) = seq {
-        let span = JsonConvert.DeserializeObject<Propulsion.Kafka.Codec.RenderedSpan>(spanJson)
-        yield! __.Interpret(streamName, EquinoxSpan.EnumCodecEvents span) }
+/// When using parallel or batch processing, items are not grouped by stream and the concurrency management is different
+module Messages =
+    
+    // We'll use the same event parsing logic, though it works a little different
+    open Streams
 
-type Processor() =
-    let mutable favorited, unfavorited, saved, cleared = 0, 0, 0, 0 
-    let cats, keys = CatStats(), ConcurrentDictionary()
+    type Message = Faves of Favorites.Event | Saves of SavedForLater.Event | OtherCat of name : string * count : int | Unclassified of messageKey : string 
 
-    member __.DumpStats(log : ILogger) =
-        log.Information("Favorited {f} Unfavorited {u} Saved {s} Cleared {c} Keys {keyCount} Categories {@catCount}",
-            favorited, unfavorited, saved, cleared, keys.Count, Seq.truncate 5 cats.StatsDescending)
-        favorited <- 0; unfavorited <- 0; saved <- 0; cleared <- 0; cats.Clear(); keys.Clear()
-    member __.Handle = function
-        | Faves (Favorites.Favorited _) -> Interlocked.Increment &favorited |> ignore
-        | Faves (Favorites.Unfavorited _) -> Interlocked.Increment &unfavorited |> ignore
-        | Saves (SavedForLater.Added e) -> Interlocked.Add(&saved,e.skus.Length) |> ignore
-        | Saves (SavedForLater.Removed e) -> Interlocked.Add(&cleared,e.skus.Length) |> ignore
-        | Saves (SavedForLater.Merged e) -> Interlocked.Add(&saved,e.items.Length) |> ignore
-        | Category (cat,count) -> lock cats <| fun () -> cats.Ingest(cat, int64 count)
-        | Unclassified messageKey -> keys.TryAdd(messageKey, ()) |> ignore
+    type MessageInterpreter() =
+        let log = Log.ForContext<MessageInterpreter>()
 
-open Confluent.Kafka
-open Jet.ConfluentKafka.FSharp
-open Propulsion.Kafka
+        /// Handles various category / eventType / payload types as produced by Equinox.Tool
+        member __.Interpret(streamName, events) = seq {
+            let tryDecode  f = tryDecode f log streamName
+            match streamName with
+            | Category (Favorites.CategoryId,_) -> yield! events |> Seq.choose (tryDecode Favorites.codec >> Option.map Faves)
+            | Category (SavedForLater.CategoryId,_) -> yield! events |> Seq.choose (tryDecode SavedForLater.codec >> Option.map Saves)
+            | Category (other,_) -> yield OtherCat (other, Seq.length events)
+            | _ -> yield Unclassified streamName }
 
-type BatchesSync =
-    /// Starts a consumer that consumes a topic in a batched mode, based on a source defined by `cfg`
-    /// Processing runs as a single Async computation per batch, which can work well where parallism is not relevant
-    static member Start(config : KafkaConsumerConfig) =
-        let log = Log.ForContext<BatchesSync>()
-        let interpreter = MessageInterpreter()
-        let handleBatch (msgs : ConsumeResult<_,_>[]) = async {
-            let processor = Processor()
-            for m in msgs do
-                for x in interpreter.TryDecode(m.Key, m.Value) do
-                    processor.Handle x
-            processor.DumpStats log }
-        BatchedConsumer.Start(log, config, handleBatch)
-        
-type Messages =
-    /// Starts a consumer that consumes a topic in streamed mode
-    /// StreamingConsumer manages the parallelism, spreading individual messages out to Async tasks
-    /// Optimal where each Message naturally lends itself to independent processing with no ordering constraints
-    static member Start(config : KafkaConsumerConfig, degreeOfParallelism : int) =
-        let log = Log.ForContext<Messages>()
-        let interpreter, processor = MessageInterpreter(), Processor()
-        let handleMessage (KeyValue (streamName,eventsSpan)) = async {
-            for x in interpreter.TryDecode(streamName,eventsSpan) do
-                processor.Handle x }
-        ParallelConsumer.Start(log, config, degreeOfParallelism, handleMessage, statsInterval = TimeSpan.FromSeconds 30., logExternalStats = processor.DumpStats)
-        
-type Streams =
-    static member Start(config : KafkaConsumerConfig, degreeOfParallelism : int) =
-        let log = Log.ForContext<Streams>()
-        let interpreter, processor = MessageInterpreter(), Processor()
-        let statsInterval, stateInterval = TimeSpan.FromSeconds 30., TimeSpan.FromMinutes 5.
-        let handle (streamName : string, span : Propulsion.Streams.StreamSpan<_>) = async {
-            for x in interpreter.Interpret(streamName, EquinoxSpan.EnumCodecEvents span) do
-                processor.Handle x
-            return span.events.Length }
-        let categorize (streamName : string) =
-            streamName.Split([|'-';'_'|],2).[0]
-        StreamsConsumer.Start
-            (   log, config, degreeOfParallelism, interpreter.EnumStreamEvents, handle, categorize, maxSubmissionsPerPartition = 4,
-                statsInterval = statsInterval, stateInterval = stateInterval, logExternalStats = processor.DumpStats)
-        
-type BatchesAsync =
-    /// Starts a consumer that consumes a topic in a batched mode, based on a source defined by `cfg`
-    /// Processing fans out as parallel Async computations (limited to max `degreeOfParallelism` concurrent tasks
-    /// The messages in the batch emanate from a single partition and are all in sequence
-    /// notably useful where there's an ability to share some processing cost across a batch of work by doing the processing in phases
-    static member Start(config : KafkaConsumerConfig, degreeOfParallelism : int) =
-        let log = Log.ForContext<BatchesAsync>()
-        let dop = new SemaphoreSlim(degreeOfParallelism)
-        let interpreter = MessageInterpreter()
-        let handleBatch (msgs : ConsumeResult<_,_>[]) = async {
-            let processor = Processor()
-            let! _ =
-                seq { for x in msgs do yield! interpreter.TryDecode(x.Key, x.Value) }
-                |> Seq.map (fun x -> async { processor.Handle x } |> dop.Throttle)
-                |> Async.Parallel
-            processor.DumpStats log }
-        BatchedConsumer.Start(log, config, handleBatch)
+        //member __.EnumStreamEvents(KeyValue (streamName : string, spanJson)) : seq<Propulsion.Streams.StreamEvent<_>> =
+
+        //    let span = JsonConvert.DeserializeObject<Propulsion.Kafka.Codec.RenderedSpan>(spanJson)
+        //    Propulsion.Kafka.Codec.RenderedSpan.enumStreamEvents span
+
+        member __.TryDecode(streamName : string, spanJson) = seq {
+            if streamName.StartsWith("#serial") then () else
+            let span = JsonConvert.DeserializeObject<Propulsion.Codec.NewtonsoftJson.RenderedSpan>(spanJson)
+            yield! __.Interpret(streamName, span.Events) }
+
+    type Processor() =
+        let mutable favorited, unfavorited, saved, removed, cleared = 0, 0, 0, 0, 0
+        let cats, keys = CatStats(), ConcurrentDictionary()
+
+        member __.DumpStats(log : ILogger) =
+            log.Information("Favorited {f} Unfavorited {u} Saved {s} Removed {r} Cleared {c} Keys {keyCount} Categories {@catCount}",
+                favorited, unfavorited, saved, removed, cleared, keys.Count, Seq.truncate 5 cats.StatsDescending)
+            favorited <- 0; unfavorited <- 0; saved <- 0; removed <- 0; cleared <- 0; cats.Clear(); keys.Clear()
+
+        // NB outcomes will arrive concurrently, care is required
+        member __.Handle = function
+            | Faves (Favorites.Favorited _) -> Interlocked.Increment &favorited |> ignore
+            | Faves (Favorites.Unfavorited _) -> Interlocked.Increment &unfavorited |> ignore
+            | Saves (SavedForLater.Added e) -> Interlocked.Add(&saved,e.skus.Length) |> ignore
+            | Saves (SavedForLater.Removed e) -> Interlocked.Add(&cleared,e.skus.Length) |> ignore
+            | Saves (SavedForLater.Merged e) -> Interlocked.Add(&saved,e.items.Length) |> ignore
+            | Saves (SavedForLater.Cleared) -> Interlocked.Increment(&cleared) |> ignore
+            | OtherCat (cat,count) -> lock cats <| fun () -> cats.Ingest(cat, int64 count)
+            | Unclassified messageKey -> keys.TryAdd(messageKey, ()) |> ignore
+
+    type BatchesSync =
+        /// Starts a consumer that consumes a topic in a batched mode, based on a source defined by `cfg`
+        /// Processing runs as a single Async computation per batch, which can work well where parallism is not relevant
+        static member Start(config : Jet.ConfluentKafka.FSharp.KafkaConsumerConfig) =
+            let log = Log.ForContext<BatchesSync>()
+            let interpreter = MessageInterpreter()
+            let handleBatch (msgs : Confluent.Kafka.ConsumeResult<_,_>[]) = async {
+                let processor = Processor()
+                for m in msgs do
+                    for x in interpreter.TryDecode(m.Key, m.Value) do
+                        processor.Handle x
+                processor.DumpStats log }
+            Jet.ConfluentKafka.FSharp.BatchedConsumer.Start(log, config, handleBatch)
+    
+    type Parallel =
+        /// Starts a consumer that consumes a topic in streamed mode
+        /// StreamingConsumer manages the parallelism, spreading individual messages out to Async tasks
+        /// Optimal where each Message naturally lends itself to independent processing with no ordering constraints
+        static member Start(config : Jet.ConfluentKafka.FSharp.KafkaConsumerConfig, degreeOfParallelism : int) =
+            let log = Log.ForContext<Parallel>()
+            let interpreter, processor = MessageInterpreter(), Processor()
+            let handleMessage (KeyValue (streamName,eventsSpan)) = async {
+                for x in interpreter.TryDecode(streamName,eventsSpan) do
+                    processor.Handle x }
+            Propulsion.Kafka.ParallelConsumer.Start(
+                log, config, degreeOfParallelism, handleMessage,
+                statsInterval = TimeSpan.FromSeconds 30., logExternalStats = processor.DumpStats)
+
+    type BatchesAsync =
+        /// Starts a consumer that consumes a topic in a batched mode, based on a source defined by `cfg`
+        /// Processing fans out as parallel Async computations (limited to max `degreeOfParallelism` concurrent tasks
+        /// The messages in the batch emanate from a single partition and are all in sequence
+        /// notably useful where there's an ability to share some processing cost across a batch of work by doing the processing in phases
+        static member Start(config : Jet.ConfluentKafka.FSharp.KafkaConsumerConfig, degreeOfParallelism : int) =
+            let log = Log.ForContext<BatchesAsync>()
+            let dop = new SemaphoreSlim(degreeOfParallelism)
+            let interpreter = MessageInterpreter()
+            let handleBatch (msgs : Confluent.Kafka.ConsumeResult<_,_>[]) = async {
+                let processor = Processor()
+                let! _ =
+                    seq { for x in msgs do yield! interpreter.TryDecode(x.Key, x.Value) }
+                    |> Seq.map (fun x -> async { processor.Handle x } |> dop.Throttle)
+                    |> Async.Parallel
+                processor.DumpStats log }
+            Jet.ConfluentKafka.FSharp.BatchedConsumer.Start(log, config, handleBatch)

--- a/equinox-projector/Consumer/Program.fs
+++ b/equinox-projector/Consumer/Program.fs
@@ -63,10 +63,10 @@ let start (args : CmdParser.Arguments) =
     Logging.initialize args.Verbose
     let clientId, mem, stats = "ProjectorTemplate", args.MaxInFlightBytes, args.LagFrequency
     let c = Jet.ConfluentKafka.FSharp.KafkaConsumerConfig.Create(clientId, args.Broker, [args.Topic], args.Group, maxInFlightBytes = mem, ?statisticsInterval = stats)
-    //BatchesSync.Start(c)
-    //BatchesAsync.Start(c, args.MaxWriters)
-    //Messages.Start(c, args.MaxWriters)
-    Streams.Start(c, args.MaxDop)
+    //Messages.BatchesSync.Start(c)
+    //Messages.BatchesAsync.Start(c, args.MaxDop)
+    //Messages.Parallel.Start(c, args.MaxDop)
+    Streams.start(c, args.MaxDop)
 
 [<EntryPoint>]
 let main argv =

--- a/equinox-projector/Projector/Projector.fsproj
+++ b/equinox-projector/Projector/Projector.fsproj
@@ -13,9 +13,9 @@
   <ItemGroup>
     <PackageReference Include="Argu" Version="5.4.0" />
     <PackageReference Include="Destructurama.FSharp.NetCore" Version="1.0.14" />
-    <PackageReference Include="Propulsion.Cosmos" Version="1.0.1-rc2" />
+    <PackageReference Include="Propulsion.Cosmos" Version="1.0.1-rc3" />
     <!--#if (kafka)-->
-    <PackageReference Include="Propulsion.Kafka" Version="1.0.1-rc2" />
+    <PackageReference Include="Propulsion.Kafka" Version="1.0.1-rc3" />
     <!--#endif-->
     <PackageReference Include="Serilog.Sinks.Console" Version="3.1.1" />
   </ItemGroup>


### PR DESCRIPTION
Expands the examples to illustrate result processing/logging facilities added in Propulsion 1.0.1-rc3

Also reworks the Streams to illustrate the reduced need to deal with concurrency when compared with the Parallel and/or Batched modes