### PR TITLE
Add TrackingConsumer template

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ The `Unreleased` section name is replaced by the expected version of next releas
 
 ### Added
 
-- `trackingConsumer` template providing a baseline for projecting accumulating updates across autonomous bounded contexts: [#29](https://github.com/jet/dotnet-templates/pull/30) [@luo4neck](https://github.com/luo4neck)
+- `trackingConsumer` template providing a baseline for projecting accumulating updates across autonomous bounded contexts: [#30](https://github.com/jet/dotnet-templates/pull/30) [@luo4neck](https://github.com/luo4neck)
 
 ### Changed
 ### Removed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ The `Unreleased` section name is replaced by the expected version of next releas
 ## [Unreleased]
 
 ### Added
+
+- `trackingConsumer` template providing a baseline for projecting accumulating updates across autonomous bounded contexts: [#29](https://github.com/jet/dotnet-templates/pull/30) [@luo4neck](https://github.com/luo4neck)
+
 ### Changed
 ### Removed
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -23,6 +23,8 @@ This repo hosts the source for Jet's [`dotnet new`](https://docs.microsoft.com/e
 
 - [`summaryConsumer`](propulsion-summary-consumer/README.md) - Boilerplate for an Apache Kafka Consumer using [`Propulsion.Kafka`](https://github.com/jet/propulsion) to ingest versioned summaries produced by a `dotnet new summaryProjector`)
 
+- [`trackingConsumer`](propulsion-tracking-consumer/README.md) - Boilerplate for an Apache Kafka Consumer using [`Propulsion.Kafka`](https://github.com/jet/propulsion) to ingest accumulating changes in an `Equinox.Cosmos` store idempotently.
+
 - [`proSync`](propulsion-sync/README.md) - Boilerplate for a console app that that syncs events between [`Equinox.Cosmos` and `Equinox.EventStore` stores](https://github.com/jet/equinox) using the [relevant `Propulsion`.* libraries](https://github.com/jet/propulsion), filtering/enriching/mapping Events as necessary.
 
 ## Walkthrough

--- a/propulsion-tracking-consumer/.template.config/template.json
+++ b/propulsion-tracking-consumer/.template.config/template.json
@@ -1,0 +1,19 @@
+{
+  "$schema": "http://json.schemastore.org/template",
+  "author": "@jet @bartelink",
+  "classifications": [
+    "Event Sourcing",
+    "Equinox",
+    "Propulsion",
+    "CosmosDb",
+    "Kafka"
+  ],
+  "tags": {
+    "language": "F#"
+  },
+  "identity": "Propulsion.Template.TrackingConsumer",
+  "name": "Propulsion/Equinox Tracking Consumer",
+  "shortName": "trackingConsumer",
+  "sourceName": "ConsumerTemplate",
+  "preferNameDirectory": true
+}

--- a/propulsion-tracking-consumer/Infrastructure.fs
+++ b/propulsion-tracking-consumer/Infrastructure.fs
@@ -6,7 +6,7 @@ open System
 module StreamCodec =
 
     /// Uses the supplied codec to decode the supplied event record `x` (iff at LogEventLevel.Debug, detail fails to `log` citing the `stream` and content)
-    let tryDecode (codec : FsCodec.IUnionEncoder<_,_>) (log : Serilog.ILogger) (stream : string) (x : FsCodec.IEvent<byte[]>) =
+    let tryDecode (codec : FsCodec.IUnionEncoder<_,_>) (log : Serilog.ILogger) (stream : string) (x : FsCodec.IIndexedEvent<byte[]>) =
         match codec.TryDecode x with
         | None ->
             if log.IsEnabled Serilog.Events.LogEventLevel.Debug then

--- a/propulsion-tracking-consumer/Infrastructure.fs
+++ b/propulsion-tracking-consumer/Infrastructure.fs
@@ -1,0 +1,26 @@
+﻿namespace ConsumerTemplate
+
+open FSharp.UMX // see https://github.com/fsprojects/FSharp.UMX - % operator and ability to apply units of measure to Guids+strings
+open System
+
+module StreamCodec =
+
+    /// Uses the supplied codec to decode the supplied event record `x` (iff at LogEventLevel.Debug, detail fails to `log` citing the `stream` and content)
+    let tryDecode (codec : FsCodec.IUnionEncoder<_,_>) (log : Serilog.ILogger) (stream : string) (x : FsCodec.IEvent<byte[]>) =
+        match codec.TryDecode x with
+        | None ->
+            if log.IsEnabled Serilog.Events.LogEventLevel.Debug then
+                log.ForContext("event", System.Text.Encoding.UTF8.GetString(x.Data), true)
+                    .Debug("Codec {type} Could not decode {eventType} in {stream}", codec.GetType().FullName, x.EventType, stream)
+            None
+        | x -> x
+
+module Guid =
+    let inline toStringN (x : Guid) = x.ToString "N"
+
+/// SkuId strongly typed id; represented internally as a string
+type SkuId = string<skuId>
+and [<Measure>] skuId
+module SkuId =
+    let toString (value : SkuId) : string = % value
+    let parse (value : string) : SkuId = let raw = value in % raw

--- a/propulsion-tracking-consumer/Program.fs
+++ b/propulsion-tracking-consumer/Program.fs
@@ -1,0 +1,127 @@
+﻿module ConsumerTemplate.Program
+
+open Equinox.Cosmos
+open Serilog
+open System
+
+module CmdParser =
+    open Argu
+
+    exception MissingArg of string
+    let envBackstop msg key =
+        match Environment.GetEnvironmentVariable key with
+        | null -> raise <| MissingArg (sprintf "Please provide a %s, either as an argument or via the %s environment variable" msg key)
+        | x -> x
+
+    module Cosmos =
+        type [<NoEquality; NoComparison>] Parameters =
+            | [<AltCommandLine "-s">] Connection of string
+            | [<AltCommandLine "-cm">] ConnectionMode of ConnectionMode
+            | [<AltCommandLine "-d">] Database of string
+            | [<AltCommandLine "-c">] Container of string
+            | [<AltCommandLine "-o">] Timeout of float
+            | [<AltCommandLine "-r">] Retries of int
+            | [<AltCommandLine "-rt">] RetriesWaitTime of int
+            interface IArgParserTemplate with
+                member a.Usage =
+                    match a with
+                    | Connection _ ->       "specify a connection string for a Cosmos account (defaults: envvar:EQUINOX_COSMOS_CONNECTION, Cosmos Emulator)."
+                    | ConnectionMode _ ->   "override the connection mode (default: DirectTcp)."
+                    | Database _ ->         "specify a database name for Cosmos store (defaults: envvar:EQUINOX_COSMOS_DATABASE)."
+                    | Container _ ->        " specify a container name for Cosmos store (defaults: envvar:EQUINOX_COSMOS_CONTAINER)."
+                    | Timeout _ ->          "specify operation timeout in seconds (default: 5)."
+                    | Retries _ ->          "specify operation retries (default: 1)."
+                    | RetriesWaitTime _ ->  "specify max wait-time for retry when being throttled by Cosmos in seconds (default: 5)"
+        type Arguments(a : ParseResults<Parameters>) =
+            member __.Mode = a.GetResult(ConnectionMode,ConnectionMode.Direct)
+            member __.Connection =          match a.TryGetResult Connection  with Some x -> x | None -> envBackstop "Connection" "EQUINOX_COSMOS_CONNECTION"
+            member __.Database =            match a.TryGetResult Database    with Some x -> x | None -> envBackstop "Database"   "EQUINOX_COSMOS_DATABASE"
+            member __.Container =           match a.TryGetResult Container   with Some x -> x | None -> envBackstop "Container"  "EQUINOX_COSMOS_CONTAINER"
+
+            member __.Timeout =             a.GetResult(Timeout,5.) |> TimeSpan.FromSeconds
+            member __.Retries =             a.GetResult(Retries, 1)
+            member __.MaxRetryWaitTime =    a.GetResult(RetriesWaitTime, 5)
+
+            member x.Connect(clientId) = async {
+                let (Discovery.UriAndKey (endpointUri,_) as discovery) = Discovery.FromConnectionString x.Connection
+                Log.Information("CosmosDb {mode} {endpointUri} Database {database} Container {container}.",
+                    x.Mode, endpointUri, x.Database, x.Container)
+                Log.Information("CosmosDb timeout {timeout}s; Throttling retries {retries}, max wait {maxRetryWaitTime}s",
+                    (let t = x.Timeout in t.TotalSeconds), x.Retries, x.MaxRetryWaitTime)
+                let! connection = Connector(x.Timeout, x.Retries, x.MaxRetryWaitTime, Log.Logger, mode=x.Mode).Connect(clientId,discovery)
+                return Context(connection, x.Database, x.Container) }
+
+    [<NoEquality; NoComparison>]
+    type Parameters =
+        | [<AltCommandLine "-g"; Unique>] Group of string
+        | [<AltCommandLine "-b"; Unique>] Broker of string
+        | [<AltCommandLine "-t"; Unique>] Topic of string
+        | [<AltCommandLine "-w"; Unique>] MaxDop of int
+        | [<AltCommandLine "-m"; Unique>] MaxInflightGb of float
+        | [<AltCommandLine "-l"; Unique>] LagFreqM of float
+        | [<AltCommandLine "-v"; Unique>] Verbose
+        | [<CliPrefix(CliPrefix.None); Last>] Cosmos of ParseResults<Cosmos.Parameters>
+
+        interface IArgParserTemplate with
+            member a.Usage = a |> function
+                | Group _ ->            "specify Kafka Consumer Group Id. (optional if environment variable PROPULSION_KAFKA_GROUP specified)"
+                | Broker _ ->           "specify Kafka Broker, in host:port format. (optional if environment variable PROPULSION_KAFKA_BROKER specified)"
+                | Topic _ ->            "specify Kafka Topic name. (optional if environment variable PROPULSION_KAFKA_TOPIC specified)"
+                | MaxDop _ ->           "maximum number of items to process in parallel. Default: 1024"
+                | MaxInflightGb _ ->    "maximum GB of data to read ahead. Default: 0.5"
+                | LagFreqM _ ->         "specify frequency (minutes) to dump lag stats. Default: off"
+                | Verbose _ ->          "request verbose logging."
+                | Cosmos _ ->           "specify CosmosDb input parameters"
+
+    type Arguments(args : ParseResults<Parameters>) =
+        member val Cosmos =             Cosmos.Arguments(args.GetResult Cosmos)
+        member __.Broker =              Uri(match args.TryGetResult Broker with Some x -> x | None -> envBackstop "Broker" "PROPULSION_KAFKA_BROKER")
+        member __.Topic =               match args.TryGetResult Topic with Some x -> x | None -> envBackstop "Topic" "PROPULSION_KAFKA_TOPIC"
+        member __.Group =               match args.TryGetResult Group with Some x -> x | None -> envBackstop "Group" "PROPULSION_KAFKA_GROUP"
+        member __.MaxDop =              match args.TryGetResult MaxDop with Some x -> x | None -> 1024
+        member __.MaxInFlightBytes =    (match args.TryGetResult MaxInflightGb with Some x -> x | None -> 0.5) * 1024. * 1024. *1024. |> int64
+        member __.LagFrequency =        args.TryGetResult LagFreqM |> Option.map TimeSpan.FromMinutes
+        member __.Verbose =             args.Contains Verbose
+
+    /// Parse the commandline; can throw exceptions in response to missing arguments and/or `-h`/`--help` args
+    let parse argv =
+        let programName = Reflection.Assembly.GetEntryAssembly().GetName().Name
+        let parser = ArgumentParser.Create<Parameters>(programName = programName)
+        parser.ParseCommandLine argv |> Arguments
+
+module Logging =
+    let initialize verbose =
+        Log.Logger <-
+            LoggerConfiguration()
+                .Destructure.FSharpTypes()
+                .Enrich.FromLogContext()
+            |> fun c -> if verbose then c.MinimumLevel.Debug() else c
+            |> fun c -> let theme = Sinks.SystemConsole.Themes.AnsiConsoleTheme.Code
+                        if not verbose then c.WriteTo.Console(theme=theme)
+                        else c.WriteTo.Console(theme=theme, outputTemplate="[{Timestamp:HH:mm:ss} {Level:u3}] {Message:lj}|{Properties}{NewLine}{Exception}")
+            |> fun c -> c.CreateLogger()
+
+let [<Literal>] appName = "ConsumerTemplate"
+
+let startConsumer (args : CmdParser.Arguments) =
+    Logging.initialize args.Verbose
+    let context = args.Cosmos.Connect(appName) |> Async.RunSynchronously
+    let cache = Caching.Cache (appName, 10) // here rather than in Todo aggregate as it can be shared with other Aggregates
+    let service = SkuSummary.Repository.createService cache context
+    let config =
+        Jet.ConfluentKafka.FSharp.KafkaConsumerConfig.Create(
+            appName, args.Broker, [args.Topic], args.Group,
+            maxInFlightBytes = args.MaxInFlightBytes, ?statisticsInterval = args.LagFrequency)
+    SkuIngester.startConsumer config Log.Logger service args.MaxDop
+
+[<EntryPoint>]
+let main argv =
+    try try use consumer = argv |> CmdParser.parse |> startConsumer
+            Async.RunSynchronously <| consumer.AwaitCompletion()
+            if consumer.RanToCompletion then 0 else 2
+        with :? Argu.ArguParseException as e -> eprintfn "%s" e.Message; 1
+            | CmdParser.MissingArg msg -> eprintfn "%s" msg; 1
+            // If the handler throws, we exit the app in order to let an orchestrator flag the failure
+            | e -> Log.Fatal(e, "Exiting"); 1
+    // need to ensure all logs are flushed prior to exit
+    finally Log.CloseAndFlush()

--- a/propulsion-tracking-consumer/README.md
+++ b/propulsion-tracking-consumer/README.md
@@ -1,0 +1,29 @@
+# Propulsion Kafka Tracking Consumer
+
+This project was generated using:
+
+    dotnet new -i Equinox.Templates # just once, to install/update in the local templates store
+    dotnet new trackingConsumer
+
+## Usage instructions
+
+0. Create and run an instance of the Projector in the source Container (see README in `dotnet new proProjector` for details)
+   _NB none of the templates presently produce data in this format_
+
+1. establish connection strings for the target container into which the summaries will synced. per https://github.com/jet/equinox README
+
+        $env:EQUINOX_COSMOS_CONNECTION="AccountEndpoint=https://....;AccountKey=....=;" # or use -s
+        $env:EQUINOX_COSMOS_DATABASE="equinox-test" # or use -d
+        $env:EQUINOX_COSMOS_CONTAINER="equinox-test" # or use - c
+
+2. To run an instance of the Consumer:
+
+        $env:PROPULSION_KAFKA_BROKER="instance.kafka.mysite.com:9092" # or use -b
+        $env:PROPULSION_KAFKA_TOPIC="topic0" # or use -t
+        $env:PROPULSION_KAFKA_GROUP="group0" # or use -g
+
+        # `-t topic0` identifies the Kafka topic from which the consumers should read
+        # `-g group0` identifies the Kafka consumer group among which the consumption is to be spread
+        dotnet run -- -t topic0 -g group0 cosmos
+
+        # (you can run as many instances as there are partitions configured for the topic on the broker)

--- a/propulsion-tracking-consumer/SkuIngester.fs
+++ b/propulsion-tracking-consumer/SkuIngester.fs
@@ -1,0 +1,74 @@
+/// Follows a feed of messages representing items being added/updated on an aggregate that maintains a list of child items
+/// Compared to the SummaryIngester in the `summaryProjector` template, each event is potentially relevant
+module ConsumerTemplate.SkuIngester
+
+open ConsumerTemplate.SkuSummary.Events
+open System
+
+/// Defines the shape of input messages on the topic we're consuming
+module SkuUpdates =
+
+    type OrderInfo = { poNumber : string; reservedUnitQuantity : int }
+    type Message =
+        {  skuId : SkuId // primary key for the aggregate
+           locationId : string
+           messageIndex : int64
+           pickTicketId : string
+           purchaseOrderInfo : OrderInfo[] }
+    let parse (utf8 : byte[]) : Message =
+        System.Text.Encoding.UTF8.GetString(utf8)
+        |> Propulsion.Codec.NewtonsoftJson.Serdes.Deserialize<Message>
+
+type Outcome = Completed of used : int * total : int
+
+/// Gathers stats based on the outcome of each Span processed for emission at intervals controlled by `StreamsConsumer`
+type Stats(log, ?statsInterval, ?stateInterval) =
+    inherit Propulsion.Kafka.StreamsConsumerStats<Outcome>
+        (log, defaultArg statsInterval (TimeSpan.FromMinutes 1.), defaultArg stateInterval (TimeSpan.FromMinutes 5.))
+
+    let mutable (ok, skipped) = 0, 0
+
+    override __.HandleOk res = res |> function
+        | Completed (used,total) -> ok <- ok + used; skipped <- skipped + (total-used)
+
+    override __.DumpStats () =
+        if ok <> 0 || skipped <> 0 then
+            log.Information(" Used {ok} Ignored {skipped}", ok, skipped)
+            ok <- 0; skipped <- 0
+
+/// StreamsConsumer buffers and deduplicates messages from a contiguous stream with each message bearing an index.
+/// The messages we consume don't have such characteristics, so we generate a fake `index` by keeping an int per stream in a dictionary
+type MessagesByArrivalOrder() =
+    // we synthesize a monotonically increasing index to render the deduplication facility inert
+    static let indices = System.Collections.Generic.Dictionary()
+    static let genIndex streamName =
+        match indices.TryGetValue streamName with
+        | true, v -> let x = v + 1 in indices.[streamName] <- x; x
+        | false, _ -> let x = 0 in indices.[streamName] <- x; x
+
+    // Stuff the full content of the message into an Event record - we'll parse it when it comes out the other end in a span
+    static member ToStreamEvent (KeyValue (k,v : string)) : Propulsion.Streams.StreamEvent<byte[]> seq =
+        let e = FsCodec.Core.EventData.Create(eventType = String.Empty,data = System.Text.Encoding.UTF8.GetBytes v)
+        Seq.singleton { stream=k; index=genIndex k |> int64; event=e }
+
+let (|SkuId|) (value : string) = SkuId.parse value
+
+/// Starts a processing loop accumulating messages by stream - each time we handle all the incoming updates for a give Sku as a single transaction
+let startConsumer (config : Jet.ConfluentKafka.FSharp.KafkaConsumerConfig) (log : Serilog.ILogger) (service : SkuSummary.Service) maxDop =
+    let ingestIncomingSummaryMessage(SkuId skuId, span : Propulsion.Streams.StreamSpan<_>) : Async<Outcome> = async {
+        let items =
+            [ for e in span.events do
+                let x = SkuUpdates.parse e.Data
+                for o in x.purchaseOrderInfo do
+                    yield { locationId = x.locationId
+                            messageIndex = x.messageIndex
+                            picketTicketId = x.pickTicketId
+                            poNumber = o.poNumber
+                            reservedQuantity = o.reservedUnitQuantity } ]
+        let! used = service.Ingest(skuId, items)
+        return Outcome.Completed(used,List.length items)
+    }
+    let stats = Stats(log)
+    // No categorization required, out inputs are all one big family defying categorization
+    let category _streamName = "Sku"
+    Propulsion.Kafka.StreamsConsumer.Start(log, config, maxDop, MessagesByArrivalOrder.ToStreamEvent, ingestIncomingSummaryMessage, stats, category)

--- a/propulsion-tracking-consumer/SkuSummary.fs
+++ b/propulsion-tracking-consumer/SkuSummary.fs
@@ -1,0 +1,83 @@
+﻿module ConsumerTemplate.SkuSummary
+
+// NB - these types and the union case names reflect the actual storage formats and hence need to be versioned with care
+module Events =
+
+    type ItemData =
+        {   locationId : string
+            messageIndex : int64
+            picketTicketId : string
+            poNumber : string
+            reservedQuantity : int }
+    type Event =
+        | Ingested of ItemData
+        | Snapshotted of ItemData[]
+        interface TypeShape.UnionContract.IUnionContract
+    let codec = FsCodec.NewtonsoftJson.Codec.Create<Event>()
+
+module Folds =
+
+    open Events
+
+    type State = ItemData list
+    module State =
+        let equals (x : Events.ItemData) (y : Events.ItemData) =
+            x.locationId = y.locationId
+        let supersedes (x : Events.ItemData) (y : Events.ItemData) =
+            equals x y
+            && y.messageIndex > x.messageIndex
+            && y.reservedQuantity <> x.reservedQuantity
+        let isNewOrUpdated state x =
+            not (state |> List.exists (fun y -> equals y x || supersedes y x))
+
+    let initial = []
+    // Defines a valid starting point for a fold, i.e. the point beyond which we don't need any preceding events to buid the state
+    let isOrigin = function
+        | Events.Snapshotted _ -> true // Yes, a snapshot is enough info
+        | Events.Ingested _ -> false
+    let evolve state = function
+        | Ingested e -> e :: state
+        | Snapshotted items -> List.ofArray items
+    let fold (state : State) : Event seq -> State = Seq.fold evolve state
+    let snapshot (x : State) : Event = Snapshotted (Array.ofList x)
+
+module Commands =
+
+    type Command =
+        | Consume of Events.ItemData list
+
+    let interpret command (state : Folds.State) =
+        match command with
+        | Consume updates ->
+            [for x in updates do if x |> Folds.State.isNewOrUpdated state then yield Events.Ingested x]
+
+let [<Literal>]categoryId = "SkuSummary"
+
+type Service(log, resolve, ?maxAttempts) =
+    let (|AggregateId|) (id : SkuId) = Equinox.AggregateId(categoryId, SkuId.toString id)
+    let (|Stream|) (AggregateId id) = Equinox.Stream<Events.Event,Folds.State>(log, resolve id, maxAttempts = defaultArg maxAttempts 2)
+
+    let executeWithCount (Stream stream) command : Async<int> =
+        let decide state =
+            let events = Commands.interpret command state
+            List.length events,events
+        stream.Transact(decide)
+
+    let query (Stream stream) (projection : Folds.State -> 't) : Async<'t> =
+        stream.Query projection
+
+    /// <returns>count of items</returns>
+    member __.Ingest(skuId, items) : Async<int> =
+        executeWithCount skuId <| Commands.Consume items
+
+    member __.Read skuId: Async<Events.ItemData list> =
+        query skuId id
+
+module Repository =
+    open Equinox.Cosmos // Everything until now is independent of a concrete store
+    let private resolve cache context =
+        // We don't want to write any events, so here we supply the `transmute` function to teach it how to treat our events as snapshots
+        let accessStrategy = AccessStrategy.Snapshot(Folds.isOrigin, Folds.snapshot)
+        let cacheStrategy = CachingStrategy.SlidingWindow (cache, System.TimeSpan.FromMinutes 20.)
+        Resolver(context, Events.codec, Folds.fold, Folds.initial, cacheStrategy, accessStrategy).Resolve
+    let createService cache context = Service(Serilog.Log.ForContext<Service>(), resolve cache context)

--- a/propulsion-tracking-consumer/TrackingConsumer.fsproj
+++ b/propulsion-tracking-consumer/TrackingConsumer.fsproj
@@ -1,0 +1,26 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <WarningLevel>5</WarningLevel>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <None Include="README.md" />
+    <Compile Include="Infrastructure.fs" />
+    <Compile Include="SkuSummary.fs" />
+    <Compile Include="SkuIngester.fs" />
+    <Compile Include="Program.fs" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Argu" Version="5.4.0" />
+    <PackageReference Include="Destructurama.FSharp.NetCore" Version="1.0.14" />
+    <PackageReference Include="FSharp.UMX" Version="1.0.0" />
+    <PackageReference Include="Propulsion.Cosmos" Version="1.1.0" />
+    <PackageReference Include="Propulsion.Kafka" Version="1.1.0" />
+    <PackageReference Include="Serilog.Sinks.Console" Version="3.1.1" />
+  </ItemGroup>
+
+</Project>

--- a/propulsion-tracking-consumer/TrackingConsumer.fsproj
+++ b/propulsion-tracking-consumer/TrackingConsumer.fsproj
@@ -18,8 +18,8 @@
     <PackageReference Include="Argu" Version="5.4.0" />
     <PackageReference Include="Destructurama.FSharp.NetCore" Version="1.0.14" />
     <PackageReference Include="FSharp.UMX" Version="1.0.0" />
-    <PackageReference Include="Propulsion.Cosmos" Version="1.1.0" />
-    <PackageReference Include="Propulsion.Kafka" Version="1.1.0" />
+    <PackageReference Include="Propulsion.Cosmos" Version="1.2.0" />
+    <PackageReference Include="Propulsion.Kafka" Version="1.2.0" />
     <PackageReference Include="Serilog.Sinks.Console" Version="3.1.1" />
   </ItemGroup>
 


### PR DESCRIPTION
Template demonstrating how to track a Kafka feed whose messages represent adds/updates to a list. The list is maintained in an `Equinox.Cosmos` store as a single document per stream, with deduplication of redundant updates based on a version identifier encoded within the input message. @luo4neck