### PR TITLE
Use FsCodec in trackingConsumer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ The `Unreleased` section name is replaced by the expected version of next releas
 ### Changed
 
 - SummaryConsumer: Target FsCodec 1.1.0 to simplify `up` function [#32](https://github.com/jet/dotnet-templates/pull/32)
+- `trackingConsumer`: switch serializer to FsCodec [#35](https://github.com/jet/dotnet-templates/pull/35)
 - SummaryProjector: Use `AllowStale` for CheckpointSeries as should only run single instance
 
 ### Removed

--- a/propulsion-tracking-consumer/Ingester.fs
+++ b/propulsion-tracking-consumer/Ingester.fs
@@ -16,8 +16,9 @@ module Contract =
            pickTicketId : string
            purchaseOrderInfo : OrderInfo[] }
     let parse (utf8 : byte[]) : Message =
+        // NB see https://github.com/jet/FsCodec for details of the default serialization profile (TL;DR only has an `OptionConverter`)
         System.Text.Encoding.UTF8.GetString(utf8)
-        |> Propulsion.Codec.NewtonsoftJson.Serdes.Deserialize<Message>
+        |> FsCodec.NewtonsoftJson.Serdes.Deserialize<Message>
 
 type Outcome = Completed of used : int * total : int
 


### PR DESCRIPTION
While the example technically works as it is, the normal recommended serialization mechanism is FsCodec.*