### PR TITLE
Add TCP mode argument processing for ES templates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ The `Unreleased` section name is replaced by the expected version of next releas
 
 ### Added
 
-- Add handling for `-T` TCP.IP switch on EventStore args [#46](https://github.com/jet/dotnet-templates/pulls/46)
+- Add handling for `-T` TCP/IP switch on EventStore args [#46](https://github.com/jet/dotnet-templates/pulls/46)
 
 ### Changed
 ### Removed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ The `Unreleased` section name is replaced by the expected version of next releas
 ## [Unreleased]
 
 ### Added
+
+- Add handling for `-T` TCP.IP switch on EventStore args [#46](https://github.com/jet/dotnet-templates/pulls/46)
+
 ### Changed
 ### Removed
 ### Fixed

--- a/equinox-testbed/Storage.fs
+++ b/equinox-testbed/Storage.fs
@@ -104,7 +104,8 @@ module EventStore =
         | [<AltCommandLine "-V">]       VerboseStore
         | [<AltCommandLine "-o">]       Timeout of float
         | [<AltCommandLine "-r">]       Retries of int
-        | [<AltCommandLine "-g">]       Host of string
+        | [<AltCommandLine "-T">]       Tcp
+        | [<AltCommandLine "-h">]       Host of string
         | [<AltCommandLine "-u">]       Username of string
         | [<AltCommandLine "-p">]       Password of string
         | [<AltCommandLine "-c">]       ConcurrentOperationsLimit of int
@@ -114,7 +115,8 @@ module EventStore =
                 | VerboseStore ->       "include low level Store logging."
                 | Timeout _ ->          "specify operation timeout in seconds. Default: 5."
                 | Retries _ ->          "specify operation retries. Default: 1."
-                | Host _ ->             "specify a DNS query, using Gossip-driven discovery against all A records returned. Default: localhost."
+                | Tcp ->                "Request connecting direct to a TCP/IP endpoint. Default: Use Clustered mode with Gossip-driven discovery (unless environment variable EQUINOX_ES_TCP specifies 'true')."
+                | Host _ ->             "TCP mode: specify a hostname to connect to directly. Clustered mode: use Gossip protocol against all A records returned from DNS query. (optional if environment variable EQUINOX_ES_HOST specified)"
                 | Username _ ->         "specify a username. Default: admin."
                 | Password _ ->         "specify a Password. Default: changeit."
                 | ConcurrentOperationsLimit _ -> "max concurrent operations in flight. Default: 5000."

--- a/propulsion-all-projector/Program.fs
+++ b/propulsion-all-projector/Program.fs
@@ -119,6 +119,7 @@ module CmdParser =
         | [<AltCommandLine "-o">]           Timeout of float
         | [<AltCommandLine "-r">]           Retries of int
         | [<AltCommandLine "-oh">]          HeartbeatTimeout of float
+        | [<AltCommandLine "-T">]           Tcp
         | [<AltCommandLine "-h">]           Host of string
         | [<AltCommandLine "-x">]           Port of int
         | [<AltCommandLine "-u">]           Username of string
@@ -138,8 +139,9 @@ module CmdParser =
                 | Percent _ ->              "EventStore $all Stream Position to commence from (as a percentage of current tail position)"
 
                 | Verbose ->                "Include low level Store logging."
-                | Host _ ->                 "specify a DNS query, using Gossip-driven discovery against all A records returned. (optional if environment variable EQUINOX_ES_HOST specified)"
-                | Port _ ->                 "specify a custom port. Defaults: envvar:EQUINOX_ES_PORT, 30778."
+                | Tcp ->                    "Request connecting direct to a TCP/IP endpoint. Default: Use Clustered mode with Gossip-driven discovery (unless environment variable EQUINOX_ES_TCP specifies 'true')."
+                | Host _ ->                 "TCP mode: specify a hostname to connect to directly. Clustered mode: use Gossip protocol against all A records returned from DNS query. (optional if environment variable EQUINOX_ES_HOST specified)"
+                | Port _ ->                 "specify a custom port. Uses value of environment variable EQUINOX_ES_PORT if specified. Defaults for Cluster and Direct TCP/IP mode are 30778 and 1113 respectively."
                 | Username _ ->             "specify a username. (optional if environment variable EQUINOX_ES_USERNAME specified)"
                 | Password _ ->             "specify a Password. (optional if environment variable EQUINOX_ES_PASSWORD specified)"
                 | Timeout _ ->              "specify operation timeout in seconds. Default: 20."
@@ -161,7 +163,15 @@ module CmdParser =
             | None, None, None, true ->     StartPos.TailOrCheckpoint
             | None, None, None, _ ->        StartPos.StartOrCheckpoint
 
-        member __.Discovery =               match __.Port with Some p -> Discovery.GossipDnsCustomPort (__.Host, p) | None -> Discovery.GossipDns __.Host
+        member __.Discovery =
+            match __.Tcp, __.Port with
+            | false, None ->   Discovery.GossipDns            __.Host
+            | false, Some p -> Discovery.GossipDnsCustomPort (__.Host, p)
+            | true, None ->    Discovery.Uri                 (UriBuilder("tcp", __.Host).Uri)
+            | true, Some p ->  Discovery.Uri                 (UriBuilder("tcp", __.Host, p).Uri)
+        member __.Tcp =
+            a.Contains EsSourceParameters.Tcp
+            || EnvVar.tryGet "EQUINOX_ES_TCP" |> Option.exists (fun s -> String.Equals(s, bool.TrueString, StringComparison.OrdinalIgnoreCase))
         member __.Port =                    match a.TryGetResult Port with Some x -> Some x | None -> EnvVar.tryGet "EQUINOX_ES_PORT" |> Option.map int
         member __.Host =                    a.TryGetResult Host     |> defaultWithEnvVar "EQUINOX_ES_HOST"     "Host"
         member __.User =                    a.TryGetResult Username |> defaultWithEnvVar "EQUINOX_ES_USERNAME" "Username"

--- a/propulsion-summary-projector/Program.fs
+++ b/propulsion-summary-projector/Program.fs
@@ -103,6 +103,7 @@ module CmdParser =
         | [<AltCommandLine "-o">]           Timeout of float
         | [<AltCommandLine "-r">]           Retries of int
         | [<AltCommandLine "-oh">]          HeartbeatTimeout of float
+        | [<AltCommandLine "-T">]           Tcp
         | [<AltCommandLine "-h">]           Host of string
         | [<AltCommandLine "-x">]           Port of int
         | [<AltCommandLine "-u">]           Username of string
@@ -122,8 +123,9 @@ module CmdParser =
                 | Percent _ ->              "EventStore $all Stream Position to commence from (as a percentage of current tail position)"
 
                 | Verbose ->                "Include low level Store logging."
-                | Host _ ->                 "specify a DNS query, using Gossip-driven discovery against all A records returned. (optional if environment variable EQUINOX_ES_HOST specified)"
-                | Port _ ->                 "specify a custom port. Defaults: envvar:EQUINOX_ES_PORT, 30778."
+                | Tcp ->                    "Request connecting direct to a TCP/IP endpoint. Default: Use Clustered mode with Gossip-driven discovery (unless environment variable EQUINOX_ES_TCP specifies 'true')."
+                | Host _ ->                 "TCP mode: specify a hostname to connect to directly. Clustered mode: use Gossip protocol against all A records returned from DNS query. (optional if environment variable EQUINOX_ES_HOST specified)"
+                | Port _ ->                 "specify a custom port. Uses value of environment variable EQUINOX_ES_PORT if specified. Defaults for Cluster and Direct TCP/IP mode are 30778 and 1113 respectively."
                 | Username _ ->             "specify a username. (optional if environment variable EQUINOX_ES_USERNAME specified)"
                 | Password _ ->             "specify a Password. (optional if environment variable EQUINOX_ES_PASSWORD specified)"
                 | Timeout _ ->              "specify operation timeout in seconds. Default: 20."
@@ -145,7 +147,15 @@ module CmdParser =
             | None, None, None, true ->     StartPos.TailOrCheckpoint
             | None, None, None, _ ->        StartPos.StartOrCheckpoint
 
-        member __.Discovery =               match __.Port with Some p -> Discovery.GossipDnsCustomPort (__.Host, p) | None -> Discovery.GossipDns __.Host
+        member __.Discovery =
+            match __.Tcp, __.Port with
+            | false, None ->   Discovery.GossipDns            __.Host
+            | false, Some p -> Discovery.GossipDnsCustomPort (__.Host, p)
+            | true, None ->    Discovery.Uri                 (UriBuilder("tcp", __.Host).Uri)
+            | true, Some p ->  Discovery.Uri                 (UriBuilder("tcp", __.Host, p).Uri)
+        member __.Tcp =
+            a.Contains EsSourceParameters.Tcp
+            || EnvVar.tryGet "EQUINOX_ES_TCP" |> Option.exists (fun s -> String.Equals(s, bool.TrueString, StringComparison.OrdinalIgnoreCase))
         member __.Port =                    match a.TryGetResult Port with Some x -> Some x | None -> EnvVar.tryGet "EQUINOX_ES_PORT" |> Option.map int
         member __.Host =                    a.TryGetResult Host     |> defaultWithEnvVar "EQUINOX_ES_HOST"     "Host"
         member __.User =                    a.TryGetResult Username |> defaultWithEnvVar "EQUINOX_ES_USERNAME" "Username"


### PR DESCRIPTION
This PR adds, for each template that supports an ES config:
- a `-T` flag to opt-in to TCP/IP direct connections
- fallback to treat `ES_EQUINOX_TCP` value of `true` as implying the same request