### PR TITLE
Extend Program.fs conventions commentary

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,15 +140,20 @@ Pssst ... the above is also what implementing [#2](https://github.com/jet/dotnet
 
 # PATTERNS / GUIDANCE
 
-## Strongly typed ids
+## Use Strongly typed ids
 
-- `FSharp.UMX` is useful to transparently pin types in a message contract cheaply
+Wherever possible, the samples strongly type identifiers, particularly ones that might naturally be represented as primitives, i.e. `string` etc.
+
+- [`FSharp.UMX`](https://github.com/fsprojects/FSharp.UMX) is useful to transparently pin types in a message contract cheaply - it works well for a number of contexts:
+
+  - Coding/decoding events using [FsCodec](https://github.com/jet/fscodec). (because Events are things that **have happened**, validating them is not a central concern as we load and fold these incontrovertible Facts)
+  - Model binding in ASP.NET (because the types de-sugar to the primitives, no special support is required). _Unlike events, there are more considerations in play in this context though; often you'll want to apply validation to the inputs (representing Commands) as you map them to [Value Objects](https://martinfowler.com/bliki/ValueObject.html), [Making Illegal States Unrepresentable](https://fsharpforfunandprofit.com/posts/designing-with-types-making-illegal-states-unrepresentable/). Often, Single Case Discriminated Unions can be a better tool inb that context_
 
 ## Managing Projections and Reactions with Equinox, Propulsion and FsKafka
 
-## Microservice Program.fs
+## Microservice Program.fs conventions
 
-All the templates herein attempt to adhere to a consistent structure for the root `module` (the one containing an Application’s `main`)
+All the templates herein attempt to adhere to a consistent structure for the [composition root](https://blog.ploeh.dk/2011/07/28/CompositionRoot/) `module` (the one containing an Application’s `main`)
 
 ### `module Settings`
 

--- a/README.md
+++ b/README.md
@@ -152,32 +152,37 @@ All the templates herein attempt to adhere to a consistent structure for the roo
 
 ### `module Settings`
 
-_Responsible for: Loading secrets and configuration into Environment variables_
+_Responsible for: Loading secrets and custom configuration, supplying defaults when environment variables are not set_
 
-Wiring up retrieval of configuration values is the most environment-dependent aspect of the wiring up of an applications data sources. This is particularly relevant where there is variance between local (development time), testing and production deployments. For this reason, the retrieval of values from configuration stores or key vaults is not managed directly within the [`CmdParser` section](#module-cmdparser)
+Wiring up retrieval of configuration values is the most environment-dependent aspect of the wiring up of an application's interaction with its environment and/or data storage mechanisms. This is particularly relevant where there is variance between local (development time), testing and production deployments. For this reason, the retrieval of values from configuration stores or key vaults is not managed directly within the [`CmdParser` section](#module-cmdparser)
 
 The `Settings` module is responsible for the following:
 1. Feeding defaults into process-local Environment Variables, _where those are not already supplied_
 2. Encapsulating all bindings to Configuration or Secret stores (Vaults) in order that this does not have to be complected with the argument parsing or defaulting in `CmdParser`
 
 - DO (sparingly) rely on inputs from the command line to drive the lookup process
-- DONT log values (CmdParser’s Arguments wrappers should do that as applicable as part of the wire process)
+- DONT log values (CmdParser’s Arguments wrappers should do that as applicable as part of the wireup process)
 - DONT perform redundant work to load values if they’ve already been supplied via Environment Variables
 
 ### `module CmdParser`
 
-_Responsible for: mapping Environment Variables and Command Line `argv` to an `Arguments` model_
+_Responsible for: mapping Environment Variables and the Command Line `argv` to an `Arguments` model_
 
 The `CmdParser` module fulfils three roles:
 
 1. uses [Argu](http://fsprojects.github.io/Argu/tutorial.html) to map the inputs passed via `argv` to values per argument, providing good error and/or help messages in the case of invalid inputs
-2. Is responsible for managing all defaulting of input values _including echoing them them such that an operator can infer the arguments in force_ without having to go look up defaults in a source control repo
-3. Exposes an object model that the `build` or `start` functions can use to succinctly wire up the dependencies without needing to touch `Argu`, `Settings`, or any concrete Configuration or Secrets store technology
+2. responsible for managing all defaulting of input values _including echoing them them such that an operator can infer the arguments in force_ without having to go look up defaults in a source control repo
+3. expose an object model that the `build` or `start` functions can use to succinctly wire up the dependencies without needing to touch `Argu`, `Settings`, or any concrete Configuration or Secrets storage mechanisms
 
 - DO log the values being applied, especially where defaulting is in play
 - DONT log secrets
 - DO take values via Argu or Environment Variables
-- DONT mix in any application or settings specific logic (no retrieval of values, don’t make people read the boilerplate to see if this app has custom secrets retrieval)
+- DONT mix in any application or settings specific logic (**no retrieval of values, don’t make people read the boilerplate to see if this app has custom secrets retrieval**)
+- DONT invest time changing the layout; leaving it consistent makes it easier for others to scan
+- DONT be tempted to merge blocks of variables - the intention is to (to the maximum extent possible) group arguments into clusters of 5-7 related items
+- DONT reorder types - it'll just make it harder if you ever want to remix and/or compare and contrast across a set of programs
+
+NOTE: there's a [medium term plan to submit a PR to Argu](https://github.com/fsprojects/Argu/issues/143) extending it to be able to fall back to environment variables where a value is not supplied by means of declarative attributes on the Argument specification in the DU, _including having the `--help` message automatically include a reference to the name of the environment variable that one can supply the value through_
 
 ### `module Logging`
 

--- a/propulsion-consumer/Program.fs
+++ b/propulsion-consumer/Program.fs
@@ -8,6 +8,9 @@ module EnvVar =
     let tryGet varName : string option = Environment.GetEnvironmentVariable varName |> Option.ofObj
     let set varName value : unit = Environment.SetEnvironmentVariable(varName, value)
 
+// TODO remove this entire comment after reading https://github.com/jet/dotnet-templates#module-settings
+// - this is where any custom retrieval of settings not arriving via commandline arguments or environment variables should go
+// - values should be propagated by setting environment variables and/or returning them from `initialize`
 module Settings =
 
     let private initEnvVar var key loadF =
@@ -19,6 +22,13 @@ module Settings =
         // e.g. initEnvVar     "EQUINOX_COSMOS_COLLECTION"    "CONSUL KEY" readFromConsul
         () // TODO add any custom logic preprocessing commandline arguments and/or gathering custom defaults from external sources, etc
 
+// TODO remove this entire comment after reading https://github.com/jet/dotnet-templates#module-cmdparser
+// - this module is responsible solely for parsing/validating the commandline arguments (including falling back to values supplied via environment variables)
+// - It's expected that the properties on *Arguments types will summarize the active settings as a side effect of
+// TODO DONT invest time reorganizing or reformatting this - half the value is having a legible summary of all program parameters in a consistent value
+//      you may want to regenerate it at a different time and/or facilitate comparing it with the CmdParser of other programs
+// TODO NEVER hack temporary overrides in here; if you're going to do that, use commandline arguments that fall back to environment variables
+//      or (as a last resort) supply them via code in `module Settings`
 module CmdParser =
 
     exception MissingArg of string
@@ -67,6 +77,8 @@ module CmdParser =
         let parser = ArgumentParser.Create<Parameters>(programName = programName)
         parser.ParseCommandLine argv |> Arguments
 
+// TODO remove this entire comment after reading https://github.com/jet/dotnet-templates#module-logging
+// Application logic assumes the global `Serilog.Log` is initialized _immediately_ after a successful ArgumentParser.ParseCommandline
 module Logging =
 
     let initialize verbose =

--- a/propulsion-consumer/README.md
+++ b/propulsion-consumer/README.md
@@ -11,7 +11,7 @@ This project was generated using:
 
 1. To run an instance of the Consumer:
 
-        $env:PROPULSION_KAFKA_BROKER="instance.kafka.mysite.com:9092" # or use -b
+        $env:PROPULSION_KAFKA_BROKER="instance.kafka.example.com:9092" # or use -b
         $env:PROPULSION_KAFKA_TOPIC="topic0" # or use -t
         $env:PROPULSION_KAFKA_GROUP="group0" # or use -g
 

--- a/propulsion-projector/.template.config/template.json
+++ b/propulsion-projector/.template.config/template.json
@@ -25,7 +25,7 @@
       "datatype": "bool",
       "isRequired": false,
       "defaultValue": "false",
-      "description": "Include a code projecting to, and consuming from Kafka."
+      "description": "Include code projecting to Kafka."
     },
     "parallelOnly": {
       "type": "parameter",

--- a/propulsion-projector/Program.fs
+++ b/propulsion-projector/Program.fs
@@ -9,6 +9,9 @@ module EnvVar =
     let tryGet varName : string option = Environment.GetEnvironmentVariable varName |> Option.ofObj
     let set varName value : unit = Environment.SetEnvironmentVariable(varName, value)
 
+// TODO remove this entire comment after reading https://github.com/jet/dotnet-templates#module-settings
+// - this is where any custom retrieval of settings not arriving via commandline arguments or environment variables should go
+// - values should be propagated by setting environment variables and/or returning them from `initialize`
 module Settings =
 
     let private initEnvVar var key loadF =
@@ -20,6 +23,13 @@ module Settings =
         // e.g. initEnvVar     "EQUINOX_COSMOS_COLLECTION"    "CONSUL KEY" readFromConsul
         () // TODO add any custom logic preprocessing commandline arguments and/or gathering custom defaults from external sources, etc
 
+// TODO remove this entire comment after reading https://github.com/jet/dotnet-templates#module-cmdparser
+// - this module is responsible solely for parsing/validating the commandline arguments (including falling back to values supplied via environment variables)
+// - It's expected that the properties on *Arguments types will summarize the active settings as a side effect of
+// TODO DONT invest time reorganizing or reformatting this - half the value is having a legible summary of all program parameters in a consistent value
+//      you may want to regenerate it at a different time and/or facilitate comparing it with the CmdParser of other programs
+// TODO NEVER hack temporary overrides in here; if you're going to do that, use commandline arguments that fall back to environment variables
+//      or (as a last resort) supply them via code in `module Settings`
 module CmdParser =
 
     exception MissingArg of string
@@ -145,8 +155,8 @@ module CmdParser =
         let parser = ArgumentParser.Create<Parameters>(programName = programName)
         parser.ParseCommandLine argv |> Arguments
 
-// Illustrates how to emit direct to the Console using Serilog
-// Other topographies can be achieved by using various adapters and bridges, e.g., SerilogTarget or Serilog.Sinks.NLog
+// TODO remove this entire comment after reading https://github.com/jet/dotnet-templates#module-logging
+// Application logic assumes the global `Serilog.Log` is initialized _immediately_ after a successful ArgumentParser.ParseCommandline
 module Logging =
 
     let initialize verbose changeLogVerbose =

--- a/propulsion-projector/README.md
+++ b/propulsion-projector/README.md
@@ -26,7 +26,7 @@ This project was generated using:
 
 1. Use the `eqx` tool to initialize and then run some transactions in a CosmosDb container
 
-        dotnet tool install -g Equinox.Tool --version 2.0.0-rc* # only needed once
+        dotnet tool install -g Equinox.Tool # only needed once
 
         # (either add environment variables as per step 0 or use -s/-d/-c to specify them)
 
@@ -43,7 +43,7 @@ This project was generated using:
 
         # (either add environment variables as per step 0 or use -s/-d/-c to specify them)
 
-        $env:PROPULSION_KAFKA_BROKER="instance.kafka.mysite.com:9092" # or use -b
+        $env:PROPULSION_KAFKA_BROKER="instance.kafka.example.com:9092" # or use -b
 
         # `-g default` defines the Projector Group identity - each id has separated state in the aux container (aka LeaseId)
         # `-m 1000` sets the change feed maximum document limit to 1000
@@ -51,7 +51,7 @@ This project was generated using:
         # cosmos specifies the source (if you have specified 3x EQUINOX_COSMOS_* environment vars, no arguments are needed)
         dotnet run -- -g default -m 1000 -t topic0 cosmos
 
-        # (assuming you've scaled up enough to have >1 range, you can run a second instance in a second console with the same arguments)
+        # (assuming you've scaled up enough to have >1 physical partition range, you can run a second instance in a second console with the same arguments)
 
 3. To create a Consumer, use `dotnet new proConsumer`
 //#else
@@ -65,5 +65,5 @@ This project was generated using:
         # cosmos specifies the source (if you have specified 3x EQUINOX_COSMOS_* environment vars, no arguments are needed)
         dotnet run -- -g default -m 1000 cosmos
 
-        # NB (assuming you've scaled up enough to have >1 range, you can run a second instance in a second console with the same arguments)
+        # NB (assuming you've scaled up enough to have >1 physical partition range, you can run a second instance in a second console with the same arguments)
 //#endif

--- a/propulsion-reactor/Program.fs
+++ b/propulsion-reactor/Program.fs
@@ -14,6 +14,9 @@ module EnvVar =
     let tryGet varName : string option = Environment.GetEnvironmentVariable varName |> Option.ofObj
     let set varName value : unit = Environment.SetEnvironmentVariable(varName, value)
 
+// TODO remove this entire comment after reading https://github.com/jet/dotnet-templates#module-settings
+// - this is where any custom retrieval of settings not arriving via commandline arguments or environment variables should go
+// - values should be propagated by setting environment variables and/or returning them from `initialize`
 module Settings =
 
     let private initEnvVar var key loadF =
@@ -25,6 +28,13 @@ module Settings =
         // e.g. initEnvVar     "EQUINOX_COSMOS_COLLECTION"    "CONSUL KEY" readFromConsul
         () // TODO add any custom logic preprocessing commandline arguments and/or gathering custom defaults from external sources, etc
 
+// TODO remove this entire comment after reading https://github.com/jet/dotnet-templates#module-cmdparser
+// - this module is responsible solely for parsing/validating the commandline arguments (including falling back to values supplied via environment variables)
+// - It's expected that the properties on *Arguments types will summarize the active settings as a side effect of
+// TODO DONT invest time reorganizing or reformatting this - half the value is having a legible summary of all program parameters in a consistent value
+//      you may want to regenerate it at a different time and/or facilitate comparing it with the CmdParser of other programs
+// TODO NEVER hack temporary overrides in here; if you're going to do that, use commandline arguments that fall back to environment variables
+//      or (as a last resort) supply them via code in `module Settings`
 module CmdParser =
 
     exception MissingArg of string
@@ -403,6 +413,8 @@ module CmdParser =
         let parser = ArgumentParser.Create<Parameters>(programName = programName)
         parser.ParseCommandLine argv |> Arguments
 
+// TODO remove this entire comment after reading https://github.com/jet/dotnet-templates#module-logging
+// Application logic assumes the global `Serilog.Log` is initialized _immediately_ after a successful ArgumentParser.ParseCommandline
 module Logging =
 
     let initialize verbose verboseConsole =

--- a/propulsion-reactor/README.md
+++ b/propulsion-reactor/README.md
@@ -68,7 +68,7 @@ This project was generated using:
 3. To run an instance of the Projector from a CosmosDb ChangeFeed
 
 //#if kafka
-        $env:PROPULSION_KAFKA_BROKER="instance.kafka.mysite.com:9092" # or use -b
+        $env:PROPULSION_KAFKA_BROKER="instance.kafka.example.com:9092" # or use -b
 
         # `-g default` defines the Projector Group identity - each id has separated state in the checkpoints store (`Sync-default` in the cited `cosmos` store)
         # `-c $env:EQUINOX_COSMOS_CONTAINER ` specifies the source (if you have specified 2x EQUINOX_COSMOS_* environment vars, no connection/database arguments are needed, but the monitored (source) container must be specified explicitly)
@@ -91,7 +91,7 @@ This project was generated using:
         $env:EQUINOX_ES_HOST="localhost" # or use -g
 
 //#if kafka
-        $env:PROPULSION_KAFKA_BROKER="instance.kafka.mysite.com:9092" # or use -b
+        $env:PROPULSION_KAFKA_BROKER="instance.kafka.example.com:9092" # or use -b
 
         # `-g default` defines the Projector Group identity - each id has separated state in the checkpoints store (`Sync-default` in the cited `cosmos` store)
         # `es` specifies the source (if you have specified 3x EQUINOX_ES_* environment vars, no arguments are needed)

--- a/propulsion-summary-consumer/Program.fs
+++ b/propulsion-summary-consumer/Program.fs
@@ -8,6 +8,9 @@ module EnvVar =
     let tryGet varName : string option = Environment.GetEnvironmentVariable varName |> Option.ofObj
     let set varName value : unit = Environment.SetEnvironmentVariable(varName, value)
 
+// TODO remove this entire comment after reading https://github.com/jet/dotnet-templates#module-settings
+// - this is where any custom retrieval of settings not arriving via commandline arguments or environment variables should go
+// - values should be propagated by setting environment variables and/or returning them from `initialize`
 module Settings =
 
     let private initEnvVar var key loadF =
@@ -19,6 +22,13 @@ module Settings =
         // e.g. initEnvVar     "EQUINOX_COSMOS_COLLECTION"    "CONSUL KEY" readFromConsul
         () // TODO add any custom logic preprocessing commandline arguments and/or gathering custom defaults from external sources, etc
 
+// TODO remove this entire comment after reading https://github.com/jet/dotnet-templates#module-cmdparser
+// - this module is responsible solely for parsing/validating the commandline arguments (including falling back to values supplied via environment variables)
+// - It's expected that the properties on *Arguments types will summarize the active settings as a side effect of
+// TODO DONT invest time reorganizing or reformatting this - half the value is having a legible summary of all program parameters in a consistent value
+//      you may want to regenerate it at a different time and/or facilitate comparing it with the CmdParser of other programs
+// TODO NEVER hack temporary overrides in here; if you're going to do that, use commandline arguments that fall back to environment variables
+//      or (as a last resort) supply them via code in `module Settings`
 module CmdParser =
 
     exception MissingArg of string
@@ -110,6 +120,8 @@ module CmdParser =
         let parser = ArgumentParser.Create<Parameters>(programName = programName)
         parser.ParseCommandLine argv |> Arguments
 
+// TODO remove this entire comment after reading https://github.com/jet/dotnet-templates#module-logging
+// Application logic assumes the global `Serilog.Log` is initialized _immediately_ after a successful ArgumentParser.ParseCommandline
 module Logging =
 
     let initialize verbose =

--- a/propulsion-summary-consumer/README.md
+++ b/propulsion-summary-consumer/README.md
@@ -17,7 +17,7 @@ This project was generated using:
 
 2. To run an instance of the Consumer:
 
-        $env:PROPULSION_KAFKA_BROKER="instance.kafka.mysite.com:9092" # or use -b
+        $env:PROPULSION_KAFKA_BROKER="instance.kafka.example.com:9092" # or use -b
         $env:PROPULSION_KAFKA_TOPIC="topic0" # or use -t
         $env:PROPULSION_KAFKA_GROUP="group0" # or use -g
 

--- a/propulsion-sync/Program.fs
+++ b/propulsion-sync/Program.fs
@@ -15,6 +15,9 @@ module EnvVar =
     let tryGet varName : string option = Environment.GetEnvironmentVariable varName |> Option.ofObj
     let set varName value : unit = Environment.SetEnvironmentVariable(varName, value)
 
+// TODO remove this entire comment after reading https://github.com/jet/dotnet-templates#module-settings
+// - this is where any custom retrieval of settings not arriving via commandline arguments or environment variables should go
+// - values should be propagated by setting environment variables and/or returning them from `initialize`
 module Settings =
 
     let private initEnvVar var key loadF =
@@ -26,6 +29,13 @@ module Settings =
         // e.g. initEnvVar     "EQUINOX_COSMOS_COLLECTION"    "CONSUL KEY" readFromConsul
         () // TODO add any custom logic preprocessing commandline arguments and/or gathering custom defaults from external sources, etc
 
+// TODO remove this entire comment after reading https://github.com/jet/dotnet-templates#module-cmdparser
+// - this module is responsible solely for parsing/validating the commandline arguments (including falling back to values supplied via environment variables)
+// - It's expected that the properties on *Arguments types will summarize the active settings as a side effect of
+// TODO DONT invest time reorganizing or reformatting this - half the value is having a legible summary of all program parameters in a consistent value
+//      you may want to regenerate it at a different time and/or facilitate comparing it with the CmdParser of other programs
+// TODO NEVER hack temporary overrides in here; if you're going to do that, use commandline arguments that fall back to environment variables
+//      or (as a last resort) supply them via code in `module Settings`
 module CmdParser =
 
     exception MissingArg of string
@@ -431,8 +441,8 @@ module CmdParser =
         let parser = ArgumentParser.Create<Parameters>(programName = programName)
         parser.ParseCommandLine argv |> Arguments
 
-// Illustrates how to emit direct to the Console using Serilog
-// Other topographies can be achieved by using various adapters and bridges, e.g., SerilogTarget or Serilog.Sinks.NLog
+// TODO remove this entire comment after reading https://github.com/jet/dotnet-templates#module-logging
+// Application logic assumes the global `Serilog.Log` is initialized _immediately_ after a successful ArgumentParser.ParseCommandline
 module Logging =
 
     open Serilog.Events

--- a/propulsion-tracking-consumer/Program.fs
+++ b/propulsion-tracking-consumer/Program.fs
@@ -8,6 +8,9 @@ module EnvVar =
     let tryGet varName : string option = Environment.GetEnvironmentVariable varName |> Option.ofObj
     let set varName value : unit = Environment.SetEnvironmentVariable(varName, value)
 
+// TODO remove this entire comment after reading https://github.com/jet/dotnet-templates#module-settings
+// - this is where any custom retrieval of settings not arriving via commandline arguments or environment variables should go
+// - values should be propagated by setting environment variables and/or returning them from `initialize`
 module Settings =
 
     let private initEnvVar var key loadF =
@@ -19,6 +22,13 @@ module Settings =
         // e.g. initEnvVar     "EQUINOX_COSMOS_COLLECTION"    "CONSUL KEY" readFromConsul
         () // TODO add any custom logic preprocessing commandline arguments and/or gathering custom defaults from external sources, etc
 
+// TODO remove this entire comment after reading https://github.com/jet/dotnet-templates#module-cmdparser
+// - this module is responsible solely for parsing/validating the commandline arguments (including falling back to values supplied via environment variables)
+// - It's expected that the properties on *Arguments types will summarize the active settings as a side effect of
+// TODO DONT invest time reorganizing or reformatting this - half the value is having a legible summary of all program parameters in a consistent value
+//      you may want to regenerate it at a different time and/or facilitate comparing it with the CmdParser of other programs
+// TODO NEVER hack temporary overrides in here; if you're going to do that, use commandline arguments that fall back to environment variables
+//      or (as a last resort) supply them via code in `module Settings`
 module CmdParser =
 
     exception MissingArg of string
@@ -110,6 +120,8 @@ module CmdParser =
         let parser = ArgumentParser.Create<Parameters>(programName = programName)
         parser.ParseCommandLine argv |> Arguments
 
+// TODO remove this entire comment after reading https://github.com/jet/dotnet-templates#module-logging
+// Application logic assumes the global `Serilog.Log` is initialized _immediately_ after a successful ArgumentParser.ParseCommandline
 module Logging =
 
     let initialize verbose =

--- a/propulsion-tracking-consumer/README.md
+++ b/propulsion-tracking-consumer/README.md
@@ -18,7 +18,7 @@ This project was generated using:
 
 2. To run an instance of the Consumer:
 
-        $env:PROPULSION_KAFKA_BROKER="instance.kafka.mysite.com:9092" # or use -b
+        $env:PROPULSION_KAFKA_BROKER="instance.kafka.example.com:9092" # or use -b
         $env:PROPULSION_KAFKA_TOPIC="topic0" # or use -t
         $env:PROPULSION_KAFKA_GROUP="group0" # or use -g
 


### PR DESCRIPTION
This continues the work of #42 in summarizing the reasoning behind some subtle elements of the canonical form of `Program.fs` files across all these templates