### PR TITLE
Cleanup mains, inline startConsumer, standardize naming

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ The `Unreleased` section name is replaced by the expected version of next releas
 
 ### Added
 ### Changed
+
+- Lots of coding style fine-tuning [#53](https://github.com/jet/dotnet-templates/pulls/53) 
+- Clean up `resolve`/`resolver` helper template [#54](https://github.com/jet/dotnet-templates/pulls/54) 
+
 ### Removed
 ### Fixed
 

--- a/README.md
+++ b/README.md
@@ -169,21 +169,21 @@ All the templates herein attempt to adhere to a consistent structure for the [co
 
 _Responsible for: Loading secrets and custom configuration, supplying defaults when environment variables are not set_
 
-Wiring up retrieval of configuration values is the most environment-dependent aspect of the wiring up of an application's interaction with its environment and/or data storage mechanisms. This is particularly relevant where there is variance between local (development time), testing and production deployments. For this reason, the retrieval of values from configuration stores or key vaults is not managed directly within the [`CommandLine` section](#module-commandline)
+Wiring up retrieval of configuration values is the most environment-dependent aspect of the wiring up of an application's interaction with its environment and/or data storage mechanisms. This is particularly relevant where there is variance between local (development time), testing and production deployments. For this reason, the retrieval of values from configuration stores or key vaults is not managed directly within the [`module Args` section](#module-args)
 
 The `Settings` module is responsible for the following:
 1. Feeding defaults into process-local Environment Variables, _where those are not already supplied_
-2. Encapsulating all bindings to Configuration or Secret stores (Vaults) in order that this does not have to be complected with the argument parsing or defaulting in `CommandLine`
+2. Encapsulating all bindings to Configuration or Secret stores (Vaults) in order that this does not have to be complected with the argument parsing or defaulting in `module Args`
 
 - DO (sparingly) rely on inputs from the command line to drive the lookup process
-- DONT log values (`CommandLine`’s `Arguments` wrappers should do that as applicable as part of the wireup process)
+- DONT log values (`mpdule Args`’s `Arguments` wrappers should do that as applicable as part of the wireup process)
 - DONT perform redundant work to load values if they’ve already been supplied via Environment Variables
 
-### `module CommandLine`
+### `module Args`
 
 _Responsible for: mapping Environment Variables and the Command Line `argv` to an `Arguments` model_
 
-The `CommandLine` module fulfils three roles:
+`module Args` fulfils three roles:
 
 1. uses [Argu](http://fsprojects.github.io/Argu/tutorial.html) to map the inputs passed via `argv` to values per argument, providing good error and/or help messages in the case of invalid inputs
 2. responsible for managing all defaulting of input values _including echoing them them such that an operator can infer the arguments in force_ without having to go look up defaults in a source control repo
@@ -203,7 +203,7 @@ NOTE: there's a [medium term plan to submit a PR to Argu](https://github.com/fsp
 
 _Responsible for applying logging config and setting up loggers for the application_
 
-- DO allow overriding of log level via a command line argument and/or environment variable (by passing `CommandLine.Arguments` or values from it
+- DO allow overriding of log level via a command line argument and/or environment variable (by passing `Args.Arguments` or values from it
 
 #### example
 
@@ -220,7 +220,7 @@ The `start` function contains the specific wireup relevant to the infrastructure
 #### example
 
 ```
-let start (args : CommandLine.Arguments) =
+let start (args : Args.Arguments) =
 	…
 	(yields a started application loop)
 ```
@@ -246,13 +246,13 @@ let run args =
 
 [<EntryPoint>]
 let main argv =
-    try let args = CommandLine.parse argv
+    try let args = Args.parse argv
         try Logging.initialize args.Verbose
             try Settings.initialize ()
                 if run args then 0 else 3
             with e -> Log.Fatal(e, "Exiting"); 2
         finally Log.CloseAndFlush()
-    with CommandLine.MissingArg msg -> eprintfn "%s" msg; 1
+    with Args.MissingArg msg -> eprintfn "%s" msg; 1
         | :? Argu.ArguParseException as e -> eprintfn "%s" e.Message; 1
         | e -> eprintf "Exception %s" e.Message; 1
 ```

--- a/README.md
+++ b/README.md
@@ -165,7 +165,7 @@ Wherever possible, the samples strongly type identifiers, particularly ones that
 
 All the templates herein attempt to adhere to a consistent structure for the [composition root](https://blog.ploeh.dk/2011/07/28/CompositionRoot/) `module` (the one containing an Application’s `main`)
 
-### `module Settings`
+### `module Configuration`
 
 _Responsible for: Loading secrets and custom configuration, supplying defaults when environment variables are not set_
 
@@ -248,7 +248,7 @@ let run args =
 let main argv =
     try let args = Args.parse argv
         try Logging.initialize args.Verbose
-            try Settings.initialize ()
+            try Configuration.initialize ()
                 if run args then 0 else 3
             with e -> Log.Fatal(e, "Exiting"); 2
         finally Log.CloseAndFlush()

--- a/README.md
+++ b/README.md
@@ -163,7 +163,7 @@ Wherever possible, the samples strongly type identifiers, particularly ones that
 
 ## Microservice Program.fs conventions
 
-All the templates herein attempt to adhere to a consistent structure for the [composition root](https://blog.ploeh.dk/2011/07/28/CompositionRoot/) `module` (the one containing an Application’s `main`)
+All the templates herein attempt to adhere to a consistent structure for the [composition root](https://blog.ploeh.dk/2011/07/28/CompositionRoot/) `module` (the one containing an Application’s `main`), consisting of the following common elements:
 
 ### `module Configuration`
 
@@ -176,7 +176,7 @@ The `Settings` module is responsible for the following:
 2. Encapsulating all bindings to Configuration or Secret stores (Vaults) in order that this does not have to be complected with the argument parsing or defaulting in `module Args`
 
 - DO (sparingly) rely on inputs from the command line to drive the lookup process
-- DONT log values (`mpdule Args`’s `Arguments` wrappers should do that as applicable as part of the wireup process)
+- DONT log values (`module Args`’s `Arguments` wrappers should do that as applicable as part of the wireup process)
 - DONT perform redundant work to load values if they’ve already been supplied via Environment Variables
 
 ### `module Args`
@@ -186,29 +186,30 @@ _Responsible for: mapping Environment Variables and the Command Line `argv` to a
 `module Args` fulfils three roles:
 
 1. uses [Argu](http://fsprojects.github.io/Argu/tutorial.html) to map the inputs passed via `argv` to values per argument, providing good error and/or help messages in the case of invalid inputs
-2. responsible for managing all defaulting of input values _including echoing them them such that an operator can infer the arguments in force_ without having to go look up defaults in a source control repo
-3. expose an object model that the `build` or `start` functions can use to succinctly wire up the dependencies without needing to touch `Argu`, `Settings`, or any concrete Configuration or Secrets storage mechanisms
+2. responsible for managing all defaulting of input values _including echoing them to console such that an operator can infer the arguments in force_ without having to go look up defaults in a source control repo
+3. expose an object model that the `build` or `start` functions can use to succinctly wire up the dependencies without needing to touch `Argu`, `Configuration`, or any concrete Configuration or Secrets storage mechanisms
 
+- DO take values via Argu or Environment Variables
 - DO log the values being applied, especially where defaulting is in play
 - DONT log secrets
-- DO take values via Argu or Environment Variables
 - DONT mix in any application or settings specific logic (**no retrieval of values, don’t make people read the boilerplate to see if this app has custom secrets retrieval**)
 - DONT invest time changing the layout; leaving it consistent makes it easier for others to scan
-- DONT be tempted to merge blocks of variables - the intention is to (to the maximum extent possible) group arguments into clusters of 5-7 related items
+- DONT be tempted to merge blocks of variables into a coupled monster - the intention is to (to the maximum extent possible) group arguments into clusters of 5-7 related items
 - DONT reorder types - it'll just make it harder if you ever want to remix and/or compare and contrast across a set of programs
 
-NOTE: there's a [medium term plan to submit a PR to Argu](https://github.com/fsprojects/Argu/issues/143) extending it to be able to fall back to environment variables where a value is not supplied by means of declarative attributes on the Argument specification in the DU, _including having the `--help` message automatically include a reference to the name of the environment variable that one can supply the value through_
+NOTE: there's a [medium term plan to submit a PR to Argu](https://github.com/fsprojects/Argu/issues/143) extending it to be able to fall back to environment variables where a value is not supplied, by means of declarative attributes on the Argument specification in the DU, _including having the `--help` message automatically include a reference to the name of the environment variable that one can supply the value through_
 
 ### `module Logging`
 
 _Responsible for applying logging config and setting up loggers for the application_
 
-- DO allow overriding of log level via a command line argument and/or environment variable (by passing `Args.Arguments` or values from it
+- DO allow overriding of log level via a command line argument and/or environment variable (by passing `Args.Arguments` or values from it)
 
 #### example
 
 ```
 module Logging =
+
     let initialize verbose =
 	Log.Logger <- LoggerConfiguration(….)
 ```
@@ -221,20 +222,20 @@ The `start` function contains the specific wireup relevant to the infrastructure
 
 ```
 let start (args : Args.Arguments) =
-	…
-	(yields a started application loop)
+    …
+    (yields a started application loop)
 ```
 
 ### `run`,  `main` functions
 
 The `run` function formalizes the overall pattern. It is responsible for:
 
-1. Managing the correct sequencing of the startup procedure, weaving together the above elements,
+1. Managing the correct sequencing of the startup procedure, weaving together the above elements
 2. managing the emission of startup or abnormal termination messages to the console
 
 - DONT alter the canonical form - the processing is in this exact order for a multitude of reasons
-- DONT have any application specific wire within `run` - any such logic should live within the `start` function
-- DONT return an `int` from `run`, let main tage charge of the exit codes
+- DONT have any application specific wire within `run` - any such logic should live within the `start` and/or `build` functions
+- DONT return an `int` from `run`; let `main` define the exit codes in one place
 
 #### example
 
@@ -259,7 +260,7 @@ let main argv =
 
 ## CONTRIBUTING
 
-Please don't hesitate to [create a GitHub issue](https://github.com/jet/dotnet-templates/issues/new) for any questions so others can benefit from the discussion. For any significant planned changes or additions, please err on the side of [reaching out early](https://github.com/jet/dotnet-templates/issues/new) so we can align expectations - there's nothing more frustrating than having your hard work not yielding a mutually agreeable result ;)
+Please don't hesitate to [create a GitHub issue](https://github.com/jet/dotnet-templates/issues/new) for any questions, so others can benefit from the discussion. For any significant planned changes or additions, please err on the side of [reaching out early](https://github.com/jet/dotnet-templates/issues/new) so we can align expectations - there's nothing more frustrating than having your hard work not yielding a mutually agreeable result ;)
 
 See [the Equinox repo's CONTRIBUTING section](https://github.com/jet/equinox/blob/master/README.md#contributing) for general guidelines wrt how contributions are considered specifically wrt Equinox.
 
@@ -270,10 +271,10 @@ The following sorts of things are top of the list for the templates:
 - support for additional languages in the templates
 - further straightforward starter projects
 
-While there is no rigid or defined limit to what makes sense to add, it should be borne in mind that `dotnet new eqx*` is often going to be a new user's first interaction with Equinox and/or [asp]dotnetcore. Hence there's a delicate (and intrinsically subjective) balance to be struck between:
+While there is no rigid or defined limit to what makes sense to add, it should be borne in mind that `dotnet new eqx/pro*` is sometimes going to be a new user's first interaction with Equinox and/or [asp]dotnetcore. Hence there's a delicate (and intrinsically subjective) balance to be struck between:
 
   1. simplicity of programming techniques used / beginner friendliness
   2. brevity of the generated code
   3. encouraging good design practices
 
-  In other words, there's lots of subtlety to what should and shouldn't go into a template - so discussing changes before investing time is encouraged; and agreed changes will generally be rolled out across the repo
+  In other words, there's lots of subtlety to what should and shouldn't go into a template - so discussing changes before investing time is encouraged; agreed changes will generally be rolled out across the repo.

--- a/equinox-testbed/Program.fs
+++ b/equinox-testbed/Program.fs
@@ -8,7 +8,7 @@ open System
 open System.Threading
 
 [<AutoOpen>]
-module CmdParser =
+module CommandLine =
 
     type [<NoEquality; NoComparison>]
         Parameters =
@@ -140,7 +140,7 @@ module LoadTest =
                 with e -> domainLog.Warning(e, "Test threw an exception"); e.Reraise () }
         execute
     let private createResultLog fileName = LoggerConfiguration().WriteTo.File(fileName).CreateLogger()
-    let run (log: ILogger) (verbose, verboseConsole, maybeSeq) reportFilename (a : CmdParser.TestArguments) =
+    let run (log: ILogger) (verbose, verboseConsole, maybeSeq) reportFilename (a : CommandLine.TestArguments) =
         let createStoreLog verboseStore = createStoreLog verboseStore verboseConsole maybeSeq
         let storeLog, storeConfig: ILogger * Storage.StorageConfig = a.ConfigureStore(log, createStoreLog)
         let runSingleTest : ClientId -> Async<unit> =

--- a/equinox-testbed/Program.fs
+++ b/equinox-testbed/Program.fs
@@ -8,7 +8,7 @@ open System
 open System.Threading
 
 [<AutoOpen>]
-module CommandLine =
+module Args =
 
     type [<NoEquality; NoComparison>]
         Parameters =
@@ -140,7 +140,7 @@ module LoadTest =
                 with e -> domainLog.Warning(e, "Test threw an exception"); e.Reraise () }
         execute
     let private createResultLog fileName = LoggerConfiguration().WriteTo.File(fileName).CreateLogger()
-    let run (log: ILogger) (verbose, verboseConsole, maybeSeq) reportFilename (a : CommandLine.TestArguments) =
+    let run (log: ILogger) (verbose, verboseConsole, maybeSeq) reportFilename (a : Args.TestArguments) =
         let createStoreLog verboseStore = createStoreLog verboseStore verboseConsole maybeSeq
         let storeLog, storeConfig: ILogger * Storage.StorageConfig = a.ConfigureStore(log, createStoreLog)
         let runSingleTest : ClientId -> Async<unit> =

--- a/equinox-web/Domain/Aggregate.fs
+++ b/equinox-web/Domain/Aggregate.fs
@@ -1,9 +1,10 @@
 ﻿module TodoBackendTemplate.Aggregate
 
+let [<Literal>] Category = "Aggregate"
+let streamName (id: string) = FsCodec.StreamName.create Category id
+
 // NB - these types and the union case names reflect the actual storage formats and hence need to be versioned with care
 module Events =
-
-    let (|For|) (id: string) = FsCodec.StreamName.create "Aggregate" id
 
     type SnapshottedData = { happened: bool }
 
@@ -35,7 +36,9 @@ type View = { sorted : bool }
 
 type Service internal (log, resolve, maxAttempts) =
 
-    let resolve (Events.For id) = Equinox.Stream<Events.Event, Fold.State>(log, resolve id, maxAttempts)
+    let resolve id =
+        let stream = resolve (streamName id)
+        Equinox.Stream<Events.Event, Fold.State>(log, stream, maxAttempts)
 
     /// Read the present state
     // TOCONSIDER: you should probably be separating this out per CQRS and reading from a denormalized/cached set of projections

--- a/equinox-web/Domain/Aggregate.fs
+++ b/equinox-web/Domain/Aggregate.fs
@@ -34,11 +34,7 @@ let interpret c (state : Fold.State) =
 
 type View = { sorted : bool }
 
-type Service internal (log, resolve, maxAttempts) =
-
-    let resolve id =
-        let stream = resolve (streamName id)
-        Equinox.Stream<Events.Event, Fold.State>(log, stream, maxAttempts)
+type Service internal (resolve : string -> Equinox.Stream<Events.Event, Fold.State>) =
 
     /// Read the present state
     // TOCONSIDER: you should probably be separating this out per CQRS and reading from a denormalized/cached set of projections
@@ -51,4 +47,8 @@ type Service internal (log, resolve, maxAttempts) =
         let stream = resolve clientId
         stream.Transact(interpret command)
 
-let create resolve = Service(Serilog.Log.ForContext<Service>(), resolve, maxAttempts = 3)
+let create resolver =
+    let resolve id =
+        let stream = resolver (streamName id)
+        Equinox.Stream(Serilog.Log.ForContext<Service>(), stream, maxAttempts = 3)
+    Service(resolve)

--- a/equinox-web/Domain/Todo.fs
+++ b/equinox-web/Domain/Todo.fs
@@ -76,11 +76,7 @@ let interpret c (state : Fold.State) =
 type View = { id: int; order: int; title: string; completed: bool }
 
 /// Defines operations that a Controller can perform on a Todo List
-type Service internal (log, resolve, maxAttempts) =
-
-    let resolve clientId =
-        let stream = resolve (streamName clientId)
-        Equinox.Stream(log, stream, maxAttempts = maxAttempts)
+type Service internal (resolve : ClientId -> Equinox.Stream<Events.Event, Fold.State>) =
 
     let execute clientId command =
         let stream = resolve clientId
@@ -129,4 +125,8 @@ type Service internal (log, resolve, maxAttempts) =
         let! state' = handle clientId (Update (id, value))
         return state' |> List.find (fun x -> x.id = id) |> render}
 
-let create resolve = Service(Serilog.Log.ForContext<Service>(), resolve, maxAttempts = 3)
+let create resolver =
+    let resolve clientId =
+        let stream = resolver (streamName clientId)
+        Equinox.Stream(Serilog.Log.ForContext<Service>(), stream, maxAttempts = 3)
+    Service(resolve)

--- a/equinox-web/Web/Program.fs
+++ b/equinox-web/Web/Program.fs
@@ -1,30 +1,29 @@
-namespace TodoBackendTemplate.Web
+module TodoBackendTemplate.Web.Program
 
 open Microsoft.AspNetCore
 open Microsoft.AspNetCore.Hosting
 open Serilog
 
-module Program =
-    let createWebHostBuilder args : IWebHostBuilder =
-        WebHost
-            .CreateDefaultBuilder(args)
-            .UseSerilog()
-            .UseStartup<Startup>()
+let initLogging () =
+    Log.Logger <-
+        LoggerConfiguration()
+            .MinimumLevel.Debug()
+            .MinimumLevel.Override("Microsoft.AspNetCore", Serilog.Events.LogEventLevel.Warning)
+            .Enrich.FromLogContext()
+            .WriteTo.Console()
+            .CreateLogger()
 
-    [<EntryPoint>]
-    let main argv =
-        try
-            Log.Logger <-
-                LoggerConfiguration()
-                    .MinimumLevel.Debug()
-                    .MinimumLevel.Override("Microsoft.AspNetCore", Serilog.Events.LogEventLevel.Warning)
-//.MinimumLevel.Override("Microsoft", Serilog.Events.LogEventLevel.Warning)
-                    .Enrich.FromLogContext()
-                    .WriteTo.Console()
-                    .CreateLogger()
-                :> ILogger
-            createWebHostBuilder(argv).Build().Run()
-            0
-        with e ->
-            eprintfn "%s" e.Message
-            1
+let createWebHostBuilder args : IWebHostBuilder =
+    WebHost
+        .CreateDefaultBuilder(args)
+        .UseSerilog()
+        .UseStartup<Startup>()
+
+[<EntryPoint>]
+let main argv =
+    try initLogging ()
+        createWebHostBuilder(argv).Build().Run()
+        0
+    with e ->
+        eprintfn "%s" e.Message
+        1

--- a/propulsion-consumer/Program.fs
+++ b/propulsion-consumer/Program.fs
@@ -8,10 +8,10 @@ module EnvVar =
     let tryGet varName : string option = Environment.GetEnvironmentVariable varName |> Option.ofObj
     let set varName value : unit = Environment.SetEnvironmentVariable(varName, value)
 
-// TODO remove this entire comment after reading https://github.com/jet/dotnet-templates#module-settings
+// TODO remove this entire comment after reading https://github.com/jet/dotnet-templates#module-configuration
 // - this is where any custom retrieval of settings not arriving via commandline arguments or environment variables should go
 // - values should be propagated by setting environment variables and/or returning them from `initialize`
-module Settings =
+module Configuration =
 
     let private initEnvVar var key loadF =
         if None = EnvVar.tryGet var then
@@ -28,7 +28,7 @@ module Settings =
 // TODO DONT invest time reorganizing or reformatting this - half the value is having a legible summary of all program parameters in a consistent value
 //      you may want to regenerate it at a different time and/or facilitate comparing it with the `module Args` of other programs
 // TODO NEVER hack temporary overrides in here; if you're going to do that, use commandline arguments that fall back to environment variables
-//      or (as a last resort) supply them via code in `module Settings`
+//      or (as a last resort) supply them via code in `module Configuration`
 module Args =
 
     exception MissingArg of string
@@ -111,7 +111,7 @@ let run args =
 let main argv =
     try let args = Args.parse argv
         try Logging.initialize args.Verbose
-            try Settings.initialize ()
+            try Configuration.initialize ()
                 if run args then 0 else 3
             with e -> Log.Fatal(e, "Exiting"); 2
         finally Log.CloseAndFlush()

--- a/propulsion-consumer/Program.fs
+++ b/propulsion-consumer/Program.fs
@@ -26,10 +26,10 @@ module Settings =
 // - this module is responsible solely for parsing/validating the commandline arguments (including falling back to values supplied via environment variables)
 // - It's expected that the properties on *Arguments types will summarize the active settings as a side effect of
 // TODO DONT invest time reorganizing or reformatting this - half the value is having a legible summary of all program parameters in a consistent value
-//      you may want to regenerate it at a different time and/or facilitate comparing it with the CmdParser of other programs
+//      you may want to regenerate it at a different time and/or facilitate comparing it with the CommandLine of other programs
 // TODO NEVER hack temporary overrides in here; if you're going to do that, use commandline arguments that fall back to environment variables
 //      or (as a last resort) supply them via code in `module Settings`
-module CmdParser =
+module CommandLine =
 
     exception MissingArg of string
     let private getEnvVarForArgumentOrThrow varName argName =
@@ -91,7 +91,7 @@ module Logging =
                         c.WriteTo.Console(theme=theme, outputTemplate="[{Timestamp:HH:mm:ss} {Level:u3}] {Message:lj} {Properties}{NewLine}{Exception}")
             |> fun c -> c.CreateLogger()
 
-let start (args : CmdParser.Arguments) =
+let start (args : CommandLine.Arguments) =
     let c =
         FsKafka.KafkaConsumerConfig.Create(
             "ConsumerTemplate",
@@ -102,20 +102,19 @@ let start (args : CmdParser.Arguments) =
     //NultiMessages.Parallel.Start(c, args.MaxDop)
     MultiStreams.start(c, args.MaxDop)
 
-let run argv =
-    try let args = CmdParser.parse argv
-        Logging.initialize args.Verbose
-        Settings.initialize ()
-        use consumer = start args
-        consumer.AwaitCompletion() |> Async.RunSynchronously
-        if consumer.RanToCompletion then 0 else 2
-    with :? Argu.ArguParseException as e -> eprintfn "%s" e.Message; 1
-        | :? Argu.ArguException as e -> eprintf "Argument parsing exception %s" e.Message; 1
-        | CmdParser.MissingArg msg -> eprintfn "%s" msg; 1
-        // If the handler throws, we exit the app in order to let an orchestrator flag the failure
-        | e -> Log.Fatal(e, "Exiting"); 1
+let run args =
+    use consumer = start args
+    consumer.AwaitCompletion() |> Async.RunSynchronously
+    consumer.RanToCompletion
 
 [<EntryPoint>]
 let main argv =
-    try run argv
-    finally Log.CloseAndFlush()
+    try let args = CommandLine.parse argv
+        try Logging.initialize args.Verbose
+            try Settings.initialize ()
+                if run args then 0 else 3
+            with e -> Log.Fatal(e, "Exiting"); 2
+        finally Log.CloseAndFlush()
+    with CommandLine.MissingArg msg -> eprintfn "%s" msg; 1
+        | :? Argu.ArguParseException as e -> eprintfn "%s" e.Message; 1
+        | e -> eprintf "Exception %s" e.Message; 1

--- a/propulsion-consumer/Program.fs
+++ b/propulsion-consumer/Program.fs
@@ -22,7 +22,7 @@ module Settings =
         // e.g. initEnvVar     "EQUINOX_COSMOS_COLLECTION"    "CONSUL KEY" readFromConsul
         () // TODO add any custom logic preprocessing commandline arguments and/or gathering custom defaults from external sources, etc
 
-// TODO remove this entire comment after reading https://github.com/jet/dotnet-templates#module-cmdparser
+// TODO remove this entire comment after reading https://github.com/jet/dotnet-templates#module-commandline
 // - this module is responsible solely for parsing/validating the commandline arguments (including falling back to values supplied via environment variables)
 // - It's expected that the properties on *Arguments types will summarize the active settings as a side effect of
 // TODO DONT invest time reorganizing or reformatting this - half the value is having a legible summary of all program parameters in a consistent value

--- a/propulsion-consumer/Program.fs
+++ b/propulsion-consumer/Program.fs
@@ -22,14 +22,14 @@ module Settings =
         // e.g. initEnvVar     "EQUINOX_COSMOS_COLLECTION"    "CONSUL KEY" readFromConsul
         () // TODO add any custom logic preprocessing commandline arguments and/or gathering custom defaults from external sources, etc
 
-// TODO remove this entire comment after reading https://github.com/jet/dotnet-templates#module-commandline
+// TODO remove this entire comment after reading https://github.com/jet/dotnet-templates#module-args
 // - this module is responsible solely for parsing/validating the commandline arguments (including falling back to values supplied via environment variables)
 // - It's expected that the properties on *Arguments types will summarize the active settings as a side effect of
 // TODO DONT invest time reorganizing or reformatting this - half the value is having a legible summary of all program parameters in a consistent value
-//      you may want to regenerate it at a different time and/or facilitate comparing it with the CommandLine of other programs
+//      you may want to regenerate it at a different time and/or facilitate comparing it with the `module Args` of other programs
 // TODO NEVER hack temporary overrides in here; if you're going to do that, use commandline arguments that fall back to environment variables
 //      or (as a last resort) supply them via code in `module Settings`
-module CommandLine =
+module Args =
 
     exception MissingArg of string
     let private getEnvVarForArgumentOrThrow varName argName =
@@ -91,7 +91,7 @@ module Logging =
                         c.WriteTo.Console(theme=theme, outputTemplate="[{Timestamp:HH:mm:ss} {Level:u3}] {Message:lj} {Properties}{NewLine}{Exception}")
             |> fun c -> c.CreateLogger()
 
-let start (args : CommandLine.Arguments) =
+let start (args : Args.Arguments) =
     let c =
         FsKafka.KafkaConsumerConfig.Create(
             "ConsumerTemplate",
@@ -109,12 +109,12 @@ let run args =
 
 [<EntryPoint>]
 let main argv =
-    try let args = CommandLine.parse argv
+    try let args = Args.parse argv
         try Logging.initialize args.Verbose
             try Settings.initialize ()
                 if run args then 0 else 3
             with e -> Log.Fatal(e, "Exiting"); 2
         finally Log.CloseAndFlush()
-    with CommandLine.MissingArg msg -> eprintfn "%s" msg; 1
+    with Args.MissingArg msg -> eprintfn "%s" msg; 1
         | :? Argu.ArguParseException as e -> eprintfn "%s" e.Message; 1
         | e -> eprintf "Exception %s" e.Message; 1

--- a/propulsion-projector/Program.fs
+++ b/propulsion-projector/Program.fs
@@ -1,5 +1,6 @@
 ﻿module ProjectorTemplate.Program
 
+open Equinox.Cosmos
 open Propulsion.Cosmos
 open Serilog
 open System
@@ -41,7 +42,6 @@ module Args =
         | None -> getEnvVarForArgumentOrThrow varName argName
         | Some x -> x
     open Argu
-    open Equinox.Cosmos
     type [<NoEquality; NoComparison>] CosmosParameters =
         | [<AltCommandLine "-m">]       ConnectionMode of Equinox.Cosmos.ConnectionMode
         | [<AltCommandLine "-s">]       Connection of string

--- a/propulsion-projector/Program.fs
+++ b/propulsion-projector/Program.fs
@@ -10,10 +10,10 @@ module EnvVar =
     let tryGet varName : string option = Environment.GetEnvironmentVariable varName |> Option.ofObj
     let set varName value : unit = Environment.SetEnvironmentVariable(varName, value)
 
-// TODO remove this entire comment after reading https://github.com/jet/dotnet-templates#module-settings
+// TODO remove this entire comment after reading https://github.com/jet/dotnet-templates#module-configuration
 // - this is where any custom retrieval of settings not arriving via commandline arguments or environment variables should go
 // - values should be propagated by setting environment variables and/or returning them from `initialize`
-module Settings =
+module Configuration =
 
     let private initEnvVar var key loadF =
         if None = EnvVar.tryGet var then
@@ -30,7 +30,7 @@ module Settings =
 // TODO DONT invest time reorganizing or reformatting this - half the value is having a legible summary of all program parameters in a consistent value
 //      you may want to regenerate it at a different time and/or facilitate comparing it with the `module Args` of other programs
 // TODO NEVER hack temporary overrides in here; if you're going to do that, use commandline arguments that fall back to environment variables
-//      or (as a last resort) supply them via code in `module Settings`
+//      or (as a last resort) supply them via code in `module Configuration`
 module Args =
 
     exception MissingArg of string
@@ -219,7 +219,7 @@ let run args =
 let main argv =
     try let args = Args.parse argv
         try Logging.initialize args.Verbose args.VerboseConsole
-            try Settings.initialize ()
+            try Configuration.initialize ()
                 if run args then 0 else 3
             with e -> Log.Fatal(e, "Exiting"); 2
         finally Log.CloseAndFlush()

--- a/propulsion-projector/Program.fs
+++ b/propulsion-projector/Program.fs
@@ -23,7 +23,7 @@ module Settings =
         // e.g. initEnvVar     "EQUINOX_COSMOS_COLLECTION"    "CONSUL KEY" readFromConsul
         () // TODO add any custom logic preprocessing commandline arguments and/or gathering custom defaults from external sources, etc
 
-// TODO remove this entire comment after reading https://github.com/jet/dotnet-templates#module-cmdparser
+// TODO remove this entire comment after reading https://github.com/jet/dotnet-templates#module-commandline
 // - this module is responsible solely for parsing/validating the commandline arguments (including falling back to values supplied via environment variables)
 // - It's expected that the properties on *Arguments types will summarize the active settings as a side effect of
 // TODO DONT invest time reorganizing or reformatting this - half the value is having a legible summary of all program parameters in a consistent value

--- a/propulsion-projector/Program.fs
+++ b/propulsion-projector/Program.fs
@@ -23,14 +23,14 @@ module Settings =
         // e.g. initEnvVar     "EQUINOX_COSMOS_COLLECTION"    "CONSUL KEY" readFromConsul
         () // TODO add any custom logic preprocessing commandline arguments and/or gathering custom defaults from external sources, etc
 
-// TODO remove this entire comment after reading https://github.com/jet/dotnet-templates#module-commandline
+// TODO remove this entire comment after reading https://github.com/jet/dotnet-templates#module-args
 // - this module is responsible solely for parsing/validating the commandline arguments (including falling back to values supplied via environment variables)
 // - It's expected that the properties on *Arguments types will summarize the active settings as a side effect of
 // TODO DONT invest time reorganizing or reformatting this - half the value is having a legible summary of all program parameters in a consistent value
-//      you may want to regenerate it at a different time and/or facilitate comparing it with the CommandLine of other programs
+//      you may want to regenerate it at a different time and/or facilitate comparing it with the `module Args` of other programs
 // TODO NEVER hack temporary overrides in here; if you're going to do that, use commandline arguments that fall back to environment variables
 //      or (as a last resort) supply them via code in `module Settings`
-module CommandLine =
+module Args =
 
     exception MissingArg of string
     let private getEnvVarForArgumentOrThrow varName argName =
@@ -180,7 +180,7 @@ module Logging =
 
 let [<Literal>] AppName = "ProjectorTemplate"
 
-let build (args : CommandLine.Arguments) =
+let build (args : Args.Arguments) =
     let discovery, source, connector = args.Cosmos.BuildConnectionDetails()
     let aux, leaseId, startFromTail, maxDocuments, lagFrequency, (maxReadAhead, maxConcurrentStreams) = args.BuildChangeFeedParams()
 #if kafka
@@ -218,12 +218,12 @@ let run args =
 
 [<EntryPoint>]
 let main argv =
-    try let args = CommandLine.parse argv
+    try let args = Args.parse argv
         try Logging.initialize args.Verbose args.VerboseConsole
             try Settings.initialize ()
                 if run args then 0 else 3
             with e -> Log.Fatal(e, "Exiting"); 2
         finally Log.CloseAndFlush()
-    with CommandLine.MissingArg msg -> eprintfn "%s" msg; 1
+    with Args.MissingArg msg -> eprintfn "%s" msg; 1
         | :? Argu.ArguParseException as e -> eprintfn "%s" e.Message; 1
         | e -> eprintf "Exception %s" e.Message; 1

--- a/propulsion-reactor/Program.fs
+++ b/propulsion-reactor/Program.fs
@@ -28,14 +28,14 @@ module Settings =
         // e.g. initEnvVar     "EQUINOX_COSMOS_COLLECTION"    "CONSUL KEY" readFromConsul
         () // TODO add any custom logic preprocessing commandline arguments and/or gathering custom defaults from external sources, etc
 
-// TODO remove this entire comment after reading https://github.com/jet/dotnet-templates#module-commandline
+// TODO remove this entire comment after reading https://github.com/jet/dotnet-templates#module-args
 // - this module is responsible solely for parsing/validating the commandline arguments (including falling back to values supplied via environment variables)
 // - It's expected that the properties on *Arguments types will summarize the active settings as a side effect of
 // TODO DONT invest time reorganizing or reformatting this - half the value is having a legible summary of all program parameters in a consistent value
-//      you may want to regenerate it at a different time and/or facilitate comparing it with the CommandLine of other programs
+//      you may want to regenerate it at a different time and/or facilitate comparing it with the `module Args` of other programs
 // TODO NEVER hack temporary overrides in here; if you're going to do that, use commandline arguments that fall back to environment variables
 //      or (as a last resort) supply them via code in `module Settings`
-module CommandLine =
+module Args =
 
     exception MissingArg of string
     let private getEnvVarForArgumentOrThrow varName argName =
@@ -446,7 +446,7 @@ module EventStoreContext =
     let create connection = Equinox.EventStore.Context(connection, Equinox.EventStore.BatchingPolicy(maxBatchSize=500))
 
 //#endif
-let build (args : CommandLine.Arguments) =
+let build (args : Args.Arguments) =
 #if (!kafkaEventSpans)
 //#if (!changeFeedOnly)
     match args.SourceParams() with
@@ -593,12 +593,12 @@ let run args =
 
 [<EntryPoint>]
 let main argv =
-    try let args = CommandLine.parse argv
+    try let args = Args.parse argv
         try Logging.initialize args.Verbose args.VerboseConsole
             try Settings.initialize ()
                 if run args then 0 else 3
             with e -> Log.Fatal(e, "Exiting"); 2
         finally Log.CloseAndFlush()
-    with CommandLine.MissingArg msg -> eprintfn "%s" msg; 1
+    with Args.MissingArg msg -> eprintfn "%s" msg; 1
         | :? Argu.ArguParseException as e -> eprintfn "%s" e.Message; 1
         | e -> eprintf "Exception %s" e.Message; 1

--- a/propulsion-reactor/Program.fs
+++ b/propulsion-reactor/Program.fs
@@ -32,10 +32,10 @@ module Settings =
 // - this module is responsible solely for parsing/validating the commandline arguments (including falling back to values supplied via environment variables)
 // - It's expected that the properties on *Arguments types will summarize the active settings as a side effect of
 // TODO DONT invest time reorganizing or reformatting this - half the value is having a legible summary of all program parameters in a consistent value
-//      you may want to regenerate it at a different time and/or facilitate comparing it with the CmdParser of other programs
+//      you may want to regenerate it at a different time and/or facilitate comparing it with the CommandLine of other programs
 // TODO NEVER hack temporary overrides in here; if you're going to do that, use commandline arguments that fall back to environment variables
 //      or (as a last resort) supply them via code in `module Settings`
-module CmdParser =
+module CommandLine =
 
     exception MissingArg of string
     let private getEnvVarForArgumentOrThrow varName argName =
@@ -446,7 +446,7 @@ module EventStoreContext =
     let create connection = Equinox.EventStore.Context(connection, Equinox.EventStore.BatchingPolicy(maxBatchSize=500))
 
 //#endif
-let build (args : CmdParser.Arguments) =
+let build (args : CommandLine.Arguments) =
 #if (!kafkaEventSpans)
 //#if (!changeFeedOnly)
     match args.SourceParams() with
@@ -581,24 +581,24 @@ let build (args : CmdParser.Arguments) =
         sink, runPipeline
 #endif // !kafkaEventSpans
 
-let run argv =
-    try let args = CmdParser.parse argv
-        Logging.initialize args.Verbose args.VerboseConsole
-        Settings.initialize ()
+let run args =
 #if (!kafkaEventSpans)
-        let projector, runSourcePipeline = build args
-        runSourcePipeline |> Async.Start
+    let projector, runSourcePipeline = build args
+    runSourcePipeline |> Async.Start
 #else
-        let projector = build args
+    let projector = build args
 #endif
-        projector.AwaitCompletion() |> Async.RunSynchronously
-        if projector.RanToCompletion then 0 else 2
-    with :? Argu.ArguParseException as e -> eprintfn "%s" e.Message; 1
-        | :? Argu.ArguException as e -> eprintf "Argument parsing exception %s" e.Message; 1
-        | CmdParser.MissingArg msg -> eprintfn "%s" msg; 1
-        | e -> Log.Fatal(e, "Exiting"); 1
+    projector.AwaitCompletion() |> Async.RunSynchronously
+    projector.RanToCompletion
 
 [<EntryPoint>]
 let main argv =
-    try run argv
-    finally Log.CloseAndFlush()
+    try let args = CommandLine.parse argv
+        try Logging.initialize args.Verbose args.VerboseConsole
+            try Settings.initialize ()
+                if run args then 0 else 3
+            with e -> Log.Fatal(e, "Exiting"); 2
+        finally Log.CloseAndFlush()
+    with CommandLine.MissingArg msg -> eprintfn "%s" msg; 1
+        | :? Argu.ArguParseException as e -> eprintfn "%s" e.Message; 1
+        | e -> eprintf "Exception %s" e.Message; 1

--- a/propulsion-reactor/Program.fs
+++ b/propulsion-reactor/Program.fs
@@ -1,5 +1,6 @@
 ﻿module ReactorTemplate.Program
 
+open Equinox.Cosmos
 //#if (!kafkaEventSpans)
 open Propulsion.Cosmos
 //#if multiSource
@@ -46,7 +47,6 @@ module Args =
         | None -> getEnvVarForArgumentOrThrow varName argName
         | Some x -> x
     open Argu
-    open Equinox.Cosmos
 //#if multiSource
     open Equinox.EventStore
 //#endif

--- a/propulsion-reactor/Program.fs
+++ b/propulsion-reactor/Program.fs
@@ -28,7 +28,7 @@ module Settings =
         // e.g. initEnvVar     "EQUINOX_COSMOS_COLLECTION"    "CONSUL KEY" readFromConsul
         () // TODO add any custom logic preprocessing commandline arguments and/or gathering custom defaults from external sources, etc
 
-// TODO remove this entire comment after reading https://github.com/jet/dotnet-templates#module-cmdparser
+// TODO remove this entire comment after reading https://github.com/jet/dotnet-templates#module-commandline
 // - this module is responsible solely for parsing/validating the commandline arguments (including falling back to values supplied via environment variables)
 // - It's expected that the properties on *Arguments types will summarize the active settings as a side effect of
 // TODO DONT invest time reorganizing or reformatting this - half the value is having a legible summary of all program parameters in a consistent value

--- a/propulsion-reactor/Program.fs
+++ b/propulsion-reactor/Program.fs
@@ -15,10 +15,10 @@ module EnvVar =
     let tryGet varName : string option = Environment.GetEnvironmentVariable varName |> Option.ofObj
     let set varName value : unit = Environment.SetEnvironmentVariable(varName, value)
 
-// TODO remove this entire comment after reading https://github.com/jet/dotnet-templates#module-settings
+// TODO remove this entire comment after reading https://github.com/jet/dotnet-templates#module-configuration
 // - this is where any custom retrieval of settings not arriving via commandline arguments or environment variables should go
 // - values should be propagated by setting environment variables and/or returning them from `initialize`
-module Settings =
+module Configuration =
 
     let private initEnvVar var key loadF =
         if None = EnvVar.tryGet var then
@@ -35,7 +35,7 @@ module Settings =
 // TODO DONT invest time reorganizing or reformatting this - half the value is having a legible summary of all program parameters in a consistent value
 //      you may want to regenerate it at a different time and/or facilitate comparing it with the `module Args` of other programs
 // TODO NEVER hack temporary overrides in here; if you're going to do that, use commandline arguments that fall back to environment variables
-//      or (as a last resort) supply them via code in `module Settings`
+//      or (as a last resort) supply them via code in `module Configuration`
 module Args =
 
     exception MissingArg of string
@@ -595,7 +595,7 @@ let run args =
 let main argv =
     try let args = Args.parse argv
         try Logging.initialize args.Verbose args.VerboseConsole
-            try Settings.initialize ()
+            try Configuration.initialize ()
                 if run args then 0 else 3
             with e -> Log.Fatal(e, "Exiting"); 2
         finally Log.CloseAndFlush()

--- a/propulsion-reactor/Todo.fs
+++ b/propulsion-reactor/Todo.fs
@@ -52,11 +52,7 @@ module Fold =
     let impliesStateChange = function Events.Snapshotted _ -> false | _ -> true
 
 /// Defines operations that a Controller or Projector can perform on a Todo List
-type Service internal (log, resolve, maxAttempts) =
-
-    let resolve clientId =
-        let stream = resolve (streamName clientId)
-        Equinox.Stream<Events.Event, Fold.State>(log, stream, maxAttempts)
+type Service internal (resolve : ClientId -> Equinox.Stream<Events.Event, Fold.State>) =
 
     /// Load and render the state
     member __.QueryWithVersion(clientId, render : Fold.State -> 'res) : Async<int64*'res> =
@@ -64,25 +60,25 @@ type Service internal (log, resolve, maxAttempts) =
         // Establish the present state of the Stream, project from that (using QueryEx so we can determine the version in effect)
         stream.QueryEx(fun c -> c.Version, render c.State)
 
-let create resolve = Service(Serilog.Log.ForContext<Service>(), resolve, maxAttempts = 3)
+let create resolver =
+    let resolve clientId =
+        let stream = resolver (streamName clientId)
+        Equinox.Stream(Serilog.Log.ForContext<Service>(), stream, maxAttempts = 3)
+    Service(resolve)
 
 //#if multiSource
 module EventStore =
 
-    open Equinox.EventStore // Everything until now is independent of a concrete store
-
-    let private resolve (context, cache) =
-        let cacheStrategy = CachingStrategy.SlidingWindow (cache, System.TimeSpan.FromMinutes 20.)
-        Resolver(context, Events.codec, Fold.fold, Fold.initial, cacheStrategy).Resolve
-    let create (context, cache) = resolve (context, cache) |> create
+    let private resolver (context, cache) =
+        let cacheStrategy = Equinox.EventStore.CachingStrategy.SlidingWindow (cache, System.TimeSpan.FromMinutes 20.)
+        Equinox.EventStore.Resolver(context, Events.codec, Fold.fold, Fold.initial, cacheStrategy).Resolve
+    let create (context, cache) = create (resolver (context, cache))
 
 //#endif
 module Cosmos =
 
-    open Equinox.Cosmos // Everything until now is independent of a concrete store
-
-    let accessStrategy = AccessStrategy.Snapshot (Fold.isOrigin, Fold.snapshot)
-    let private resolve (context, cache) =
-        let cacheStrategy = CachingStrategy.SlidingWindow (cache, System.TimeSpan.FromMinutes 20.)
-        Resolver(context, Events.codec, Fold.fold, Fold.initial, cacheStrategy, accessStrategy).Resolve
-    let create (context, cache) = resolve (context, cache) |> create
+    let accessStrategy = Equinox.Cosmos.AccessStrategy.Snapshot (Fold.isOrigin, Fold.snapshot)
+    let private resolver (context, cache) =
+        let cacheStrategy = Equinox.Cosmos.CachingStrategy.SlidingWindow (cache, System.TimeSpan.FromMinutes 20.)
+        Equinox.Cosmos.Resolver(context, Events.codec, Fold.fold, Fold.initial, cacheStrategy, accessStrategy).Resolve
+    let create (context, cache) = create (resolver (context, cache))

--- a/propulsion-reactor/TodoSummary.fs
+++ b/propulsion-reactor/TodoSummary.fs
@@ -44,11 +44,7 @@ let render : Fold.State -> Item[] = function
     | _ -> [||]
 
 /// Defines the operations that the Read side of a Controller and/or the Ingester can perform on the 'aggregate'
-type Service internal (log, resolve, maxAttempts) =
-
-    let resolve clientId =
-        let stream = resolve (streamName clientId)
-        Equinox.Stream<Events.Event, Fold.State>(log, stream, maxAttempts)
+type Service internal (resolve : ClientId -> Equinox.Stream<Events.Event, Fold.State>) =
 
     member __.Ingest(clientId, version, value) : Async<bool> =
         let stream = resolve clientId
@@ -58,25 +54,25 @@ type Service internal (log, resolve, maxAttempts) =
         let stream = resolve clientId
         stream.Query render
 
-let create resolve = Service(Serilog.Log.ForContext<Service>(), resolve, maxAttempts = 3)
+let create resolver =
+    let resolve clientId =
+        let stream = resolver (streamName clientId)
+        Equinox.Stream(Serilog.Log.ForContext<Service>(), stream, maxAttempts = 3)
+    Service(resolve)
 
 //#if multiSource
 module EventStore =
 
-    open Equinox.EventStore // Everything until now is independent of a concrete store
-
-    let private resolve (context, cache) =
-        let cacheStrategy = CachingStrategy.SlidingWindow (cache, System.TimeSpan.FromMinutes 20.)
-        Resolver(context, Events.codec, Fold.fold, Fold.initial, cacheStrategy).Resolve
-    let create (context, cache) = resolve (context, cache) |> create
+    let private resolver (context, cache) =
+        let cacheStrategy = Equinox.EventStore.CachingStrategy.SlidingWindow (cache, System.TimeSpan.FromMinutes 20.)
+        Equinox.EventStore.Resolver(context, Events.codec, Fold.fold, Fold.initial, cacheStrategy).Resolve
+    let create (context, cache) = create (resolver (context, cache))
 
 //#endif
 module Cosmos =
 
-    open Equinox.Cosmos // Everything until now is independent of a concrete store
-
     let accessStrategy = Equinox.Cosmos.AccessStrategy.RollingState Fold.snapshot
-    let private resolve (context, cache) =
-        let cacheStrategy = CachingStrategy.SlidingWindow (cache, System.TimeSpan.FromMinutes 20.)
-        Resolver(context, Events.codec, Fold.fold, Fold.initial, cacheStrategy, accessStrategy).Resolve
-    let create (context, cache) = create (resolve (context, cache))
+    let private resolver (context, cache) =
+        let cacheStrategy = Equinox.Cosmos.CachingStrategy.SlidingWindow (cache, System.TimeSpan.FromMinutes 20.)
+        Equinox.Cosmos.Resolver(context, Events.codec, Fold.fold, Fold.initial, cacheStrategy, accessStrategy).Resolve
+    let create (context, cache) = create (resolver (context, cache))

--- a/propulsion-summary-consumer/Ingester.fs
+++ b/propulsion-summary-consumer/Ingester.fs
@@ -7,9 +7,9 @@ open System
 /// Defines the contract we share with the proReactor --'s published feed
 module Contract =
 
-    let [<Literal>] CategoryId = "TodoSummary"
+    let [<Literal>] Category = "TodoSummary"
     let (|MatchesCategory|_|) = function
-        | FsCodec.StreamName.CategoryAndId (CategoryId, ClientId.Parse clientId) -> Some clientId
+        | FsCodec.StreamName.CategoryAndId (Category, ClientId.Parse clientId) -> Some clientId
         | _ -> None
 
     /// A single Item in the Todo List

--- a/propulsion-summary-consumer/Program.fs
+++ b/propulsion-summary-consumer/Program.fs
@@ -8,10 +8,10 @@ module EnvVar =
     let tryGet varName : string option = Environment.GetEnvironmentVariable varName |> Option.ofObj
     let set varName value : unit = Environment.SetEnvironmentVariable(varName, value)
 
-// TODO remove this entire comment after reading https://github.com/jet/dotnet-templates#module-settings
+// TODO remove this entire comment after reading https://github.com/jet/dotnet-templates#module-configuration
 // - this is where any custom retrieval of settings not arriving via commandline arguments or environment variables should go
 // - values should be propagated by setting environment variables and/or returning them from `initialize`
-module Settings =
+module Configuration =
 
     let private initEnvVar var key loadF =
         if None = EnvVar.tryGet var then
@@ -28,7 +28,7 @@ module Settings =
 // TODO DONT invest time reorganizing or reformatting this - half the value is having a legible summary of all program parameters in a consistent value
 //      you may want to regenerate it at a different time and/or facilitate comparing it with the `module Args` of other programs
 // TODO NEVER hack temporary overrides in here; if you're going to do that, use commandline arguments that fall back to environment variables
-//      or (as a last resort) supply them via code in `module Settings`
+//      or (as a last resort) supply them via code in `module Configuration`
 module Args =
 
     exception MissingArg of string
@@ -158,7 +158,7 @@ let run args =
 let main argv =
     try let args = Args.parse argv
         try Logging.initialize args.Verbose
-            try Settings.initialize ()
+            try Configuration.initialize ()
                 if run args then 0 else 3
             with e -> Log.Fatal(e, "Exiting"); 2
         finally Log.CloseAndFlush()

--- a/propulsion-summary-consumer/Program.fs
+++ b/propulsion-summary-consumer/Program.fs
@@ -22,14 +22,14 @@ module Settings =
         // e.g. initEnvVar     "EQUINOX_COSMOS_COLLECTION"    "CONSUL KEY" readFromConsul
         () // TODO add any custom logic preprocessing commandline arguments and/or gathering custom defaults from external sources, etc
 
-// TODO remove this entire comment after reading https://github.com/jet/dotnet-templates#module-commandline
+// TODO remove this entire comment after reading https://github.com/jet/dotnet-templates#module-args
 // - this module is responsible solely for parsing/validating the commandline arguments (including falling back to values supplied via environment variables)
 // - It's expected that the properties on *Arguments types will summarize the active settings as a side effect of
 // TODO DONT invest time reorganizing or reformatting this - half the value is having a legible summary of all program parameters in a consistent value
-//      you may want to regenerate it at a different time and/or facilitate comparing it with the CommandLine of other programs
+//      you may want to regenerate it at a different time and/or facilitate comparing it with the `module Args` of other programs
 // TODO NEVER hack temporary overrides in here; if you're going to do that, use commandline arguments that fall back to environment variables
 //      or (as a last resort) supply them via code in `module Settings`
-module CommandLine =
+module Args =
 
     exception MissingArg of string
     let private getEnvVarForArgumentOrThrow varName argName =
@@ -137,7 +137,7 @@ module Logging =
 
 let [<Literal>] AppName = "ConsumerTemplate"
 
-let start (args : CommandLine.Arguments) =
+let start (args : Args.Arguments) =
     let context = args.Cosmos.Connect(AppName) |> Async.RunSynchronously
     let cache = Equinox.Cache (AppName, sizeMb = 10) // here rather than in Todo aggregate as it can be shared with other Aggregates
     let service = TodoSummary.Cosmos.create (context, cache)
@@ -157,12 +157,12 @@ let run args =
 
 [<EntryPoint>]
 let main argv =
-    try let args = CommandLine.parse argv
+    try let args = Args.parse argv
         try Logging.initialize args.Verbose
             try Settings.initialize ()
                 if run args then 0 else 3
             with e -> Log.Fatal(e, "Exiting"); 2
         finally Log.CloseAndFlush()
-    with CommandLine.MissingArg msg -> eprintfn "%s" msg; 1
+    with Args.MissingArg msg -> eprintfn "%s" msg; 1
         | :? Argu.ArguParseException as e -> eprintfn "%s" e.Message; 1
         | e -> eprintf "Exception %s" e.Message; 1

--- a/propulsion-summary-consumer/Program.fs
+++ b/propulsion-summary-consumer/Program.fs
@@ -40,44 +40,43 @@ module Args =
         | None -> getEnvVarForArgumentOrThrow varName argName
         | Some x -> x
     open Argu
-    module Cosmos =
-        open Equinox.Cosmos
-        type [<NoEquality; NoComparison>] Parameters =
-            | [<AltCommandLine "-m">]       ConnectionMode of ConnectionMode
-            | [<AltCommandLine "-s">]       Connection of string
-            | [<AltCommandLine "-d">]       Database of string
-            | [<AltCommandLine "-c">]       Container of string
-            | [<AltCommandLine "-o">]       Timeout of float
-            | [<AltCommandLine "-r">]       Retries of int
-            | [<AltCommandLine "-rt">]      RetriesWaitTime of float
-            interface IArgParserTemplate with
-                member a.Usage =
-                    match a with
-                    | ConnectionMode _ ->   "override the connection mode. Default: Direct."
-                    | Connection _ ->       "specify a connection string for a Cosmos account. (optional if environment variable EQUINOX_COSMOS_CONNECTION specified)"
-                    | Database _ ->         "specify a database name for Cosmos store. (optional if environment variable EQUINOX_COSMOS_DATABASE specified)"
-                    | Container _ ->        "specify a container name for Cosmos store. (optional if environment variable EQUINOX_COSMOS_CONTAINER specified)"
-                    | Timeout _ ->          "specify operation timeout in seconds. Default: 5."
-                    | Retries _ ->          "specify operation retries. Default: 1."
-                    | RetriesWaitTime _ ->  "specify max wait-time for retry when being throttled by Cosmos in seconds. Default: 5."
-        type Arguments(a : ParseResults<Parameters>) =
-            member __.Mode =                a.GetResult(ConnectionMode, ConnectionMode.Direct)
-            member __.Connection =          a.TryGetResult Connection |> defaultWithEnvVar "EQUINOX_COSMOS_CONNECTION" "Connection"
-            member __.Database =            a.TryGetResult Database   |> defaultWithEnvVar "EQUINOX_COSMOS_DATABASE"   "Database"
-            member __.Container =           a.TryGetResult Container  |> defaultWithEnvVar "EQUINOX_COSMOS_CONTAINER"  "Container"
+    open Equinox.Cosmos
+    type [<NoEquality; NoComparison>] CosmosParameters =
+        | [<AltCommandLine "-m">]       ConnectionMode of ConnectionMode
+        | [<AltCommandLine "-s">]       Connection of string
+        | [<AltCommandLine "-d">]       Database of string
+        | [<AltCommandLine "-c">]       Container of string
+        | [<AltCommandLine "-o">]       Timeout of float
+        | [<AltCommandLine "-r">]       Retries of int
+        | [<AltCommandLine "-rt">]      RetriesWaitTime of float
+        interface IArgParserTemplate with
+            member a.Usage =
+                match a with
+                | ConnectionMode _ ->   "override the connection mode. Default: Direct."
+                | Connection _ ->       "specify a connection string for a Cosmos account. (optional if environment variable EQUINOX_COSMOS_CONNECTION specified)"
+                | Database _ ->         "specify a database name for Cosmos store. (optional if environment variable EQUINOX_COSMOS_DATABASE specified)"
+                | Container _ ->        "specify a container name for Cosmos store. (optional if environment variable EQUINOX_COSMOS_CONTAINER specified)"
+                | Timeout _ ->          "specify operation timeout in seconds. Default: 5."
+                | Retries _ ->          "specify operation retries. Default: 1."
+                | RetriesWaitTime _ ->  "specify max wait-time for retry when being throttled by Cosmos in seconds. Default: 5."
+    type CosmosArguments(a : ParseResults<CosmosParameters>) =
+        member __.Mode =                a.GetResult(ConnectionMode, ConnectionMode.Direct)
+        member __.Connection =          a.TryGetResult Connection |> defaultWithEnvVar "EQUINOX_COSMOS_CONNECTION" "Connection"
+        member __.Database =            a.TryGetResult Database   |> defaultWithEnvVar "EQUINOX_COSMOS_DATABASE"   "Database"
+        member __.Container =           a.TryGetResult Container  |> defaultWithEnvVar "EQUINOX_COSMOS_CONTAINER"  "Container"
 
-            member __.Timeout =             a.GetResult(Timeout, 5.) |> TimeSpan.FromSeconds
-            member __.Retries =             a.GetResult(Retries, 1)
-            member __.MaxRetryWaitTime =    a.GetResult(RetriesWaitTime, 5.) |> TimeSpan.FromSeconds
+        member __.Timeout =             a.GetResult(Timeout, 5.) |> TimeSpan.FromSeconds
+        member __.Retries =             a.GetResult(Retries, 1)
+        member __.MaxRetryWaitTime =    a.GetResult(RetriesWaitTime, 5.) |> TimeSpan.FromSeconds
 
-            member x.Connect(clientId) = async {
-                let (Discovery.UriAndKey (endpointUri, _) as discovery) = Discovery.FromConnectionString x.Connection
-                Log.Information("CosmosDb {mode} {endpointUri} Database {database} Container {container}.",
-                    x.Mode, endpointUri, x.Database, x.Container)
-                Log.Information("CosmosDb timeout {timeout}s; Throttling retries {retries}, max wait {maxRetryWaitTime}s",
-                    (let t = x.Timeout in t.TotalSeconds), x.Retries, (let t = x.MaxRetryWaitTime in t.TotalSeconds))
-                let! connection = Connector(x.Timeout, x.Retries, x.MaxRetryWaitTime, Log.Logger, mode=x.Mode).Connect(clientId, discovery)
-                return Context(connection, x.Database, x.Container) }
+        member x.Connect(clientId) = async {
+            let (Discovery.UriAndKey (endpointUri, _) as discovery) = Discovery.FromConnectionString x.Connection
+            Log.Information("CosmosDb {mode} {endpointUri} Database {database} Container {container}.",
+                x.Mode, endpointUri, x.Database, x.Container)
+            Log.Information("CosmosDb timeout {timeout}s; Throttling retries {retries}, max wait {maxRetryWaitTime}s",
+                (let t = x.Timeout in t.TotalSeconds), x.Retries, (let t = x.MaxRetryWaitTime in t.TotalSeconds))
+            let! connection = Connector(x.Timeout, x.Retries, x.MaxRetryWaitTime, Log.Logger, mode=x.Mode).Connect(clientId, discovery)
+            return Context(connection, x.Database, x.Container) }
 
     [<NoEquality; NoComparison>]
     type Parameters =
@@ -89,7 +88,7 @@ module Args =
 
         | [<AltCommandLine "-w"; Unique>]   MaxWriters of int
         | [<AltCommandLine "-V"; Unique>]   Verbose
-        | [<CliPrefix(CliPrefix.None); Last>] Cosmos of ParseResults<Cosmos.Parameters>
+        | [<CliPrefix(CliPrefix.None); Last>] Cosmos of ParseResults<CosmosParameters>
 
         interface IArgParserTemplate with
             member a.Usage = a |> function
@@ -104,7 +103,7 @@ module Args =
                 | Cosmos _ ->               "specify CosmosDb input parameters"
 
     type Arguments(a : ParseResults<Parameters>) =
-        member val Cosmos =                 Cosmos.Arguments(a.GetResult Cosmos)
+        member val Cosmos =                 CosmosArguments(a.GetResult Cosmos)
         member __.Broker =                  a.TryGetResult Broker |> defaultWithEnvVar "PROPULSION_KAFKA_BROKER" "Broker" |> Uri
         member __.Topic =                   a.TryGetResult Topic  |> defaultWithEnvVar "PROPULSION_KAFKA_TOPIC"  "Topic"
         member __.Group =                   a.TryGetResult Group  |> defaultWithEnvVar "PROPULSION_KAFKA_GROUP"  "Group"

--- a/propulsion-summary-consumer/TodoSummary.fs
+++ b/propulsion-summary-consumer/TodoSummary.fs
@@ -59,7 +59,7 @@ let create resolver =
         let stream = resolver (streamName clientId)
         Equinox.Stream(Serilog.Log.ForContext<Service>(), stream, maxAttempts = 3)
 
-    Service resolve
+    Service(resolve)
 
 module Cosmos =
 

--- a/propulsion-summary-consumer/TodoSummary.fs
+++ b/propulsion-summary-consumer/TodoSummary.fs
@@ -1,10 +1,10 @@
 ﻿module ConsumerTemplate.TodoSummary
 
+let [<Literal>] Category = "TodoSummary"
+let streamName (clientId: ClientId) = FsCodec.StreamName.create Category (ClientId.toString clientId)
+
 // NB - these types and the union case names reflect the actual storage formats and hence need to be versioned with care
 module Events =
-
-    let [<Literal>] CategoryId = "TodoSummary"
-    let (|ForClientId|) (clientId: ClientId) = FsCodec.StreamName.create CategoryId (ClientId.toString clientId)
 
     type ItemData = { id: int; order: int; title: string; completed: bool }
     type SummaryData = { items : ItemData[] }
@@ -46,7 +46,9 @@ let render : Fold.State -> Item[] = function
 /// Defines the operations that the Read side of a Controller and/or the Ingester can perform on the 'aggregate'
 type Service internal (log, resolve, maxAttempts) =
 
-    let resolve (Events.ForClientId id) = Equinox.Stream<Events.Event, Fold.State>(log, resolve id, maxAttempts)
+    let resolve clientId =
+        let stream = resolve (streamName clientId)
+        Equinox.Stream<Events.Event, Fold.State>(log, stream, maxAttempts)
 
     member __.Ingest(clientId, version, value) : Async<bool> =
         let stream = resolve clientId

--- a/propulsion-sync/Program.fs
+++ b/propulsion-sync/Program.fs
@@ -15,10 +15,10 @@ module EnvVar =
     let tryGet varName : string option = Environment.GetEnvironmentVariable varName |> Option.ofObj
     let set varName value : unit = Environment.SetEnvironmentVariable(varName, value)
 
-// TODO remove this entire comment after reading https://github.com/jet/dotnet-templates#module-settings
+// TODO remove this entire comment after reading https://github.com/jet/dotnet-templates#module-configuration
 // - this is where any custom retrieval of settings not arriving via commandline arguments or environment variables should go
 // - values should be propagated by setting environment variables and/or returning them from `initialize`
-module Settings =
+module Configuration =
 
     let private initEnvVar var key loadF =
         if None = EnvVar.tryGet var then
@@ -35,7 +35,7 @@ module Settings =
 // TODO DONT invest time reorganizing or reformatting this - half the value is having a legible summary of all program parameters in a consistent value
 //      you may want to regenerate it at a different time and/or facilitate comparing it with the `module Args` of other programs
 // TODO NEVER hack temporary overrides in here; if you're going to do that, use commandline arguments that fall back to environment variables
-//      or (as a last resort) supply them via code in `module Settings`
+//      or (as a last resort) supply them via code in `module Configuration`
 module Args =
 
     exception MissingArg of string
@@ -644,7 +644,7 @@ let run (args, log, storeLog) =
 let main argv =
     try let args = Args.parse argv
         try let log, storeLog = Logging.initialize args.Verbose args.VerboseConsole args.MaybeSeqEndpoint
-            try Settings.initialize ()
+            try Configuration.initialize ()
                 if run (args, log, storeLog) then 0 else 3
             with e -> Log.Fatal(e, "Exiting"); 2
         finally Log.CloseAndFlush()

--- a/propulsion-sync/Program.fs
+++ b/propulsion-sync/Program.fs
@@ -33,10 +33,10 @@ module Settings =
 // - this module is responsible solely for parsing/validating the commandline arguments (including falling back to values supplied via environment variables)
 // - It's expected that the properties on *Arguments types will summarize the active settings as a side effect of
 // TODO DONT invest time reorganizing or reformatting this - half the value is having a legible summary of all program parameters in a consistent value
-//      you may want to regenerate it at a different time and/or facilitate comparing it with the CmdParser of other programs
+//      you may want to regenerate it at a different time and/or facilitate comparing it with the CommandLine of other programs
 // TODO NEVER hack temporary overrides in here; if you're going to do that, use commandline arguments that fall back to environment variables
 //      or (as a last resort) supply them via code in `module Settings`
-module CmdParser =
+module CommandLine =
 
     exception MissingArg of string
     let private getEnvVarForArgumentOrThrow varName argName =
@@ -545,7 +545,7 @@ let transformOrFilter catFilter (changeFeedDocument: Microsoft.Azure.Documents.D
 
 let [<Literal>] AppName = "SyncTemplate"
 
-let build (args : CmdParser.Arguments, log, storeLog : ILogger) =
+let build (args : CommandLine.Arguments, log, storeLog : ILogger) =
     let maybeDstCosmos, sink, streamFilter =
         match args.Sink with
         | Choice1Of2 cosmos ->
@@ -634,20 +634,20 @@ let build (args : CmdParser.Arguments, log, storeLog : ILogger) =
                 args.MaxReadAhead, args.StatsInterval)
         sink, runPipeline
 
-let run argv =
-    try let args = CmdParser.parse argv
-        let log, storeLog = Logging.initialize args.Verbose args.VerboseConsole args.MaybeSeqEndpoint
-        Settings.initialize ()
-        let sink,runSourcePipeline = build (args,log,storeLog)
-        runSourcePipeline |> Async.Start
-        sink.AwaitCompletion() |> Async.RunSynchronously
-        if sink.RanToCompletion then 0 else 2
-    with :? Argu.ArguParseException as e -> eprintfn "%s" e.Message; 1
-        | :? Argu.ArguException as e -> eprintf "Argument parsing exception %s" e.Message; 1
-        | CmdParser.MissingArg msg -> eprintfn "%s" msg; 1
-        | e -> Log.Fatal(e, "Exiting"); 1
+let run (args, log, storeLog) =
+    let sink,runSourcePipeline = build (args, log, storeLog)
+    runSourcePipeline |> Async.Start
+    sink.AwaitCompletion() |> Async.RunSynchronously
+    sink.RanToCompletion
 
 [<EntryPoint>]
 let main argv =
-    try run argv
-    finally Log.CloseAndFlush()
+    try let args = CommandLine.parse argv
+        try let log, storeLog = Logging.initialize args.Verbose args.VerboseConsole args.MaybeSeqEndpoint
+            try Settings.initialize ()
+                if run (args, log, storeLog) then 0 else 3
+            with e -> Log.Fatal(e, "Exiting"); 2
+        finally Log.CloseAndFlush()
+    with CommandLine.MissingArg msg -> eprintfn "%s" msg; 1
+        | :? Argu.ArguParseException as e -> eprintfn "%s" e.Message; 1
+        | e -> eprintf "Exception %s" e.Message; 1

--- a/propulsion-sync/Program.fs
+++ b/propulsion-sync/Program.fs
@@ -29,7 +29,7 @@ module Settings =
         // e.g. initEnvVar     "EQUINOX_COSMOS_COLLECTION"    "CONSUL KEY" readFromConsul
         () // TODO add any custom logic preprocessing commandline arguments and/or gathering custom defaults from external sources, etc
 
-// TODO remove this entire comment after reading https://github.com/jet/dotnet-templates#module-cmdparser
+// TODO remove this entire comment after reading https://github.com/jet/dotnet-templates#module-commandline
 // - this module is responsible solely for parsing/validating the commandline arguments (including falling back to values supplied via environment variables)
 // - It's expected that the properties on *Arguments types will summarize the active settings as a side effect of
 // TODO DONT invest time reorganizing or reformatting this - half the value is having a legible summary of all program parameters in a consistent value

--- a/propulsion-sync/Program.fs
+++ b/propulsion-sync/Program.fs
@@ -29,14 +29,14 @@ module Settings =
         // e.g. initEnvVar     "EQUINOX_COSMOS_COLLECTION"    "CONSUL KEY" readFromConsul
         () // TODO add any custom logic preprocessing commandline arguments and/or gathering custom defaults from external sources, etc
 
-// TODO remove this entire comment after reading https://github.com/jet/dotnet-templates#module-commandline
+// TODO remove this entire comment after reading https://github.com/jet/dotnet-templates#module-args
 // - this module is responsible solely for parsing/validating the commandline arguments (including falling back to values supplied via environment variables)
 // - It's expected that the properties on *Arguments types will summarize the active settings as a side effect of
 // TODO DONT invest time reorganizing or reformatting this - half the value is having a legible summary of all program parameters in a consistent value
-//      you may want to regenerate it at a different time and/or facilitate comparing it with the CommandLine of other programs
+//      you may want to regenerate it at a different time and/or facilitate comparing it with the `module Args` of other programs
 // TODO NEVER hack temporary overrides in here; if you're going to do that, use commandline arguments that fall back to environment variables
 //      or (as a last resort) supply them via code in `module Settings`
-module CommandLine =
+module Args =
 
     exception MissingArg of string
     let private getEnvVarForArgumentOrThrow varName argName =
@@ -545,7 +545,7 @@ let transformOrFilter catFilter (changeFeedDocument: Microsoft.Azure.Documents.D
 
 let [<Literal>] AppName = "SyncTemplate"
 
-let build (args : CommandLine.Arguments, log, storeLog : ILogger) =
+let build (args : Args.Arguments, log, storeLog : ILogger) =
     let maybeDstCosmos, sink, streamFilter =
         match args.Sink with
         | Choice1Of2 cosmos ->
@@ -642,12 +642,12 @@ let run (args, log, storeLog) =
 
 [<EntryPoint>]
 let main argv =
-    try let args = CommandLine.parse argv
+    try let args = Args.parse argv
         try let log, storeLog = Logging.initialize args.Verbose args.VerboseConsole args.MaybeSeqEndpoint
             try Settings.initialize ()
                 if run (args, log, storeLog) then 0 else 3
             with e -> Log.Fatal(e, "Exiting"); 2
         finally Log.CloseAndFlush()
-    with CommandLine.MissingArg msg -> eprintfn "%s" msg; 1
+    with Args.MissingArg msg -> eprintfn "%s" msg; 1
         | :? Argu.ArguParseException as e -> eprintfn "%s" e.Message; 1
         | e -> eprintf "Exception %s" e.Message; 1

--- a/propulsion-tracking-consumer/Ingester.fs
+++ b/propulsion-tracking-consumer/Ingester.fs
@@ -36,24 +36,19 @@ type Stats(log, ?statsInterval, ?stateInterval) =
             log.Information(" Used {ok} Ignored {skipped}", ok, skipped)
             ok <- 0; skipped <- 0
 
-/// Starts a processing loop accumulating messages by stream - each time we handle all the incoming updates for a give Sku as a single transaction
-let startConsumer (config : FsKafka.KafkaConsumerConfig) (log : Serilog.ILogger) (service : SkuSummary.Service) maxDop =
-    let ingestIncomingSummaryMessage(FsCodec.StreamName.CategoryAndId (_,SkuId.Parse skuId), span : Propulsion.Streams.StreamSpan<_>) : Async<Outcome> = async {
-        let items =
-            [ for e in span.events do
-                let x = Contract.parse e.Data
-                for o in x.purchaseOrderInfo do
-                    let x : SkuSummary.Events.ItemData =
-                        {   locationId = x.locationId
-                            messageIndex = x.messageIndex
-                            picketTicketId = x.pickTicketId
-                            poNumber = o.poNumber
-                            reservedQuantity = o.reservedUnitQuantity }
-                    yield x ]
-        let! used = service.Ingest(skuId, items)
-        return Outcome.Completed(used, List.length items)
-    }
-    let stats = Stats(log)
-    // No categorization required, our inputs are all one big family defying categorization
-    let sequencer = Propulsion.Kafka.Core.StreamKeyEventSequencer()
-    Propulsion.Kafka.StreamsConsumer.Start(log, config, sequencer.ToStreamEvent, ingestIncomingSummaryMessage, maxDop, stats)
+/// Ingest queued events per sku - each time we handle all the incoming updates for a given stream as a single act
+let ingest (service : SkuSummary.Service) (FsCodec.StreamName.CategoryAndId (_,SkuId.Parse skuId), span : Propulsion.Streams.StreamSpan<_>) : Async<Outcome> = async {
+    let items =
+        [ for e in span.events do
+            let x = Contract.parse e.Data
+            for o in x.purchaseOrderInfo do
+                let x : SkuSummary.Events.ItemData =
+                    {   locationId = x.locationId
+                        messageIndex = x.messageIndex
+                        picketTicketId = x.pickTicketId
+                        poNumber = o.poNumber
+                        reservedQuantity = o.reservedUnitQuantity }
+                yield x ]
+    let! used = service.Ingest(skuId, items)
+    return Outcome.Completed(used, List.length items)
+}

--- a/propulsion-tracking-consumer/Ingester.fs
+++ b/propulsion-tracking-consumer/Ingester.fs
@@ -33,7 +33,7 @@ type Stats(log, ?statsInterval, ?stateInterval) =
 
     override __.DumpStats () =
         if ok <> 0 || skipped <> 0 then
-            log.Information(" Used {ok} Ignored {skipped}", ok, skipped)
+            log.Information(" Used {ok} Skipped {skipped}", ok, skipped)
             ok <- 0; skipped <- 0
 
 /// Ingest queued events per sku - each time we handle all the incoming updates for a given stream as a single act

--- a/propulsion-tracking-consumer/Program.fs
+++ b/propulsion-tracking-consumer/Program.fs
@@ -1,5 +1,6 @@
 ﻿module ConsumerTemplate.Program
 
+open Equinox.Cosmos
 open Serilog
 open System
 
@@ -40,7 +41,6 @@ module Args =
         | None -> getEnvVarForArgumentOrThrow varName argName
         | Some x -> x
     open Argu
-    open Equinox.Cosmos
     type [<NoEquality; NoComparison>] CosmosParameters =
         | [<AltCommandLine "-m">]       ConnectionMode of ConnectionMode
         | [<AltCommandLine "-s">]       Connection of string

--- a/propulsion-tracking-consumer/Program.fs
+++ b/propulsion-tracking-consumer/Program.fs
@@ -1,6 +1,5 @@
 ﻿module ConsumerTemplate.Program
 
-open Equinox.Cosmos
 open Serilog
 open System
 
@@ -41,6 +40,7 @@ module Args =
         | None -> getEnvVarForArgumentOrThrow varName argName
         | Some x -> x
     open Argu
+    open Equinox.Cosmos
     type [<NoEquality; NoComparison>] CosmosParameters =
         | [<AltCommandLine "-m">]       ConnectionMode of ConnectionMode
         | [<AltCommandLine "-s">]       Connection of string

--- a/propulsion-tracking-consumer/Program.fs
+++ b/propulsion-tracking-consumer/Program.fs
@@ -145,7 +145,10 @@ let start (args : CommandLine.Arguments) =
         FsKafka.KafkaConsumerConfig.Create(
             AppName, args.Broker, [args.Topic], args.Group,
             maxInFlightBytes = args.MaxInFlightBytes, ?statisticsInterval = args.LagFrequency)
-    Ingester.startConsumer config Log.Logger service args.MaxConcurrentStreams
+    let stats = Ingester.Stats(Log.Logger)
+    // No categorization required, our inputs are all one big family defying categorization
+    let sequencer = Propulsion.Kafka.Core.StreamKeyEventSequencer()
+    Propulsion.Kafka.StreamsConsumer.Start(Log.Logger, config, sequencer.ToStreamEvent, Ingester.ingest service, args.MaxConcurrentStreams, stats)
 
 let run args =
     use consumer = start args

--- a/propulsion-tracking-consumer/Program.fs
+++ b/propulsion-tracking-consumer/Program.fs
@@ -26,10 +26,10 @@ module Settings =
 // - this module is responsible solely for parsing/validating the commandline arguments (including falling back to values supplied via environment variables)
 // - It's expected that the properties on *Arguments types will summarize the active settings as a side effect of
 // TODO DONT invest time reorganizing or reformatting this - half the value is having a legible summary of all program parameters in a consistent value
-//      you may want to regenerate it at a different time and/or facilitate comparing it with the CmdParser of other programs
+//      you may want to regenerate it at a different time and/or facilitate comparing it with the CommandLine of other programs
 // TODO NEVER hack temporary overrides in here; if you're going to do that, use commandline arguments that fall back to environment variables
 //      or (as a last resort) supply them via code in `module Settings`
-module CmdParser =
+module CommandLine =
 
     exception MissingArg of string
     let private getEnvVarForArgumentOrThrow varName argName =
@@ -137,7 +137,7 @@ module Logging =
 
 let [<Literal>] AppName = "ConsumerTemplate"
 
-let start (args : CmdParser.Arguments) =
+let start (args : CommandLine.Arguments) =
     let context = args.Cosmos.Connect(AppName) |> Async.RunSynchronously
     let cache = Equinox.Cache (AppName, sizeMb = 10) // here rather than in SkuSummary aggregate as it can be shared with other Aggregates
     let service = SkuSummary.Cosmos.create (context, cache)
@@ -147,20 +147,19 @@ let start (args : CmdParser.Arguments) =
             maxInFlightBytes = args.MaxInFlightBytes, ?statisticsInterval = args.LagFrequency)
     Ingester.startConsumer config Log.Logger service args.MaxConcurrentStreams
 
-let run argv =
-    try let args = CmdParser.parse argv
-        Logging.initialize args.Verbose
-        Settings.initialize ()
-        use consumer = start args
-        consumer.AwaitCompletion() |> Async.RunSynchronously
-        if consumer.RanToCompletion then 0 else 2
-    with :? Argu.ArguParseException as e -> eprintfn "%s" e.Message; 1
-        | :? Argu.ArguException as e -> eprintf "Argument parsing exception %s" e.Message; 1
-        | CmdParser.MissingArg msg -> eprintfn "%s" msg; 1
-        // If the handler throws, we exit the app in order to let an orchestrator flag the failure
-        | e -> Log.Fatal(e, "Exiting"); 1
+let run args =
+    use consumer = start args
+    consumer.AwaitCompletion() |> Async.RunSynchronously
+    if consumer.RanToCompletion then 0 else 3
 
 [<EntryPoint>]
 let main argv =
-    try run argv
-    finally Log.CloseAndFlush()
+    try let args = CommandLine.parse argv
+        try Logging.initialize args.Verbose
+            try Settings.initialize ()
+                run args
+            with e -> Log.Fatal(e, "Exiting"); 2
+        finally Log.CloseAndFlush()
+    with CommandLine.MissingArg msg -> eprintfn "%s" msg; 1
+        | :? Argu.ArguParseException as e -> eprintfn "%s" e.Message; 1
+        | e -> eprintf "Exception %s" e.Message; 1

--- a/propulsion-tracking-consumer/Program.fs
+++ b/propulsion-tracking-consumer/Program.fs
@@ -22,7 +22,7 @@ module Settings =
         // e.g. initEnvVar     "EQUINOX_COSMOS_COLLECTION"    "CONSUL KEY" readFromConsul
         () // TODO add any custom logic preprocessing commandline arguments and/or gathering custom defaults from external sources, etc
 
-// TODO remove this entire comment after reading https://github.com/jet/dotnet-templates#module-cmdparser
+// TODO remove this entire comment after reading https://github.com/jet/dotnet-templates#module-commandline
 // - this module is responsible solely for parsing/validating the commandline arguments (including falling back to values supplied via environment variables)
 // - It's expected that the properties on *Arguments types will summarize the active settings as a side effect of
 // TODO DONT invest time reorganizing or reformatting this - half the value is having a legible summary of all program parameters in a consistent value

--- a/propulsion-tracking-consumer/Program.fs
+++ b/propulsion-tracking-consumer/Program.fs
@@ -22,14 +22,14 @@ module Settings =
         // e.g. initEnvVar     "EQUINOX_COSMOS_COLLECTION"    "CONSUL KEY" readFromConsul
         () // TODO add any custom logic preprocessing commandline arguments and/or gathering custom defaults from external sources, etc
 
-// TODO remove this entire comment after reading https://github.com/jet/dotnet-templates#module-commandline
+// TODO remove this entire comment after reading https://github.com/jet/dotnet-templates#module-args
 // - this module is responsible solely for parsing/validating the commandline arguments (including falling back to values supplied via environment variables)
 // - It's expected that the properties on *Arguments types will summarize the active settings as a side effect of
 // TODO DONT invest time reorganizing or reformatting this - half the value is having a legible summary of all program parameters in a consistent value
-//      you may want to regenerate it at a different time and/or facilitate comparing it with the CommandLine of other programs
+//      you may want to regenerate it at a different time and/or facilitate comparing it with the `module Args` of other programs
 // TODO NEVER hack temporary overrides in here; if you're going to do that, use commandline arguments that fall back to environment variables
 //      or (as a last resort) supply them via code in `module Settings`
-module CommandLine =
+module Args =
 
     exception MissingArg of string
     let private getEnvVarForArgumentOrThrow varName argName =
@@ -137,7 +137,7 @@ module Logging =
 
 let [<Literal>] AppName = "ConsumerTemplate"
 
-let start (args : CommandLine.Arguments) =
+let start (args : Args.Arguments) =
     let context = args.Cosmos.Connect(AppName) |> Async.RunSynchronously
     let cache = Equinox.Cache (AppName, sizeMb = 10) // here rather than in SkuSummary aggregate as it can be shared with other Aggregates
     let service = SkuSummary.Cosmos.create (context, cache)
@@ -157,12 +157,12 @@ let run args =
 
 [<EntryPoint>]
 let main argv =
-    try let args = CommandLine.parse argv
+    try let args = Args.parse argv
         try Logging.initialize args.Verbose
             try Settings.initialize ()
                 run args
             with e -> Log.Fatal(e, "Exiting"); 2
         finally Log.CloseAndFlush()
-    with CommandLine.MissingArg msg -> eprintfn "%s" msg; 1
+    with Args.MissingArg msg -> eprintfn "%s" msg; 1
         | :? Argu.ArguParseException as e -> eprintfn "%s" e.Message; 1
         | e -> eprintf "Exception %s" e.Message; 1

--- a/propulsion-tracking-consumer/Program.fs
+++ b/propulsion-tracking-consumer/Program.fs
@@ -9,10 +9,10 @@ module EnvVar =
     let tryGet varName : string option = Environment.GetEnvironmentVariable varName |> Option.ofObj
     let set varName value : unit = Environment.SetEnvironmentVariable(varName, value)
 
-// TODO remove this entire comment after reading https://github.com/jet/dotnet-templates#module-settings
+// TODO remove this entire comment after reading https://github.com/jet/dotnet-templates#module-configuration
 // - this is where any custom retrieval of settings not arriving via commandline arguments or environment variables should go
 // - values should be propagated by setting environment variables and/or returning them from `initialize`
-module Settings =
+module Configuration =
 
     let private initEnvVar var key loadF =
         if None = EnvVar.tryGet var then
@@ -29,7 +29,7 @@ module Settings =
 // TODO DONT invest time reorganizing or reformatting this - half the value is having a legible summary of all program parameters in a consistent value
 //      you may want to regenerate it at a different time and/or facilitate comparing it with the `module Args` of other programs
 // TODO NEVER hack temporary overrides in here; if you're going to do that, use commandline arguments that fall back to environment variables
-//      or (as a last resort) supply them via code in `module Settings`
+//      or (as a last resort) supply them via code in `module Configuration`
 module Args =
 
     exception MissingArg of string
@@ -158,7 +158,7 @@ let run args =
 let main argv =
     try let args = Args.parse argv
         try Logging.initialize args.Verbose
-            try Settings.initialize ()
+            try Configuration.initialize ()
                 run args
             with e -> Log.Fatal(e, "Exiting"); 2
         finally Log.CloseAndFlush()

--- a/propulsion-tracking-consumer/SkuSummary.fs
+++ b/propulsion-tracking-consumer/SkuSummary.fs
@@ -50,11 +50,7 @@ let interpret command (state : Fold.State) =
     | Consume updates ->
         [for x in updates do if x |> Fold.State.isNewOrUpdated state then yield Events.Ingested x]
 
-type Service internal (log, resolve, maxAttempts) =
-
-    let resolve skuId =
-        let stream = resolve (streamName skuId)
-        Equinox.Stream<Events.Event, Fold.State>(log, stream, maxAttempts)
+type Service internal (resolve : SkuId -> Equinox.Stream<Events.Event, Fold.State>) =
 
     /// <returns>count of items</returns>
     member __.Ingest(skuId, items) : Async<int> =
@@ -70,14 +66,16 @@ type Service internal (log, resolve, maxAttempts) =
         let stream = resolve skuId
         stream.Query id
 
-let create resolve = Service(Serilog.Log.ForContext<Service>(), resolve, maxAttempts = 3)
+let create resolver =
+    let resolve skuId =
+        let stream = resolver (streamName skuId)
+        Equinox.Stream(Serilog.Log.ForContext<Service>(), stream, maxAttempts = 3)
+    Service(resolve)
 
 module Cosmos =
 
-    open Equinox.Cosmos // Everything until now is independent of a concrete store
-
-    let accessStrategy = AccessStrategy.Snapshot (Fold.isOrigin, Fold.snapshot)
-    let private resolve (context, cache) =
-        let cacheStrategy = CachingStrategy.SlidingWindow (cache, System.TimeSpan.FromMinutes 20.)
-        Resolver(context, Events.codec, Fold.fold, Fold.initial, cacheStrategy, accessStrategy).Resolve
-    let create (context, cache) = create (resolve (context, cache))
+    let accessStrategy = Equinox.Cosmos.AccessStrategy.Snapshot (Fold.isOrigin, Fold.snapshot)
+    let private resolver (context, cache) =
+        let cacheStrategy = Equinox.Cosmos.CachingStrategy.SlidingWindow (cache, System.TimeSpan.FromMinutes 20.)
+        Equinox.Cosmos.Resolver(context, Events.codec, Fold.fold, Fold.initial, cacheStrategy, accessStrategy).Resolve
+    let create (context, cache) = create (resolver (context, cache))


### PR DESCRIPTION
Prompted by an issue highlighted by @fnipo which triggered a restructure of `main`, but also integrating naming conventions that have proven useful and/or confusing in application contexts:
- makes the `main` functions of the templates more consistent
- renamed `CmdParser` to `Args` (not `Configuration` as that's too overloaded, not `CommandLine` an too long and does not as obviously admit usage of env vars)
- renamed from overly neutral `module Settings` to `module Configuration` to encourage that being the place where config tweaks live (vs that being within `module Args`)
- removed usage of `startConsumer` pattern - `Ingester.fs` will emphasize the testable aspects of the logic, the wireup can live in `let start (args : Args.Arguments)`
- rename `(|For|)`, `CategoryId` to `Category` and `streamName`, move to top level (to admit introduction of `module Types` in selective cases)
- Remove `ignored` vs `skipped` naming nit
- remove nested `module Cosmos` within `module Args`