### PR TITLE
Simplify resolve functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ The `Unreleased` section name is replaced by the expected version of next releas
 
 ### Added
 ### Changed
+
+- Lots of coding style fine-tuning [#53](https://github.com/jet/dotnet-templates/pulls/53) 
+- Clean up `resolve`/`resolver` helper template [#54](https://github.com/jet/dotnet-templates/pulls/54) 
+
 ### Removed
 ### Fixed
 

--- a/README.md
+++ b/README.md
@@ -260,7 +260,7 @@ let main argv =
 
 ## CONTRIBUTING
 
-Please don't hesitate to [create a GitHub issue](https://github.com/jet/dotnet-templates/issues/new) for any questions so others can benefit from the discussion. For any significant planned changes or additions, please err on the side of [reaching out early](https://github.com/jet/dotnet-templates/issues/new) so we can align expectations - there's nothing more frustrating than having your hard work not yielding a mutually agreeable result ;)
+Please don't hesitate to [create a GitHub issue](https://github.com/jet/dotnet-templates/issues/new) for any questions, so others can benefit from the discussion. For any significant planned changes or additions, please err on the side of [reaching out early](https://github.com/jet/dotnet-templates/issues/new) so we can align expectations - there's nothing more frustrating than having your hard work not yielding a mutually agreeable result ;)
 
 See [the Equinox repo's CONTRIBUTING section](https://github.com/jet/equinox/blob/master/README.md#contributing) for general guidelines wrt how contributions are considered specifically wrt Equinox.
 
@@ -271,10 +271,10 @@ The following sorts of things are top of the list for the templates:
 - support for additional languages in the templates
 - further straightforward starter projects
 
-While there is no rigid or defined limit to what makes sense to add, it should be borne in mind that `dotnet new eqx*` is often going to be a new user's first interaction with Equinox and/or [asp]dotnetcore. Hence there's a delicate (and intrinsically subjective) balance to be struck between:
+While there is no rigid or defined limit to what makes sense to add, it should be borne in mind that `dotnet new eqx/pro*` is sometimes going to be a new user's first interaction with Equinox and/or [asp]dotnetcore. Hence there's a delicate (and intrinsically subjective) balance to be struck between:
 
   1. simplicity of programming techniques used / beginner friendliness
   2. brevity of the generated code
   3. encouraging good design practices
 
-  In other words, there's lots of subtlety to what should and shouldn't go into a template - so discussing changes before investing time is encouraged; and agreed changes will generally be rolled out across the repo
+  In other words, there's lots of subtlety to what should and shouldn't go into a template - so discussing changes before investing time is encouraged; agreed changes will generally be rolled out across the repo.

--- a/equinox-web/Domain/Aggregate.fs
+++ b/equinox-web/Domain/Aggregate.fs
@@ -34,7 +34,7 @@ let interpret c (state : Fold.State) =
 
 type View = { sorted : bool }
 
-type Service internal (resolve : string -> Equinox.Stream<Events.Event,Fold.State>) =
+type Service internal (resolve : string -> Equinox.Stream<Events.Event, Fold.State>) =
 
     /// Read the present state
     // TOCONSIDER: you should probably be separating this out per CQRS and reading from a denormalized/cached set of projections
@@ -47,8 +47,8 @@ type Service internal (resolve : string -> Equinox.Stream<Events.Event,Fold.Stat
         let stream = resolve clientId
         stream.Transact(interpret command)
 
-let create resolve =
-    let resolver id =
-        let stream = resolve (streamName id)
+let create resolver =
+    let resolve id =
+        let stream = resolver (streamName id)
         Equinox.Stream(Serilog.Log.ForContext<Service>(), stream, maxAttempts = 3)
-    Service(resolver)
+    Service(resolve)

--- a/equinox-web/Domain/Todo.fs
+++ b/equinox-web/Domain/Todo.fs
@@ -125,8 +125,8 @@ type Service internal (resolve : ClientId -> Equinox.Stream<Events.Event, Fold.S
         let! state' = handle clientId (Update (id, value))
         return state' |> List.find (fun x -> x.id = id) |> render}
 
-let create resolve =
+let create resolver =
     let resolve clientId =
-        let stream = resolve (streamName clientId)
+        let stream = resolver (streamName clientId)
         Equinox.Stream(Serilog.Log.ForContext<Service>(), stream, maxAttempts = 3)
     Service(resolve)

--- a/propulsion-reactor/Todo.fs
+++ b/propulsion-reactor/Todo.fs
@@ -60,29 +60,25 @@ type Service internal (resolve : ClientId -> Equinox.Stream<Events.Event, Fold.S
         // Establish the present state of the Stream, project from that (using QueryEx so we can determine the version in effect)
         stream.QueryEx(fun c -> c.Version, render c.State)
 
-let create resolve =
+let create resolver =
     let resolve clientId =
-        let stream = resolve (streamName clientId)
+        let stream = resolver (streamName clientId)
         Equinox.Stream(Serilog.Log.ForContext<Service>(), stream, maxAttempts = 3)
     Service(resolve)
 
 //#if multiSource
 module EventStore =
 
-    open Equinox.EventStore // Everything until now is independent of a concrete store
-
-    let private resolve (context, cache) =
-        let cacheStrategy = CachingStrategy.SlidingWindow (cache, System.TimeSpan.FromMinutes 20.)
-        Resolver(context, Events.codec, Fold.fold, Fold.initial, cacheStrategy).Resolve
-    let create (context, cache) = resolve (context, cache) |> create
+    let private resolver (context, cache) =
+        let cacheStrategy = Equinox.EventStore.CachingStrategy.SlidingWindow (cache, System.TimeSpan.FromMinutes 20.)
+        Equinox.EventStore.Resolver(context, Events.codec, Fold.fold, Fold.initial, cacheStrategy).Resolve
+    let create (context, cache) = create (resolver (context, cache))
 
 //#endif
 module Cosmos =
 
-    open Equinox.Cosmos // Everything until now is independent of a concrete store
-
-    let accessStrategy = AccessStrategy.Snapshot (Fold.isOrigin, Fold.snapshot)
-    let private resolve (context, cache) =
-        let cacheStrategy = CachingStrategy.SlidingWindow (cache, System.TimeSpan.FromMinutes 20.)
-        Resolver(context, Events.codec, Fold.fold, Fold.initial, cacheStrategy, accessStrategy).Resolve
-    let create (context, cache) = resolve (context, cache) |> create
+    let accessStrategy = Equinox.Cosmos.AccessStrategy.Snapshot (Fold.isOrigin, Fold.snapshot)
+    let private resolver (context, cache) =
+        let cacheStrategy = Equinox.Cosmos.CachingStrategy.SlidingWindow (cache, System.TimeSpan.FromMinutes 20.)
+        Equinox.Cosmos.Resolver(context, Events.codec, Fold.fold, Fold.initial, cacheStrategy, accessStrategy).Resolve
+    let create (context, cache) = create (resolver (context, cache))

--- a/propulsion-summary-consumer/TodoSummary.fs
+++ b/propulsion-summary-consumer/TodoSummary.fs
@@ -44,11 +44,7 @@ let render : Fold.State -> Item[] = function
     | _ -> [||]
 
 /// Defines the operations that the Read side of a Controller and/or the Ingester can perform on the 'aggregate'
-type Service internal (log, resolve, maxAttempts) =
-
-    let resolve clientId =
-        let stream = resolve (streamName clientId)
-        Equinox.Stream<Events.Event, Fold.State>(log, stream, maxAttempts)
+type Service internal (resolve : ClientId -> Equinox.Stream<Events.Event, Fold.State>) =
 
     member __.Ingest(clientId, version, value) : Async<bool> =
         let stream = resolve clientId
@@ -58,7 +54,12 @@ type Service internal (log, resolve, maxAttempts) =
         let stream = resolve clientId
         stream.Query render
 
-let create resolve = Service(Serilog.Log.ForContext<Service>(), resolve, maxAttempts = 3)
+let create resolve =
+    let resolve clientId =
+        let stream = resolve (streamName clientId)
+        Equinox.Stream(Serilog.Log.ForContext<Service>(), stream, maxAttempts = 3)
+
+    Service resolve
 
 module Cosmos =
 

--- a/propulsion-summary-consumer/TodoSummary.fs
+++ b/propulsion-summary-consumer/TodoSummary.fs
@@ -54,19 +54,17 @@ type Service internal (resolve : ClientId -> Equinox.Stream<Events.Event, Fold.S
         let stream = resolve clientId
         stream.Query render
 
-let create resolve =
+let create resolver =
     let resolve clientId =
-        let stream = resolve (streamName clientId)
+        let stream = resolver (streamName clientId)
         Equinox.Stream(Serilog.Log.ForContext<Service>(), stream, maxAttempts = 3)
 
     Service resolve
 
 module Cosmos =
 
-    open Equinox.Cosmos // Everything until now is independent of a concrete store
-
     let accessStrategy = Equinox.Cosmos.AccessStrategy.RollingState Fold.snapshot
-    let private resolve (context, cache) =
-        let cacheStrategy = CachingStrategy.SlidingWindow (cache, System.TimeSpan.FromMinutes 20.)
-        Resolver(context, Events.codec, Fold.fold, Fold.initial, cacheStrategy, accessStrategy).Resolve
-    let create (context, cache) = create (resolve (context, cache))
+    let private resolver (context, cache) =
+        let cacheStrategy = Equinox.Cosmos.CachingStrategy.SlidingWindow (cache, System.TimeSpan.FromMinutes 20.)
+        Equinox.Cosmos.Resolver(context, Events.codec, Fold.fold, Fold.initial, cacheStrategy, accessStrategy).Resolve
+    let create (context, cache) = create (resolver (context, cache))

--- a/propulsion-tracking-consumer/Program.fs
+++ b/propulsion-tracking-consumer/Program.fs
@@ -1,6 +1,5 @@
 ﻿module ConsumerTemplate.Program
 
-open Equinox.Cosmos
 open Serilog
 open System
 
@@ -41,6 +40,7 @@ module Args =
         | None -> getEnvVarForArgumentOrThrow varName argName
         | Some x -> x
     open Argu
+    open Equinox.Cosmos
     type [<NoEquality; NoComparison>] CosmosParameters =
         | [<AltCommandLine "-m">]       ConnectionMode of ConnectionMode
         | [<AltCommandLine "-s">]       Connection of string


### PR DESCRIPTION
This is part of style cleanup in #53

This pushes out a common helper method (resolve), and its shadowing outside of the `type Service`, but has the following properties:
- ensures we keep intellisense for Stream working
- keeps `<Events.Event, Fold.State>` DRY
- keeps the `type Service` persistence agnostic
- works well wrt needs to customize the `maxAttempts` for integration tests etc

Replaces the form:
```
type Service internal (log, resolve, maxAttempts) =

    let resolve id =
        let stream = resolve (streamName id)
        Equinox.Stream<Events.Event, Fold.State>(log, stream, maxAttempts)
```
with 
```
type Service internal (resolve : string -> Equinox.Stream<Events.Event,Fold.State>) =
```
and 
```
let create resolve =
    let resolver id =
        let stream = resolve (streamName id)
        Equinox.Stream(Serilog.Log.ForContext<Service>(), stream, maxAttempts = 3)
    Service(resolver)
```
@thednaz