### PR TITLE
proReactor Add --kafka --blank, cleanup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,8 +10,7 @@ The `Unreleased` section name is replaced by the expected version of next releas
 
 ### Added
 
-- `proReactor`: Added `--kafka --blank` mode illustrating a simple publisher
-- `proReactor`: Wired producer stats emission for `--kafka` modes
+- `proReactor`: Added `--kafka --blank` mode illustrating a simple publisher [#59](https://github.com/jet/dotnet-templates/pull/59) 
 
 ### Changed
 
@@ -19,6 +18,9 @@ The `Unreleased` section name is replaced by the expected version of next releas
 
 ### Removed
 ### Fixed
+
+- `proReactor`: Fixed CFP logging omission
+- `proReactor`: Wired producer stats emission for `--kafka` modes
 
 <a name="4.3.0"></a>
 ## [4.3.0] - 2020-03-12

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ The `Unreleased` section name is replaced by the expected version of next releas
 ## [Unreleased]
 
 ### Added
+
+- `proReactor`: Wired producer stats emission for `--kafka` modes
+
 ### Changed
 
 - `proReactor`: Flip default to omitting filtering logic (`--noFilter` is now `--filter`, defaulting to omitting the logic)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The `Unreleased` section name is replaced by the expected version of next releas
 
 ### Added
 
+- `proReactor`: Added `--kafka --blank` mode illustrating a simple publisher
 - `proReactor`: Wired producer stats emission for `--kafka` modes
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ The `Unreleased` section name is replaced by the expected version of next releas
 
 ### Added
 ### Changed
+
+- `proReactor`: Flip default to omitting filtering logic (`--noFilter` is now `--filter`, defaulting to omitting the logic)
+
 ### Removed
 ### Fixed
 

--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ This repo hosts the source for Jet's [`dotnet new`](https://docs.microsoft.com/e
    0. Default processing shows importing (in summary form) from an aggregate in `EventStore` or a CosmosDB ChangeFeedProcessor to a Summary form in `Cosmos` 
    1. `--blank`: remove sample Ingester logic, yielding a minimal projector
    2. `--kafka` (without `--blank`): adds Optional projection to Apache Kafka using [`Propulsion.Kafka`](https://github.com/jet/propulsion) (instead of ingesting into a local `Cosmos` store). Produces versioned [Summary Event](http://verraes.net/2019/05/patterns-for-decoupling-distsys-summary-event/) feed.
+   3. `--kafka --blank`: provides wiring for producing to Kafka, without summary reading logic etc
     
    Miscellaneous options:
    - `--filter` - include category filtering boilerplate
@@ -93,6 +94,11 @@ To use from the command line, the outline is:
     # ... to add a Summary Projector
     md -p ../SummaryProducer | Set-Location
     dotnet new proReactor --kafka 
+    start README.md
+
+    # ... to add a Custom Projector
+    md -p ../SummaryProducer | Set-Location
+    dotnet new proReactor --kafka --blank
     start README.md
 
     # ... to add a Summary Consumer (ingesting output from `SummaryProducer`)

--- a/README.md
+++ b/README.md
@@ -20,18 +20,25 @@ This repo hosts the source for Jet's [`dotnet new`](https://docs.microsoft.com/e
 
 ## Producer/Reactor Templates combining usage of Equinox and Propulsion
 
-- [`proReactor`](propulsion-reactor/README.md) - Boilerplate for a dual mode CosmosDB ChangeFeed Processor and/or EventStore `$all` stream projector/reactor using `Propulsion.Cosmos`/`Propulsion.EventStore`
+- [`proReactor`](propulsion-reactor/README.md) - Boilerplate for an application that handles reactive actions ranging from publishing notifications via Kafka (simple, or [summarising events](http://verraes.net/2019/05/patterns-for-decoupling-distsys-summary-event/) through to driving follow-on actions implied by events (e.g., updating a denormalized view of an aggregate)
+
+   Input options are:
+   
+   0. (default) dual mode CosmosDB ChangeFeed Processor and/or EventStore `$all` stream projector/reactor using `Propulsion.Cosmos`/`Propulsion.EventStore` depending on whether the program is run with `cosmos` or `es` arguments
+   1. `--source changeFeedOnly`: removes `EventStore` wiring from commandline processing
+   2. `--source kafkaEventSpans`: changes source to be Kafka Event Spans, as emitted from `dotnet new proProjector --kafka`
+
+   The reactive behavior template has the following options:
+   
+   0. Default processing shows importing (in summary form) from an aggregate in `EventStore` or a CosmosDB ChangeFeedProcessor to a Summary form in `Cosmos` 
+   1. `--blank`: remove sample Ingester logic, yielding a minimal projector
+   2. `--kafka` (without `--blank`): adds Optional projection to Apache Kafka using [`Propulsion.Kafka`](https://github.com/jet/propulsion) (instead of ingesting into a local `Cosmos` store). Produces versioned [Summary Event](http://verraes.net/2019/05/patterns-for-decoupling-distsys-summary-event/) feed.
+    
+   Miscellaneous options:
+   - `--filter` - include category filtering boilerplate
 
   **NOTE At present, checkpoint storage when projecting from EventStore uses Azure CosmosDB - help wanted ;)**
-
-   Standard processing shows importing (in summary form) from an aggregate in `EventStore` or a CosmosDB ChangeFeedProcessor to a Summary form in `Cosmos` 
-   
-    - `--source changeFeedOnly` removes `EventStore` wiring from commandline processing
-    - `--source kafkaEventSpans` changes source to be Kafka Event Spans, as emitted from `dotnet new proProjector --kafka`
-    - `--kafka` adds Optional projection to Apache Kafka using [`Propulsion.Kafka`](https://github.com/jet/propulsion) (instead of ingesting into a local `Cosmos` store). Produces versioned [Summary Event](http://verraes.net/2019/05/patterns-for-decoupling-distsys-summary-event/) feed.
-    - `--noFilter` - removes category filtering boilerplate
-    - `--blank`: remove sample Ingester logic, yielding a minimal projector
-
+  
 - [`proSync`](propulsion-sync/README.md) - Boilerplate for a console app that that syncs events between [`Equinox.Cosmos` and `Equinox.EventStore` stores](https://github.com/jet/equinox) using the [relevant `Propulsion`.* libraries](https://github.com/jet/propulsion), filtering/enriching/mapping Events as necessary.
 
 ## Consumer Templates combining usage of Equinox and Propulsion
@@ -85,7 +92,7 @@ To use from the command line, the outline is:
 
     # ... to add a Summary Projector
     md -p ../SummaryProducer | Set-Location
-    dotnet new proReactor --kafka --noFilter
+    dotnet new proReactor --kafka 
     start README.md
 
     # ... to add a Summary Consumer (ingesting output from `SummaryProducer`)

--- a/propulsion-projector/Handler.fs
+++ b/propulsion-projector/Handler.fs
@@ -23,8 +23,12 @@ let render (doc : Microsoft.Azure.Documents.Document) : string * string =
     let equinoxPartition, documentId = doc.GetPropertyValue "p", doc.Id
     equinoxPartition, FsCodec.NewtonsoftJson.Serdes.Serialize { Id = documentId }
 #else
-/// Responsible for wrapping a span of events for a specific stream into an envelope (we use the well-known Propulsion.Codec form)
-/// Most manipulation should take place before events enter the scheduler
+/// Responsible for wrapping a span of events for a specific stream into an envelope
+/// The well-defined Propulsion.Codec form represents the accumulated span of events for a given stream as an array within
+///   each message in order to maximize throughput within constraints Kafka's model implies (we are aiming to preserve
+///   ordering at stream (key) level for messages produced to the topic)
+// TODO NOTE: The bulk of any manipulation should take place before events enter the scheduler, i.e. in program.fs
+// TODO NOTE: While filtering out entire categories is appropriate, you should not filter within a given stream (i.e., by event type)
 let render (stream : FsCodec.StreamName, span : Propulsion.Streams.StreamSpan<_>) = async {
     let value =
         span

--- a/propulsion-reactor/.template.config/template.json
+++ b/propulsion-reactor/.template.config/template.json
@@ -65,7 +65,7 @@
       "datatype": "bool",
       "isRequired": false,
       "defaultValue": "false",
-      "description": "Remove Ingestion sample code. (Not applicable if --kafka selected)"
+      "description": "Remove Ingestion/Summary Production sample code."
     },
     "kafka": {
       "type": "parameter",
@@ -79,22 +79,23 @@
     {
       "modifiers": [
         {
-          "condition": "blank",
+          "condition": "blank && !kafka",
           "exclude": [
             "Infrastructure.fs",
             "Todo.fs",
-            "Contract.fs",
+            "Contract.fs"
+          ]
+        },
+        {
+          "condition": "blank && kafka",
+          "exclude": [
+            "Todo.fs"
           ]
         },
         {
           "condition": "kafka",
           "exclude": [
-            "TodoSummary.fs"
-          ]
-        },
-        {
-          "condition": "kafka",
-          "exclude": [
+            "TodoSummary.fs",
             "Ingester.fs"
           ]
         },

--- a/propulsion-reactor/.template.config/template.json
+++ b/propulsion-reactor/.template.config/template.json
@@ -53,12 +53,12 @@
       "type": "computed",
       "value": "(source == \"multiSource\")"
     },
-    "noFilter": {
+    "filter": {
       "type": "parameter",
       "datatype": "bool",
       "isRequired": false,
       "defaultValue": "false",
-      "description": "Remove logic and commandline handling relating to filtering based on stream names."
+      "description": "Include logic and commandline handling relating to filtering based on stream names."
     },
     "blank": {
       "type": "parameter",

--- a/propulsion-reactor/Contract.fs
+++ b/propulsion-reactor/Contract.fs
@@ -1,5 +1,6 @@
 module ReactorTemplate.Contract
 
+//#if (!blank)
 /// A single Item in the list
 type ItemInfo = { id: int; order: int; title: string; completed: bool }
 
@@ -13,11 +14,43 @@ let render (item: Todo.Events.ItemData) : ItemInfo =
 let ofState (state : Todo.Fold.State) : SummaryInfo =
     { items = [| for x in state.items -> render x |]}
 
+//#endif
 //#if kafka
+#if blank
+module Input =
+
+    let [<Literal>] Category = "CategoryName"
+    type Value = { field : int }
+    type Event =
+        | EventA of Value
+        | EventB of Value
+        interface TypeShape.UnionContract.IUnionContract
+    let codec =
+        let up (evt : FsCodec.ITimelineEvent<_>, e : Event) =
+            evt.Index, e
+        let down (_,e) = e, None, None
+        FsCodec.NewtonsoftJson.Codec.Create(up, down)
+
+    let (|Decode|) (stream, span : Propulsion.Streams.StreamSpan<_>) =
+        span.events |> Array.choose (EventCodec.tryDecode codec stream)
+    let (|MatchesCategory|_|) = function
+        | FsCodec.StreamName.CategoryAndId (Category, ClientId.Parse clientId) -> Some clientId
+        | _ -> None
+    let (|Match|_|) = function
+        | (MatchesCategory clientId, _) & (Decode events) -> Some (clientId, events)
+        | _ -> None
+
+type Data = { value : int }
+type SummaryEvent =
+    | EventA of Data
+    | EventB of Data
+    interface TypeShape.UnionContract.IUnionContract
+#else
 /// Events we emit to third parties (kept here for ease of comparison, can be moved elsewhere in a larger app)
 type SummaryEvent =
     | [<System.Runtime.Serialization.DataMember(Name="TodoUpdateV1")>] Summary of SummaryInfo
     interface TypeShape.UnionContract.IUnionContract
+#endif
 let codec = FsCodec.NewtonsoftJson.Codec.Create<SummaryEvent>()
 let encode summary = codec.Encode(None, summary)
 //#endif

--- a/propulsion-reactor/Handler.fs
+++ b/propulsion-reactor/Handler.fs
@@ -24,7 +24,7 @@ type Outcome =
 let mins x = System.TimeSpan.FromMinutes x
 
 /// Gathers stats based on the outcome of each Span processed for emission, at intervals controlled by `StreamsConsumer`
-type Stats(log, statsInterval, stateInterval) =
+type Stats(log, statsInterval, stateInterval, ?logExternalStats) =
 #if (!kafkaEventSpans)
     inherit Propulsion.Streams.Sync.StreamsSyncStats<Outcome>(log, statsInterval, stateInterval)
 #else
@@ -48,6 +48,7 @@ type Stats(log, statsInterval, stateInterval) =
         if ok <> 0 || skipped <> 0 || na <> 0 then
             log.Information(" used {ok} skipped {skipped} n/a {na}", ok, skipped, na)
             ok <- 0; skipped <- 0; na <- 0
+        logExternalStats |> Option.iter log
 
 let generate stream version info =
     let event = Contract.codec.Encode(None, Contract.Summary info)

--- a/propulsion-reactor/Handler.fs
+++ b/propulsion-reactor/Handler.fs
@@ -48,7 +48,7 @@ type Stats(log, statsInterval, stateInterval, ?logExternalStats) =
         if ok <> 0 || skipped <> 0 || na <> 0 then
             log.Information(" used {ok} skipped {skipped} n/a {na}", ok, skipped, na)
             ok <- 0; skipped <- 0; na <- 0
-        logExternalStats |> Option.iter log
+        logExternalStats |> Option.iter (fun dumpTo -> dumpTo log)
 
 let generate stream version info =
     let event = Contract.codec.Encode(None, Contract.Summary info)

--- a/propulsion-reactor/Program.fs
+++ b/propulsion-reactor/Program.fs
@@ -477,7 +477,7 @@ let build (args : Args.Arguments) =
         let sink =
              Propulsion.Streams.Sync.StreamsSync.Start(
                  Log.Logger, args.MaxReadAhead, args.MaxConcurrentStreams, handle, stats,
-                 projectorStatsInterval=TimeSpan.FromMinutes 1., dumpExternalStats=producer.DumpStats)
+                 projectorStatsInterval = TimeSpan.FromMinutes 1.)
 #else // !kafka -> ingestion
 #if blank
         // TODO: establish any relevant inputs, or re-run without `-blank` for example wiring code
@@ -539,7 +539,7 @@ let build (args : Args.Arguments) =
         let srcService = Todo.Cosmos.create (context, cache)
         let dstService = TodoSummary.Cosmos.create (context, cache)
         let handle = Ingester.handleStreamEvents (Ingester.tryHandle srcService dstService)
-#else // blank -> no specific Ingester souce/destination wire-up
+#else // blank -> no specific Ingester source/destination wire-up
         // TODO: establish any relevant inputs, or re-run without `-blank` for example wiring code
         let handle = Ingester.handleStreamEvents Ingester.tryHandle
 #endif // blank
@@ -560,7 +560,7 @@ let build (args : Args.Arguments) =
 #if kafka
              Propulsion.Streams.Sync.StreamsSync.Start(
                  Log.Logger, args.MaxReadAhead, args.MaxConcurrentStreams, handle, stats,
-                 projectorStatsInterval = TimeSpan.FromMinutes 1., dumpExternalStats = producer.DumpStats)
+                 projectorStatsInterval = TimeSpan.FromMinutes 1.)
 #else
             Propulsion.Streams.StreamsProjector.Start(
                 Log.Logger, args.MaxReadAhead, args.MaxConcurrentStreams, handle, stats = stats)

--- a/propulsion-reactor/Program.fs
+++ b/propulsion-reactor/Program.fs
@@ -1,6 +1,8 @@
 ﻿module ReactorTemplate.Program
 
+//#if (multiSource || !blank)
 open Equinox.Cosmos
+//#endif
 //#if (!kafkaEventSpans)
 open Propulsion.Cosmos
 //#if multiSource
@@ -153,19 +155,19 @@ module Args =
                         batchSize = srcE.StartingBatchSize; minBatchSize = srcE.MinBatchSize; gorge = srcE.Gorge; streamReaders = 0 })
             | Choice2Of2 srcC ->
 //#endif // !changeFeedOnly
-                let disco, auxColl =
+                let auxColl =
                     match srcC.LeaseContainer with
-                    | None ->     srcC.Discovery, { database = srcC.Database; container = srcC.Container + "-aux" }
-                    | Some sc ->  srcC.Discovery, { database = srcC.Database; container = sc }
+                    | None ->     { database = srcC.Database; container = srcC.Container + "-aux" }
+                    | Some sc ->  { database = srcC.Database; container = sc }
                 Log.Information("Max read backlog: {maxReadAhead}", x.MaxReadAhead)
                 Log.Information("Processing Lease {leaseId} in Database {db} Container {container} with maximum document count limited to {maxDocuments}",
                     x.ConsumerGroupName, auxColl.database, auxColl.container, srcC.MaxDocuments)
                 if srcC.FromTail then Log.Warning("(If new projector group) Skipping projection of all existing events.")
                 srcC.LagFrequency |> Option.iter<TimeSpan> (fun s -> Log.Information("Dumping lag stats at {lagS:n0}s intervals", s.TotalSeconds))
 #if changeFeedOnly
-                (srcC, (disco, auxColl, x.ConsumerGroupName, srcC.FromTail, srcC.MaxDocuments, srcC.LagFrequency))
+                (srcC, (auxColl, x.ConsumerGroupName, srcC.FromTail, srcC.MaxDocuments, srcC.LagFrequency))
 #else
-                Choice2Of2 (srcC, (disco, auxColl, x.ConsumerGroupName, srcC.FromTail, srcC.MaxDocuments, srcC.LagFrequency))
+                Choice2Of2 (srcC, (auxColl, x.ConsumerGroupName, srcC.FromTail, srcC.MaxDocuments, srcC.LagFrequency))
 #endif
 //#endif // kafkaEventSpans
 #if kafkaEventSpans
@@ -178,24 +180,39 @@ module Args =
         | [<AltCommandLine "-t"; Unique>]   Topic of string
         | [<AltCommandLine "-m"; Unique>]   MaxInflightMb of float
         | [<AltCommandLine "-l"; Unique>]   LagFreqM of float
+#if (kafka && blank)
+        | [<CliPrefix(CliPrefix.None); Unique(*ExactlyOnce is not supported*); Last>] Kafka of ParseResults<KafkaSinkParameters>
+#else
         | [<CliPrefix(CliPrefix.None); Unique(*ExactlyOnce is not supported*); Last>] Cosmos of ParseResults<CosmosParameters>
+#endif
         interface IArgParserTemplate with
             member a.Usage = a |> function
                 | Broker _ ->               "specify Kafka Broker, in host:port format. (optional if environment variable PROPULSION_KAFKA_BROKER specified)"
                 | Topic _ ->                "specify Kafka Topic Id. (optional if environment variable PROPULSION_KAFKA_TOPIC specified)"
                 | MaxInflightMb _ ->        "maximum MiB of data to read ahead. Default: 10."
                 | LagFreqM _ ->             "specify frequency (minutes) to dump lag stats. Default: off."
+#if (kafka && blank)
+                | Kafka _ ->                "Kafka Source parameters."
+#else
                 | Cosmos _ ->               "CosmosDb Sink parameters."
+#endif
     and KafkaSourceArguments(a : ParseResults<KafkaSourceParameters>) =
         member __.Broker =                  a.TryGetResult KafkaSourceParameters.Broker |> defaultWithEnvVar "PROPULSION_KAFKA_BROKER" "Broker" |> Uri
         member __.Topic =                   a.TryGetResult KafkaSourceParameters.Topic  |> defaultWithEnvVar "PROPULSION_KAFKA_TOPIC"  "Topic"
         member __.MaxInFlightBytes =        a.GetResult(MaxInflightMb, 10.) * 1024. * 1024. |> int64
         member __.LagFrequency =            a.TryGetResult LagFreqM |> Option.map System.TimeSpan.FromMinutes
         member x.BuildSourceParams() =      x.Broker, x.Topic
+#if (kafka && blank)
+        member val Sink =
+            match a.TryGetSubCommand() with
+            | Some (KafkaSourceParameters.Kafka kafka) -> KafkaSinkArguments kafka
+            | _ -> raise (MissingArg "Must specify kafka arguments")
+#else
         member val Cosmos =
             match a.TryGetSubCommand() with
             | Some (KafkaSourceParameters.Cosmos cosmos) -> CosmosArguments cosmos
             | _ -> raise (MissingArg "Must specify cosmos details")
+#endif
 #else
     and [<NoEquality; NoComparison>] CosmosSourceParameters =
         | [<AltCommandLine "-Z"; Unique>]   FromTail
@@ -211,7 +228,11 @@ module Args =
         | [<AltCommandLine "-r">]           Retries of int
         | [<AltCommandLine "-rt">]          RetriesWaitTime of float
 
+#if (!multiSource && kafka && blank)
+        | [<CliPrefix(CliPrefix.None); Unique(*ExactlyOnce is not supported*); Last>] Kafka of ParseResults<KafkaSinkParameters>
+#else
         | [<CliPrefix(CliPrefix.None); Unique(*ExactlyOnce is not supported*); Last>] Cosmos of ParseResults<CosmosParameters>
+#endif
         interface IArgParserTemplate with
             member a.Usage = a |> function
                 | FromTail ->               "(iff the Consumer Name is fresh) - force skip to present Position. Default: Never skip an event."
@@ -227,7 +248,11 @@ module Args =
                 | Retries _ ->              "specify operation retries. Default: 1."
                 | RetriesWaitTime _ ->      "specify max wait-time for retry when being throttled by Cosmos in seconds. Default: 5."
 
+#if (!multiSource && kafka && blank)
+                | Kafka _ ->                "Kafka Source parameters."
+#else
                 | Cosmos _ ->               "CosmosDb Sink parameters."
+#endif
     and CosmosSourceArguments(a : ParseResults<CosmosSourceParameters>) =
         member __.FromTail =                a.Contains CosmosSourceParameters.FromTail
         member __.MaxDocuments =            a.TryGetResult MaxDocuments
@@ -235,7 +260,7 @@ module Args =
         member __.LeaseContainer =          a.TryGetResult CosmosSourceParameters.LeaseContainer
 
         member __.Mode =                    a.GetResult(CosmosSourceParameters.ConnectionMode, Equinox.Cosmos.ConnectionMode.Direct)
-        member __.Discovery =               Discovery.FromConnectionString __.Connection
+        member __.Discovery =               Equinox.Cosmos.Discovery.FromConnectionString __.Connection
         member __.Connection =              a.TryGetResult CosmosSourceParameters.Connection |> defaultWithEnvVar "EQUINOX_COSMOS_CONNECTION" "Connection"
         member __.Database =                a.TryGetResult CosmosSourceParameters.Database   |> defaultWithEnvVar "EQUINOX_COSMOS_DATABASE"   "Database"
         member __.Container =               a.GetResult CosmosSourceParameters.Container
@@ -243,18 +268,24 @@ module Args =
         member __.Retries =                 a.GetResult(CosmosSourceParameters.Retries, 1)
         member __.MaxRetryWaitTime =        a.GetResult(CosmosSourceParameters.RetriesWaitTime, 5.) |> TimeSpan.FromSeconds
         member x.BuildConnectionDetails() =
-            let (Discovery.UriAndKey (endpointUri, _)) as discovery = x.Discovery
+            let (Equinox.Cosmos.Discovery.UriAndKey (endpointUri, _)) as discovery = x.Discovery
             Log.Information("Source CosmosDb {mode} {endpointUri} Database {database} Container {container}",
                 x.Mode, endpointUri, x.Database, x.Container)
             Log.Information("Source CosmosDb timeout {timeout}s; Throttling retries {retries}, max wait {maxRetryWaitTime}s",
                 (let t = x.Timeout in t.TotalSeconds), x.Retries, (let t = x.MaxRetryWaitTime in t.TotalSeconds))
-            let c = Equinox.Cosmos.Connector(x.Timeout, x.Retries, x.MaxRetryWaitTime, Log.Logger, mode=x.Mode)
-            discovery, { database = x.Database; container = x.Container }, c
-
+            let connector = Equinox.Cosmos.Connector(x.Timeout, x.Retries, x.MaxRetryWaitTime, Log.Logger, mode=x.Mode)
+            discovery, { database = x.Database; container = x.Container }, connector
+#if (!multiSource && kafka && blank)
+        member val Sink =
+            match a.TryGetSubCommand() with
+            | Some (CosmosSourceParameters.Kafka kafka) -> KafkaSinkArguments kafka
+            | _ -> raise (MissingArg "Must specify `kafka` arguments")
+#else
         member val Cosmos =
             match a.TryGetSubCommand() with
             | Some (CosmosSourceParameters.Cosmos cosmos) -> CosmosArguments cosmos
             | _ -> raise (MissingArg "Must specify cosmos details")
+#endif
 //#if multiSource
     and [<NoEquality; NoComparison>] EsSourceParameters =
         | [<AltCommandLine "-Z"; Unique>]   FromTail
@@ -349,9 +380,10 @@ module Args =
             | _ -> raise (MissingArg "Must specify `cosmos` checkpoint store when source is `es`")
 //#endif
 #endif
+//#if (multiSource || !(blank && kafka))
     and [<NoEquality; NoComparison>] CosmosParameters =
         | [<AltCommandLine "-s">]           Connection of string
-        | [<AltCommandLine "-m">]           ConnectionMode of ConnectionMode
+        | [<AltCommandLine "-m">]           ConnectionMode of Equinox.Cosmos.ConnectionMode
         | [<AltCommandLine "-d">]           Database of string
         | [<AltCommandLine "-c">]           Container of string
         | [<AltCommandLine "-o">]           Timeout of float
@@ -382,7 +414,7 @@ module Args =
         member __.Retries =                 a.GetResult(CosmosParameters.Retries, 1)
         member __.MaxRetryWaitTime =        a.GetResult(CosmosParameters.RetriesWaitTime, 5.) |> TimeSpan.FromSeconds
         member x.BuildConnectionDetails() =
-            let (Discovery.UriAndKey (endpointUri, _) as discovery) = Discovery.FromConnectionString x.Connection
+            let (Equinox.Cosmos.Discovery.UriAndKey (endpointUri, _) as discovery) = Equinox.Cosmos.Discovery.FromConnectionString x.Connection
             Log.Information("CosmosDb {mode} {endpointUri} Database {database} Container {container}",
                 x.Mode, endpointUri, x.Database, x.Container)
             Log.Information("CosmosDb timeout {timeout}s; Throttling retries {retries}, max wait {maxRetryWaitTime}s",
@@ -394,6 +426,9 @@ module Args =
             match a.TryGetSubCommand() with
             | Some (CosmosParameters.Kafka kafka) -> KafkaSinkArguments kafka
             | _ -> raise (MissingArg "Must specify `kafka` arguments")
+//#endif
+//#endif // (!(!multiSource && kafka && blank))
+//#if kafka
      and [<NoEquality; NoComparison>] KafkaSinkParameters =
         | [<AltCommandLine "-b"; Unique>]   Broker of string
         | [<AltCommandLine "-t"; Unique>]   Topic of string
@@ -469,18 +504,26 @@ let build (args : Args.Arguments) =
         let producer = Propulsion.Kafka.Producer(Log.Logger, AppName, broker, topic)
         let produceSummary (x : Propulsion.Codec.NewtonsoftJson.RenderedSummary) =
             producer.ProduceAsync(x.s, Propulsion.Codec.NewtonsoftJson.Serdes.Serialize x)
+#if blank
+        let handle = Handler.handleStreamEvents (Handler.tryHandle produceSummary)
+#else
         let esConn = connectEs ()
         let srcCache = Equinox.Cache(AppName, sizeMb = 10)
         let srcService = Todo.EventStore.create (EventStoreContext.create esConn,srcCache)
         let handle = Handler.handleStreamEvents (Handler.tryHandle srcService produceSummary)
+#endif
         let stats = Handler.Stats(Log.Logger, TimeSpan.FromMinutes 1., TimeSpan.FromMinutes 5., logExternalStats = producer.DumpStats)
         let sink =
+#if (kafka && !blank)
              Propulsion.Streams.Sync.StreamsSync.Start(
                  Log.Logger, args.MaxReadAhead, args.MaxConcurrentStreams, handle, stats,
                  projectorStatsInterval = TimeSpan.FromMinutes 1.)
+#else
+             Propulsion.Streams.StreamsProjector.Start(Log.Logger, args.MaxReadAhead, args.MaxConcurrentStreams, handle, stats = stats)
+#endif
 #else // !kafka -> ingestion
 #if blank
-        // TODO: establish any relevant inputs, or re-run without `-blank` for example wiring code
+        // TODO: establish any relevant inputs, or re-run without `--blank` for example wiring code
         let handle = Ingester.handleStreamEvents Ingester.tryHandle
 #else // blank
         let esConn = connectEs ()
@@ -503,45 +546,58 @@ let build (args : Args.Arguments) =
                 Log.Logger, sink, checkpoints, connect, spec, Handler.tryMapEvent filterByStreamName,
                 args.MaxReadAhead, args.StatsInterval)
         sink, runPipeline
-    | Choice2Of2 (source, (auxDiscovery, aux, leaseId, startFromTail, maxDocuments, lagFrequency)) ->
+    | Choice2Of2 (source, (aux, leaseId, startFromTail, maxDocuments, lagFrequency)) ->
 //#endif // changeFeedOnly
 #if changeFeedOnly
-        let (source, (auxDiscovery, aux, leaseId, startFromTail, maxDocuments, lagFrequency)) = args.SourceParams()
+        let (source, (aux, leaseId, startFromTail, maxDocuments, lagFrequency)) = args.SourceParams()
 #endif
+        let monitoredDiscovery, monitored, monitoredConnector = source.BuildConnectionDetails()
+//#if (!(kafka && blank))
         let cosmos = source.Cosmos
         let (discovery, database, container, connector) = cosmos.BuildConnectionDetails()
+//#endif
 #else // !kafkaEventSpans -> wire up consumption from Kafka, with auxiliary `cosmos` store
         let source = args.Source
+//#if (!(kafka && blank))
         let cosmos = source.Cosmos
+        let (discovery, database, container, connector) = cosmos.BuildConnectionDetails()
+//#endif
         let consumerConfig =
             FsKafka.KafkaConsumerConfig.Create(
                 AppName, source.Broker, [source.Topic], args.ConsumerGroupName,
                 maxInFlightBytes = source.MaxInFlightBytes, ?statisticsInterval = source.LagFrequency)
-        let (discovery, database, container, connector) = cosmos.BuildConnectionDetails()
 #endif // kafkaEventSpans
 
 #if kafka
+#if (blank && !multiSource)
+        let (broker, topic) = source.Sink.BuildTargetParams()
+#else
         let (broker, topic) = source.Cosmos.Sink.BuildTargetParams()
+#endif
         let producer = Propulsion.Kafka.Producer(Log.Logger, AppName, broker, topic)
         let produceSummary (x : Propulsion.Codec.NewtonsoftJson.RenderedSummary) =
             producer.ProduceAsync(x.s, Propulsion.Codec.NewtonsoftJson.Serdes.Serialize x)
+#if blank
+        let handle = Handler.handleStreamEvents (Handler.tryHandle produceSummary)
+#else
         let connection = connector.Connect(AppName, discovery) |> Async.RunSynchronously
         let context = Equinox.Cosmos.Context (connection, database, container)
         let cache = Equinox.Cache(AppName, sizeMb = 10)
         let service = Todo.Cosmos.create (context, cache)
         let handle = Handler.handleStreamEvents (Handler.tryHandle service produceSummary)
+#endif
         let stats = Handler.Stats(Log.Logger, TimeSpan.FromMinutes 1., TimeSpan.FromMinutes 5., logExternalStats = producer.DumpStats)
 #else // !kafka -> Ingester only
-#if (!blank)
+#if blank
+        // TODO: establish any relevant inputs, or re-run without `-blank` for example wiring code
+        let handle = Ingester.handleStreamEvents Ingester.tryHandle
+#else // blank -> no specific Ingester source/destination wire-up
         let connection = connector.Connect(AppName, discovery) |> Async.RunSynchronously
         let context = Equinox.Cosmos.Context (connection, database, container)
         let cache = Equinox.Cache(AppName, sizeMb = 10)
         let srcService = Todo.Cosmos.create (context, cache)
         let dstService = TodoSummary.Cosmos.create (context, cache)
         let handle = Ingester.handleStreamEvents (Ingester.tryHandle srcService dstService)
-#else // blank -> no specific Ingester source/destination wire-up
-        // TODO: establish any relevant inputs, or re-run without `-blank` for example wiring code
-        let handle = Ingester.handleStreamEvents Ingester.tryHandle
 #endif // blank
         let stats = Ingester.Stats(Log.Logger, statsInterval = TimeSpan.FromMinutes 1., stateInterval = TimeSpan.FromMinutes 5.)
 #endif // kafka
@@ -549,6 +605,7 @@ let build (args : Args.Arguments) =
         let filterByStreamName = args.FilterFunction()
 #endif
 #if kafkaEventSpans
+
         let parseStreamEvents(KeyValue (_streamName : string, spanJson)) : seq<Propulsion.Streams.StreamEvent<_>> =
             Propulsion.Codec.NewtonsoftJson.RenderedSpan.parse spanJson
 #if filter
@@ -556,15 +613,15 @@ let build (args : Args.Arguments) =
 #endif
         Propulsion.Kafka.StreamsConsumer.Start(Log.Logger, consumerConfig, parseStreamEvents, handle, args.MaxConcurrentStreams, stats = stats)
 #else // !kafkaEventSpans => Default consumption, from CosmosDb
+#if (kafka && !blank)
         let sink =
-#if kafka
-             Propulsion.Streams.Sync.StreamsSync.Start(
+            Propulsion.Streams.Sync.StreamsSync.Start(
                  Log.Logger, args.MaxReadAhead, args.MaxConcurrentStreams, handle, stats,
                  projectorStatsInterval = TimeSpan.FromMinutes 1.)
 #else
-            Propulsion.Streams.StreamsProjector.Start(
-                Log.Logger, args.MaxReadAhead, args.MaxConcurrentStreams, handle, stats = stats)
+        let sink = Propulsion.Streams.StreamsProjector.Start(Log.Logger, args.MaxReadAhead, args.MaxConcurrentStreams, handle, stats = stats)
 #endif
+
         let mapToStreamItems (docs : Microsoft.Azure.Documents.Document seq) : Propulsion.Streams.StreamEvent<_> seq =
             // TODO: customize parsing to events if source is not an Equinox Container
             docs
@@ -572,12 +629,11 @@ let build (args : Args.Arguments) =
 #if filter
             |> Seq.filter (fun e -> e.stream |> FsCodec.StreamName.toString |> filterByStreamName)
 #endif
-        let source = { database = database; container = container }
         let createObserver () = CosmosSource.CreateObserver(Log.Logger, sink.StartIngester, mapToStreamItems)
         let runPipeline =
-            CosmosSource.Run(Log.Logger, connector.CreateClient(AppName, discovery), source, aux,
+            CosmosSource.Run(Log.Logger, monitoredConnector.CreateClient(AppName, monitoredDiscovery), monitored, aux,
                 leaseId, startFromTail, createObserver,
-                ?maxDocuments=maxDocuments, ?lagReportFreq=lagFrequency, auxClient=connector.CreateClient(AppName, auxDiscovery))
+                ?maxDocuments=maxDocuments, ?lagReportFreq=lagFrequency)
         sink, runPipeline
 #endif // !kafkaEventSpans
 

--- a/propulsion-reactor/Program.fs
+++ b/propulsion-reactor/Program.fs
@@ -473,7 +473,7 @@ let build (args : Args.Arguments) =
         let srcCache = Equinox.Cache(AppName, sizeMb = 10)
         let srcService = Todo.EventStore.create (EventStoreContext.create esConn,srcCache)
         let handle = Handler.handleStreamEvents (Handler.tryHandle srcService produceSummary)
-        let stats = Handler.Stats(Log.Logger, TimeSpan.FromMinutes 1., TimeSpan.FromMinutes 5.)
+        let stats = Handler.Stats(Log.Logger, TimeSpan.FromMinutes 1., TimeSpan.FromMinutes 5., logExternalStats = producer.DumpStats)
         let sink =
              Propulsion.Streams.Sync.StreamsSync.Start(
                  Log.Logger, args.MaxReadAhead, args.MaxConcurrentStreams, handle, stats,

--- a/propulsion-reactor/Reactor.fsproj
+++ b/propulsion-reactor/Reactor.fsproj
@@ -10,11 +10,15 @@
         <!--#if (!kafkaEventSpans) -->
         <None Include="README.md" />
         <!--#endif-->
-        <!--#if (!blank) -->
+        <!--#if (kafka || !blank) -->
         <Compile Include="Infrastructure.fs" />
+        <!--#endif-->
+        <!--#if (!blank) -->
         <Compile Include="Todo.fs" />
         <!--#endif-->
+        <!--#if (kafka || !blank) -->
         <Compile Include="Contract.fs" />
+        <!--#endif-->
         <!--#if (!kafka && !blank) -->
         <Compile Include="TodoSummary.fs" />
         <!--#endif-->


### PR DESCRIPTION
Rounds out the `proReactor` feature set by adding a `--kafka --blank` mode
- flipped `--noFilter` to become the default
- fixed missing logging