### PR TITLE
Adding MissingArg exception catch in main

### DIFF
--- a/propulsion-consumer/Program.fs
+++ b/propulsion-consumer/Program.fs
@@ -113,7 +113,8 @@ let main argv =
         try Logging.initialize args.Verbose
             try Configuration.initialize ()
                 if run args then 0 else 3
-            with e -> Log.Fatal(e, "Exiting"); 2
+            with Args.MissingArg msg -> eprintfn "%s" msg; 1
+                | e -> Log.Fatal(e, "Exiting"); 2
         finally Log.CloseAndFlush()
     with Args.MissingArg msg -> eprintfn "%s" msg; 1
         | :? Argu.ArguParseException as e -> eprintfn "%s" e.Message; 1

--- a/propulsion-projector/Program.fs
+++ b/propulsion-projector/Program.fs
@@ -219,7 +219,8 @@ let main argv =
         try Logging.initialize args.Verbose args.CfpVerbose
             try Configuration.initialize ()
                 if run args then 0 else 3
-            with e -> Log.Fatal(e, "Exiting"); 2
+            with Args.MissingArg msg -> eprintfn "%s" msg; 1
+                | e -> Log.Fatal(e, "Exiting"); 2
         finally Log.CloseAndFlush()
     with Args.MissingArg msg -> eprintfn "%s" msg; 1
         | :? Argu.ArguParseException as e -> eprintfn "%s" e.Message; 1

--- a/propulsion-reactor/Program.fs
+++ b/propulsion-reactor/Program.fs
@@ -667,7 +667,8 @@ let main argv =
 #endif
             try Configuration.initialize ()
                 if run args then 0 else 3
-            with e -> Log.Fatal(e, "Exiting"); 2
+            with Args.MissingArg msg -> eprintfn "%s" msg; 1
+                | e -> Log.Fatal(e, "Exiting"); 2
         finally Log.CloseAndFlush()
     with Args.MissingArg msg -> eprintfn "%s" msg; 1
         | :? Argu.ArguParseException as e -> eprintfn "%s" e.Message; 1

--- a/propulsion-summary-consumer/Program.fs
+++ b/propulsion-summary-consumer/Program.fs
@@ -160,7 +160,8 @@ let main argv =
         try Logging.initialize args.Verbose
             try Configuration.initialize ()
                 if run args then 0 else 3
-            with e -> Log.Fatal(e, "Exiting"); 2
+            with Args.MissingArg msg -> eprintfn "%s" msg; 1
+                | e -> Log.Fatal(e, "Exiting"); 2
         finally Log.CloseAndFlush()
     with Args.MissingArg msg -> eprintfn "%s" msg; 1
         | :? Argu.ArguParseException as e -> eprintfn "%s" e.Message; 1

--- a/propulsion-sync/Program.fs
+++ b/propulsion-sync/Program.fs
@@ -645,7 +645,8 @@ let main argv =
         try let log, storeLog = Logging.initialize args.Verbose args.CfpVerbose args.MaybeSeqEndpoint
             try Configuration.initialize ()
                 if run (args, log, storeLog) then 0 else 3
-            with e -> Log.Fatal(e, "Exiting"); 2
+            with Args.MissingArg msg -> eprintfn "%s" msg; 1
+                | e -> Log.Fatal(e, "Exiting"); 2
         finally Log.CloseAndFlush()
     with Args.MissingArg msg -> eprintfn "%s" msg; 1
         | :? Argu.ArguParseException as e -> eprintfn "%s" e.Message; 1

--- a/propulsion-tracking-consumer/Program.fs
+++ b/propulsion-tracking-consumer/Program.fs
@@ -160,7 +160,8 @@ let main argv =
         try Logging.initialize args.Verbose
             try Configuration.initialize ()
                 run args
-            with e -> Log.Fatal(e, "Exiting"); 2
+            with Args.MissingArg msg -> eprintfn "%s" msg; 1
+                | e -> Log.Fatal(e, "Exiting"); 2
         finally Log.CloseAndFlush()
     with Args.MissingArg msg -> eprintfn "%s" msg; 1
         | :? Argu.ArguParseException as e -> eprintfn "%s" e.Message; 1


### PR DESCRIPTION
The innermost try block in main does not catch MissingArg exception. Thus, the missing arguments that are caught after parsing the argument are not properly caught and fail to inform what is missing.
