### PR TITLE
Add support for reading from Projection Node

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ The `Unreleased` section name is replaced by the expected version of next releas
 
 ### Added
 ### Changed
+
+- `proReactor`: Start using projection event store connection to read when using event store [#62](https://github.com/jet/dotnet-templates/pull/62) 
+
 ### Removed
 ### Fixed
 

--- a/propulsion-reactor/Program.fs
+++ b/propulsion-reactor/Program.fs
@@ -48,9 +48,8 @@ module Args =
     let private defaultWithEnvVar varName argName = function
         | None -> getEnvVarForArgumentOrThrow varName argName
         | Some x -> x
-    let private defaultWithEnvVarOrFallback varName fallback = function
-        | Some x -> x
-        | None -> EnvVar.tryGet varName |> Option.defaultWith fallback        
+    let private getEnvVarTrue varName =
+         EnvVar.tryGet varName |> Option.exists (fun s -> String.Equals(s, bool.TrueString, StringComparison.OrdinalIgnoreCase))
     let private seconds (x : TimeSpan) = x.TotalSeconds
     open Argu
 //#if multiSource
@@ -337,23 +336,22 @@ module Args =
                 | Percent _ ->              "EventStore $all Stream Position to commence from (as a percentage of current tail position)"
 
                 | Verbose ->                "Include low level Store logging."
-                | Tcp ->                    "Request connecting direct to a TCP/IP endpoint. Default: Use Clustered mode with Gossip-driven discovery (unless environment variable EQUINOX_ES_TCP specifies 'true')."
-                | Host _ ->                 "TCP mode: specify a hostname to connect to directly. Clustered mode: use Gossip protocol against all A records returned from DNS query. (optional if environment variable EQUINOX_ES_HOST specified)"
-                | Port _ ->                 "specify a custom port. Uses value of environment variable EQUINOX_ES_PORT if specified. Defaults for Cluster and Direct TCP/IP mode are 30778 and 1113 respectively."
-                | Username _ ->             "specify a username. (optional if environment variable EQUINOX_ES_USERNAME specified)"
-                | Password _ ->             "specify a Password. (optional if environment variable EQUINOX_ES_PASSWORD specified)"
-                | ProjTcp ->                "Request connecting direct to a TCP/IP endpoint for Projection EventStore. Defaults to value of es tcp (-T) flag unless environment variable EQUINOX_ES_PROJ_TCP specifies 'true'."
-                | ProjHost _ ->             "specify Projection EventStore hostname to connect. Defaults to value of es host (-h) unless environment variable EQUINOX_ES__PROJ_HOST is specified."
-                | ProjPort _ ->             "specify Projection EventStore custom port. Defaults to value of es port (-x) unless environment variable EQUINOX_ES_PROJ_PORT is specified. "
-                | ProjUsername _ ->         "specify a username for Projection EventStore. Defaults to value of es user (-u) unless environment variable EQUINOX_ES_PROJ_USERNAME is specified."
-                | ProjPassword _ ->         "specify a Password for Projection EventStore. Defaults to value of es password (-p) unless environment variable EQUINOX_ES_PROJ_PASSWORD is specified."
+                | Tcp ->                    "Request connecting EventStore direct to a TCP/IP endpoint. Default: Use Clustered mode with Gossip-driven discovery (unless environment variable EQUINOX_ES_TCP specifies 'true')."
+                | Host _ ->                 "TCP mode: specify EventStore hostname to connect to directly. Clustered mode: use Gossip protocol against all A records returned from DNS query. (optional if environment variable EQUINOX_ES_HOST specified)"
+                | Port _ ->                 "specify EventStore custom port. Uses value of environment variable EQUINOX_ES_PORT if specified. Defaults for Cluster and Direct TCP/IP mode are 30778 and 1113 respectively."
+                | Username _ ->             "specify username for EventStore. (optional if environment variable EQUINOX_ES_USERNAME specified)"
+                | Password _ ->             "specify Password for EventStore. (optional if environment variable EQUINOX_ES_PASSWORD specified)"
+                | ProjTcp ->                "Request connecting Projection EventStore direct to a TCP/IP endpoint. Default: Use Clustered mode with Gossip-driven discovery (unless environment variable EQUINOX_ES_PROJ_TCP specifies 'true')."
+                | ProjHost _ ->             "specify Projection EventStore hostname to connect. Defaults to value of es host (-h) unless environment variable EQUINOX_ES_PROJ_HOST is specified."
+                | ProjPort _ ->             "specify Projection EventStore custom port. Defaults to value of es port (-x) unless environment variable EQUINOX_ES_PROJ_PORT is specified."
+                | ProjUsername _ ->         "specify username for Projection EventStore. Defaults to value of es user (-u) unless environment variable EQUINOX_ES_PROJ_USERNAME is specified."
+                | ProjPassword _ ->         "specify Password for Projection EventStore. Defaults to value of es password (-p) unless environment variable EQUINOX_ES_PROJ_PASSWORD is specified."
                 | Timeout _ ->              "specify operation timeout in seconds. Default: 20."
                 | Retries _ ->              "specify operation retries. Default: 3."
                 | HeartbeatTimeout _ ->     "specify heartbeat timeout in seconds. Default: 1.5."
 
                 | Cosmos _ ->               "CosmosDB (Checkpoint) Store parameters."
     and EsSourceArguments(a : ParseResults<EsSourceParameters>) =
-        
         let discovery (host, port, tcp) =
             match tcp, port with
             | false, None ->   Discovery.GossipDns            host
@@ -372,28 +370,30 @@ module Args =
             | _, _, Some p, _ ->            Percentage p
             | None, None, None, true ->     StartPos.TailOrCheckpoint
             | None, None, None, _ ->        StartPos.StartOrCheckpoint
-        member __.Tcp =
-            a.Contains Tcp
-            || EnvVar.tryGet "EQUINOX_ES_TCP" |> Option.exists (fun s -> String.Equals(s, bool.TrueString, StringComparison.OrdinalIgnoreCase))
+        member __.Tcp =                     a.Contains Tcp || getEnvVarTrue "EQUINOX_ES_TCP"
         member __.Port =                    match a.TryGetResult Port with Some x -> Some x | None -> EnvVar.tryGet "EQUINOX_ES_PORT" |> Option.map int
         member __.Host =                    a.TryGetResult Host     |> defaultWithEnvVar "EQUINOX_ES_HOST"     "Host"
         member __.User =                    a.TryGetResult Username |> defaultWithEnvVar "EQUINOX_ES_USERNAME" "Username"
         member __.Password =                a.TryGetResult Password |> defaultWithEnvVar "EQUINOX_ES_PASSWORD" "Password"
-        member __.ProjTcp =
-            a.Contains ProjTcp
-            || match EnvVar.tryGet "EQUINOX_ES_PROJ_TCP" with Some s -> String.Equals(s, bool.TrueString, StringComparison.OrdinalIgnoreCase) | None -> __.Tcp
+        member __.ProjTcp =                 a.Contains ProjTcp || getEnvVarTrue "EQUINOX_ES_PROJ_TCP"
         member __.ProjPort =                match a.TryGetResult ProjPort with
                                             | Some x -> Some x
-                                            | None -> (EnvVar.tryGet "EQUINOX_ES_PROJ_PORT" |> Option.map int) |> Option.orElse __.Port
-        member __.ProjHost =                a.TryGetResult ProjHost     |> defaultWithEnvVarOrFallback  "EQUINOX_ES_PROJ_HOST"     (fun () -> __.Host)
-        member __.ProjUser =                a.TryGetResult ProjUsername |> defaultWithEnvVarOrFallback  "EQUINOX_ES_PROJ_USERNAME" (fun () -> __.User)
-        member __.ProjPassword =            a.TryGetResult ProjPassword |> defaultWithEnvVarOrFallback  "EQUINOX_ES_PROJ_PASSWORD" (fun () -> __.Password)
+                                            | None -> EnvVar.tryGet "EQUINOX_ES_PROJ_PORT" |> Option.map int |> Option.orElseWith (fun () -> __.Port) 
+        member __.ProjHost =                match a.TryGetResult ProjHost with
+                                            | Some x -> x
+                                            | None -> EnvVar.tryGet "EQUINOX_ES_PROJ_HOST"      |> Option.defaultWith (fun () -> __.Host)
+        member __.ProjUser =                match a.TryGetResult ProjUsername with
+                                            | Some x -> x
+                                            | None -> EnvVar.tryGet  "EQUINOX_ES_PROJ_USERNAME" |> Option.defaultWith (fun () -> __.User)
+        member __.ProjPassword =            match a.TryGetResult ProjPassword with
+                                            | Some x -> x
+                                            | None -> EnvVar.tryGet  "EQUINOX_ES_PROJ_PASSWORD" |> Option.defaultWith (fun () -> __.Password)
         member __.Retries =                 a.GetResult(EsSourceParameters.Retries, 3)
         member __.Timeout =                 a.GetResult(EsSourceParameters.Timeout, 20.) |> TimeSpan.FromSeconds
         member __.Heartbeat =               a.GetResult(HeartbeatTimeout, 1.5) |> TimeSpan.FromSeconds
         
         member x.ConnectProj(log: ILogger, storeLog: ILogger, appName, nodePreference) =
-            let discovery = discovery(x.ProjHost, x.ProjPort, x.ProjTcp)
+            let discovery = discovery (x.ProjHost, x.ProjPort, x.ProjTcp)
             log.ForContext("projHost", x.ProjHost).ForContext("projPort", x.ProjPort)
                 .Information("Projection EventStore {discovery} heartbeat: {heartbeat}s Timeout: {timeout}s Retries {retries}",
                     discovery, seconds x.Heartbeat, seconds x.Timeout, x.Retries)
@@ -403,7 +403,7 @@ module Args =
                 .Connect(appName + "-Proj", discovery, nodePreference) |> Async.RunSynchronously
         
         member x.Connect(log: ILogger, storeLog: ILogger, appName, connectionStrategy) =
-            let discovery = discovery(x.Host, x.Port, x.Tcp)
+            let discovery = discovery (x.Host, x.Port, x.Tcp)
             log.ForContext("host", x.Host).ForContext("port", x.Port)
                 .Information("EventStore {discovery} heartbeat: {heartbeat}s Timeout: {timeout}s Retries {retries}",
                     discovery, seconds x.Heartbeat, seconds x.Timeout, x.Retries)

--- a/propulsion-reactor/Program.fs
+++ b/propulsion-reactor/Program.fs
@@ -48,7 +48,7 @@ module Args =
     let private defaultWithEnvVar varName argName = function
         | None -> getEnvVarForArgumentOrThrow varName argName
         | Some x -> x
-    let private getEnvVarTrue varName =
+    let private isEnvVarTrue varName =
          EnvVar.tryGet varName |> Option.exists (fun s -> String.Equals(s, bool.TrueString, StringComparison.OrdinalIgnoreCase))
     let private seconds (x : TimeSpan) = x.TotalSeconds
     open Argu
@@ -342,7 +342,7 @@ module Args =
                 | Username _ ->             "specify username for EventStore. (optional if environment variable EQUINOX_ES_USERNAME specified)"
                 | Password _ ->             "specify Password for EventStore. (optional if environment variable EQUINOX_ES_PASSWORD specified)"
                 | ProjTcp ->                "Request connecting Projection EventStore direct to a TCP/IP endpoint. Default: Use Clustered mode with Gossip-driven discovery (unless environment variable EQUINOX_ES_PROJ_TCP specifies 'true')."
-                | ProjHost _ ->             "specify Projection EventStore hostname to connect. Defaults to value of es host (-h) unless environment variable EQUINOX_ES_PROJ_HOST is specified."
+                | ProjHost _ ->             "TCP mode: specify Projection EventStore hostname to connect to directly. Clustered mode: use Gossip protocol against all A records returned from DNS query. Defaults to value of es host (-h) unless environment variable EQUINOX_ES_PROJ_HOST is specified."
                 | ProjPort _ ->             "specify Projection EventStore custom port. Defaults to value of es port (-x) unless environment variable EQUINOX_ES_PROJ_PORT is specified."
                 | ProjUsername _ ->         "specify username for Projection EventStore. Defaults to value of es user (-u) unless environment variable EQUINOX_ES_PROJ_USERNAME is specified."
                 | ProjPassword _ ->         "specify Password for Projection EventStore. Defaults to value of es password (-p) unless environment variable EQUINOX_ES_PROJ_PASSWORD is specified."
@@ -370,12 +370,12 @@ module Args =
             | _, _, Some p, _ ->            Percentage p
             | None, None, None, true ->     StartPos.TailOrCheckpoint
             | None, None, None, _ ->        StartPos.StartOrCheckpoint
-        member __.Tcp =                     a.Contains Tcp || getEnvVarTrue "EQUINOX_ES_TCP"
+        member __.Tcp =                     a.Contains Tcp || isEnvVarTrue "EQUINOX_ES_TCP"
         member __.Port =                    match a.TryGetResult Port with Some x -> Some x | None -> EnvVar.tryGet "EQUINOX_ES_PORT" |> Option.map int
         member __.Host =                    a.TryGetResult Host     |> defaultWithEnvVar "EQUINOX_ES_HOST"     "Host"
         member __.User =                    a.TryGetResult Username |> defaultWithEnvVar "EQUINOX_ES_USERNAME" "Username"
         member __.Password =                a.TryGetResult Password |> defaultWithEnvVar "EQUINOX_ES_PASSWORD" "Password"
-        member __.ProjTcp =                 a.Contains ProjTcp || getEnvVarTrue "EQUINOX_ES_PROJ_TCP"
+        member __.ProjTcp =                 a.Contains ProjTcp || isEnvVarTrue "EQUINOX_ES_PROJ_TCP"
         member __.ProjPort =                match a.TryGetResult ProjPort with
                                             | Some x -> Some x
                                             | None -> EnvVar.tryGet "EQUINOX_ES_PROJ_PORT" |> Option.map int |> Option.orElseWith (fun () -> __.Port) 

--- a/propulsion-reactor/Program.fs
+++ b/propulsion-reactor/Program.fs
@@ -369,19 +369,19 @@ module Args =
             | None, None, None, true ->     StartPos.TailOrCheckpoint
             | None, None, None, _ ->        StartPos.StartOrCheckpoint
         member __.Tcp =
-            a.Contains EsSourceParameters.Tcp
+            a.Contains Tcp
             || EnvVar.tryGet "EQUINOX_ES_TCP" |> Option.exists (fun s -> String.Equals(s, bool.TrueString, StringComparison.OrdinalIgnoreCase))
         member __.Port =                    match a.TryGetResult Port with Some x -> Some x | None -> EnvVar.tryGet "EQUINOX_ES_PORT" |> Option.map int
         member __.Host =                    a.TryGetResult Host     |> defaultWithEnvVar "EQUINOX_ES_HOST"     "Host"
         member __.User =                    a.TryGetResult Username |> defaultWithEnvVar "EQUINOX_ES_USERNAME" "Username"
         member __.Password =                a.TryGetResult Password |> defaultWithEnvVar "EQUINOX_ES_PASSWORD" "Password"
         member __.ProjTcp =
-            a.Contains EsSourceParameters.ProjTcp
+            a.Contains ProjTcp
             || EnvVar.tryGet "EQUINOX_ES_PROJ_TCP" |> Option.exists (fun s -> String.Equals(s, bool.TrueString, StringComparison.OrdinalIgnoreCase))
-        member __.ProjPort =                match a.TryGetResult Port with Some x -> Some x | None -> EnvVar.tryGet "EQUINOX_ES_PROJ_PORT" |> Option.map int
-        member __.ProjHost =                a.TryGetResult Host     |> defaultWithEnvVar "EQUINOX_ES_PROJ_HOST"     "ProjHost"
-        member __.ProjUser =                a.TryGetResult Username |> defaultWithEnvVar "EQUINOX_ES_PROJ_USERNAME" "Username"
-        member __.ProjPassword =            a.TryGetResult Password |> defaultWithEnvVar "EQUINOX_ES_PROJ_PASSWORD" "Password"
+        member __.ProjPort =                match a.TryGetResult ProjPort with Some x -> Some x | None -> EnvVar.tryGet "EQUINOX_ES_PROJ_PORT" |> Option.map int
+        member __.ProjHost =                a.TryGetResult ProjHost |> defaultWithEnvVar "EQUINOX_ES_PROJ_HOST"         "ProjHost"
+        member __.ProjUser =                a.TryGetResult ProjUsername |> defaultWithEnvVar "EQUINOX_ES_PROJ_USERNAME" "Username"
+        member __.ProjPassword =            a.TryGetResult ProjPassword |> defaultWithEnvVar "EQUINOX_ES_PROJ_PASSWORD" "Password"
         member __.Retries =                 a.GetResult(EsSourceParameters.Retries, 3)
         member __.Timeout =                 a.GetResult(EsSourceParameters.Timeout, 20.) |> TimeSpan.FromSeconds
         member __.Heartbeat =               a.GetResult(HeartbeatTimeout, 1.5) |> TimeSpan.FromSeconds
@@ -389,7 +389,7 @@ module Args =
         member x.ConnectProj(log: ILogger, storeLog: ILogger, appName, nodePreference) =
             let s (x : TimeSpan) = x.TotalSeconds
             let discovery = discovery(x.ProjHost, x.ProjPort, x.ProjTcp)
-            log.ForContext("host", x.ProjHost).ForContext("port", x.ProjPort)
+            log.ForContext("projHost", x.ProjHost).ForContext("projPort", x.ProjPort)
                 .Information("Projection EventStore {discovery} heartbeat: {heartbeat}s Timeout: {timeout}s Retries {retries}",
                     discovery, s x.Heartbeat, s x.Timeout, x.Retries)
             let log=if storeLog.IsEnabled Serilog.Events.LogEventLevel.Debug then Logger.SerilogVerbose storeLog else Logger.SerilogNormal storeLog

--- a/propulsion-reactor/Program.fs
+++ b/propulsion-reactor/Program.fs
@@ -313,6 +313,11 @@ module Args =
         | [<AltCommandLine "-x">]           Port of int
         | [<AltCommandLine "-u">]           Username of string
         | [<AltCommandLine "-p">]           Password of string
+        | [<AltCommandLine "-Tp">]          ProjTcp
+        | [<AltCommandLine "-hp">]          ProjHost of string
+        | [<AltCommandLine "-xp">]          ProjPort of int
+        | [<AltCommandLine "-up">]          ProjUsername of string
+        | [<AltCommandLine "-pp">]          ProjPassword of string
 
         | [<CliPrefix(CliPrefix.None); Unique(*ExactlyOnce is not supported*); Last>] Cosmos of ParseResults<CosmosParameters>
         interface IArgParserTemplate with
@@ -333,12 +338,24 @@ module Args =
                 | Port _ ->                 "specify a custom port. Uses value of environment variable EQUINOX_ES_PORT if specified. Defaults for Cluster and Direct TCP/IP mode are 30778 and 1113 respectively."
                 | Username _ ->             "specify a username. (optional if environment variable EQUINOX_ES_USERNAME specified)"
                 | Password _ ->             "specify a Password. (optional if environment variable EQUINOX_ES_PASSWORD specified)"
+                | ProjTcp ->                "Request connecting direct to a TCP/IP endpoint for Projection EventStore. Default: Use Clustered mode with Gossip-driven discovery (unless environment variable EQUINOX_ES_PROJ_TCP specifies 'true')."
+                | ProjHost _ ->             "TCP mode: specify Projection EventStore hostname to connect to directly. Clustered mode: use Gossip protocol against all A records returned from DNS query. (optional if environment variable EQUINOX_ES_PROJ_HOST specified)"
+                | ProjPort _ ->             "specify Projection EventStore custom port. Uses value of environment variable EQUINOX_ES_PROJ_PORT if specified. Defaults for Cluster and Direct TCP/IP mode are 30778 and 1113 respectively."
+                | ProjUsername _ ->         "specify a username for Projection EventStore. (optional if environment variable EQUINOX_ES_PROJ_USERNAME specified)"
+                | ProjPassword _ ->         "specify a Password for Projection EventStore. (optional if environment variable EQUINOX_ES_PROJ_PASSWORD specified)"
                 | Timeout _ ->              "specify operation timeout in seconds. Default: 20."
                 | Retries _ ->              "specify operation retries. Default: 3."
                 | HeartbeatTimeout _ ->     "specify heartbeat timeout in seconds. Default: 1.5."
 
                 | Cosmos _ ->               "CosmosDB (Checkpoint) Store parameters."
     and EsSourceArguments(a : ParseResults<EsSourceParameters>) =
+        
+        let discovery (host, port, tcp) =
+            match tcp, port with
+            | false, None ->   Discovery.GossipDns            host
+            | false, Some p -> Discovery.GossipDnsCustomPort (host, p)
+            | true, None ->    Discovery.Uri                 (UriBuilder("tcp", host).Uri)
+            | true, Some p ->  Discovery.Uri                 (UriBuilder("tcp", host, p).Uri)
         member __.Gorge =                   a.TryGetResult Gorge
         member __.TailInterval =            a.GetResult(Tail, 1.) |> TimeSpan.FromSeconds
         member __.ForceRestart =            a.Contains ForceRestart
@@ -351,13 +368,6 @@ module Args =
             | _, _, Some p, _ ->            Percentage p
             | None, None, None, true ->     StartPos.TailOrCheckpoint
             | None, None, None, _ ->        StartPos.StartOrCheckpoint
-
-        member __.Discovery =
-            match __.Tcp, __.Port with
-            | false, None ->   Discovery.GossipDns            __.Host
-            | false, Some p -> Discovery.GossipDnsCustomPort (__.Host, p)
-            | true, None ->    Discovery.Uri                 (UriBuilder("tcp", __.Host).Uri)
-            | true, Some p ->  Discovery.Uri                 (UriBuilder("tcp", __.Host, p).Uri)
         member __.Tcp =
             a.Contains EsSourceParameters.Tcp
             || EnvVar.tryGet "EQUINOX_ES_TCP" |> Option.exists (fun s -> String.Equals(s, bool.TrueString, StringComparison.OrdinalIgnoreCase))
@@ -365,12 +375,31 @@ module Args =
         member __.Host =                    a.TryGetResult Host     |> defaultWithEnvVar "EQUINOX_ES_HOST"     "Host"
         member __.User =                    a.TryGetResult Username |> defaultWithEnvVar "EQUINOX_ES_USERNAME" "Username"
         member __.Password =                a.TryGetResult Password |> defaultWithEnvVar "EQUINOX_ES_PASSWORD" "Password"
+        member __.ProjTcp =
+            a.Contains EsSourceParameters.ProjTcp
+            || EnvVar.tryGet "EQUINOX_ES_PROJ_TCP" |> Option.exists (fun s -> String.Equals(s, bool.TrueString, StringComparison.OrdinalIgnoreCase))
+        member __.ProjPort =                match a.TryGetResult Port with Some x -> Some x | None -> EnvVar.tryGet "EQUINOX_ES_PROJ_PORT" |> Option.map int
+        member __.ProjHost =                a.TryGetResult Host     |> defaultWithEnvVar "EQUINOX_ES_PROJ_HOST"     "ProjHost"
+        member __.ProjUser =                a.TryGetResult Username |> defaultWithEnvVar "EQUINOX_ES_PROJ_USERNAME" "Username"
+        member __.ProjPassword =            a.TryGetResult Password |> defaultWithEnvVar "EQUINOX_ES_PROJ_PASSWORD" "Password"
         member __.Retries =                 a.GetResult(EsSourceParameters.Retries, 3)
         member __.Timeout =                 a.GetResult(EsSourceParameters.Timeout, 20.) |> TimeSpan.FromSeconds
         member __.Heartbeat =               a.GetResult(HeartbeatTimeout, 1.5) |> TimeSpan.FromSeconds
+        
+        member x.ConnectProj(log: ILogger, storeLog: ILogger, appName, nodePreference) =
+            let s (x : TimeSpan) = x.TotalSeconds
+            let discovery = discovery(x.ProjHost, x.ProjPort, x.ProjTcp)
+            log.ForContext("host", x.ProjHost).ForContext("port", x.ProjPort)
+                .Information("Projection EventStore {discovery} heartbeat: {heartbeat}s Timeout: {timeout}s Retries {retries}",
+                    discovery, s x.Heartbeat, s x.Timeout, x.Retries)
+            let log=if storeLog.IsEnabled Serilog.Events.LogEventLevel.Debug then Logger.SerilogVerbose storeLog else Logger.SerilogNormal storeLog
+            let tags=["M", Environment.MachineName; "I", Guid.NewGuid() |> string]
+            Connector(x.ProjUser, x.ProjPassword, x.Timeout, x.Retries, log=log, heartbeatTimeout=x.Heartbeat, tags=tags)
+                .Connect(appName + "-Proj", discovery, nodePreference) |> Async.RunSynchronously
+        
         member x.Connect(log: ILogger, storeLog: ILogger, appName, connectionStrategy) =
             let s (x : TimeSpan) = x.TotalSeconds
-            let discovery = x.Discovery
+            let discovery = discovery(x.Host, x.Port, x.Tcp)
             log.ForContext("host", x.Host).ForContext("port", x.Port)
                 .Information("EventStore {discovery} heartbeat: {heartbeat}s Timeout: {timeout}s Retries {retries}",
                     discovery, s x.Heartbeat, s x.Timeout, x.Retries)
@@ -496,7 +525,8 @@ let build (args : Args.Arguments) =
 //#if (!changeFeedOnly)
     match args.SourceParams() with
     | Choice1Of2 (srcE, cosmos, spec) ->
-        let connectEs () = srcE.Connect(Log.Logger, Log.Logger, AppName, Equinox.EventStore.ConnectionStrategy.ClusterSingle Equinox.EventStore.NodePreference.PreferSlave)
+        let connectEs () = srcE.Connect(Log.Logger, Log.Logger, AppName, Equinox.EventStore.ConnectionStrategy.ClusterSingle Equinox.EventStore.NodePreference.Master)
+        let connectProjEs = srcE.ConnectProj(Log.Logger, Log.Logger, AppName, Equinox.EventStore.NodePreference.Master)
         let (discovery, database, container, connector) = cosmos.BuildConnectionDetails()
 
         let connection = connector.Connect(AppName, discovery) |> Async.RunSynchronously
@@ -545,7 +575,7 @@ let build (args : Args.Arguments) =
         let stats = Ingester.Stats(Log.Logger, statsInterval = TimeSpan.FromMinutes 1., stateInterval = TimeSpan.FromMinutes 5.)
         let sink = Propulsion.Streams.StreamsProjector.Start(Log.Logger, args.MaxReadAhead, args.MaxConcurrentStreams, handle, stats = stats)
 #endif // !kafka
-        let connect () = let c = connectEs () in c.ReadConnection
+        let connect () = connectProjEs
 #if filter
         let filterByStreamName = args.FilterFunction()
 #else

--- a/propulsion-reactor/Program.fs
+++ b/propulsion-reactor/Program.fs
@@ -48,7 +48,7 @@ module Args =
     let private defaultWithEnvVar varName argName = function
         | None -> getEnvVarForArgumentOrThrow varName argName
         | Some x -> x
-    let private defaultWithEnvVarOrFallback varName fallbackValue  = function
+    let private defaultWithEnvVarOrFallback varName fallbackValue = function
         | Some x -> x
         | None -> EnvVar.tryGet varName |> Option.defaultValue fallbackValue
     open Argu
@@ -531,7 +531,7 @@ let build (args : Args.Arguments) =
     match args.SourceParams() with
     | Choice1Of2 (srcE, cosmos, spec) ->
         let connectEs () = srcE.Connect(Log.Logger, Log.Logger, AppName, Equinox.EventStore.ConnectionStrategy.ClusterSingle Equinox.EventStore.NodePreference.Master)
-        let connectProjEs = srcE.ConnectProj(Log.Logger, Log.Logger, AppName, Equinox.EventStore.NodePreference.Master)
+        let connectProjEs = srcE.ConnectProj(Log.Logger, Log.Logger, AppName, Equinox.EventStore.NodePreference.PreferSlave)
         let (discovery, database, container, connector) = cosmos.BuildConnectionDetails()
 
         let connection = connector.Connect(AppName, discovery) |> Async.RunSynchronously

--- a/propulsion-reactor/Program.fs
+++ b/propulsion-reactor/Program.fs
@@ -338,11 +338,11 @@ module Args =
                 | Port _ ->                 "specify a custom port. Uses value of environment variable EQUINOX_ES_PORT if specified. Defaults for Cluster and Direct TCP/IP mode are 30778 and 1113 respectively."
                 | Username _ ->             "specify a username. (optional if environment variable EQUINOX_ES_USERNAME specified)"
                 | Password _ ->             "specify a Password. (optional if environment variable EQUINOX_ES_PASSWORD specified)"
-                | ProjTcp ->                "Request connecting direct to a TCP/IP endpoint for Projection EventStore. Default: Use Clustered mode with Gossip-driven discovery (unless environment variable EQUINOX_ES_PROJ_TCP specifies 'true')."
-                | ProjHost _ ->             "TCP mode: specify Projection EventStore hostname to connect to directly. Clustered mode: use Gossip protocol against all A records returned from DNS query. (optional if environment variable EQUINOX_ES_PROJ_HOST specified)"
-                | ProjPort _ ->             "specify Projection EventStore custom port. Uses value of environment variable EQUINOX_ES_PROJ_PORT if specified. Defaults for Cluster and Direct TCP/IP mode are 30778 and 1113 respectively."
-                | ProjUsername _ ->         "specify a username for Projection EventStore. (optional if environment variable EQUINOX_ES_PROJ_USERNAME specified)"
-                | ProjPassword _ ->         "specify a Password for Projection EventStore. (optional if environment variable EQUINOX_ES_PROJ_PASSWORD specified)"
+                | ProjTcp ->                "Request connecting direct to a TCP/IP endpoint for Projection EventStore. Default: Use Clustered mode with Gossip-driven discovery (unless environment variable EQUINOX_ES_TCP specifies 'true')."
+                | ProjHost _ ->             "TCP mode: specify Projection EventStore hostname to connect to directly. Clustered mode: use Gossip protocol against all A records returned from DNS query. (optional if environment variable EQUINOX_ES_HOST specified)"
+                | ProjPort _ ->             "specify Projection EventStore custom port. Uses value of environment variable EQUINOX_ES_PORT if specified. Defaults for Cluster and Direct TCP/IP mode are 30778 and 1113 respectively."
+                | ProjUsername _ ->         "specify a username for Projection EventStore. (optional if environment variable EQUINOX_ES_USERNAME specified)"
+                | ProjPassword _ ->         "specify a Password for Projection EventStore. (optional if environment variable EQUINOX_ES_PASSWORD specified)"
                 | Timeout _ ->              "specify operation timeout in seconds. Default: 20."
                 | Retries _ ->              "specify operation retries. Default: 3."
                 | HeartbeatTimeout _ ->     "specify heartbeat timeout in seconds. Default: 1.5."
@@ -377,11 +377,11 @@ module Args =
         member __.Password =                a.TryGetResult Password |> defaultWithEnvVar "EQUINOX_ES_PASSWORD" "Password"
         member __.ProjTcp =
             a.Contains ProjTcp
-            || EnvVar.tryGet "EQUINOX_ES_PROJ_TCP" |> Option.exists (fun s -> String.Equals(s, bool.TrueString, StringComparison.OrdinalIgnoreCase))
-        member __.ProjPort =                match a.TryGetResult ProjPort with Some x -> Some x | None -> EnvVar.tryGet "EQUINOX_ES_PROJ_PORT" |> Option.map int
-        member __.ProjHost =                a.TryGetResult ProjHost |> defaultWithEnvVar "EQUINOX_ES_PROJ_HOST"         "ProjHost"
-        member __.ProjUser =                a.TryGetResult ProjUsername |> defaultWithEnvVar "EQUINOX_ES_PROJ_USERNAME" "Username"
-        member __.ProjPassword =            a.TryGetResult ProjPassword |> defaultWithEnvVar "EQUINOX_ES_PROJ_PASSWORD" "Password"
+            || EnvVar.tryGet "EQUINOX_ES_TCP" |> Option.exists (fun s -> String.Equals(s, bool.TrueString, StringComparison.OrdinalIgnoreCase))
+        member __.ProjPort =                match a.TryGetResult ProjPort with Some x -> Some x | None -> EnvVar.tryGet "EQUINOX_ES_PORT" |> Option.map int
+        member __.ProjHost =                a.TryGetResult ProjHost |> defaultWithEnvVar     "EQUINOX_ES_HOST"     "ProjHost"
+        member __.ProjUser =                a.TryGetResult ProjUsername |> defaultWithEnvVar "EQUINOX_ES_USERNAME" "ProjUsername"
+        member __.ProjPassword =            a.TryGetResult ProjPassword |> defaultWithEnvVar "EQUINOX_ES_PASSWORD" "ProjPassword"
         member __.Retries =                 a.GetResult(EsSourceParameters.Retries, 3)
         member __.Timeout =                 a.GetResult(EsSourceParameters.Timeout, 20.) |> TimeSpan.FromSeconds
         member __.Heartbeat =               a.GetResult(HeartbeatTimeout, 1.5) |> TimeSpan.FromSeconds

--- a/propulsion-reactor/Program.fs
+++ b/propulsion-reactor/Program.fs
@@ -342,7 +342,7 @@ module Args =
                 | Port _ ->                 "specify a custom port. Uses value of environment variable EQUINOX_ES_PORT if specified. Defaults for Cluster and Direct TCP/IP mode are 30778 and 1113 respectively."
                 | Username _ ->             "specify a username. (optional if environment variable EQUINOX_ES_USERNAME specified)"
                 | Password _ ->             "specify a Password. (optional if environment variable EQUINOX_ES_PASSWORD specified)"
-                | ProjTcp ->                "Request connecting direct to a TCP/IP endpoint for Projection EventStore. Defaults to value of es tcp flag unless environment variable EQUINOX_ES_PROJ_TCP specifies 'true'."
+                | ProjTcp ->                "Request connecting direct to a TCP/IP endpoint for Projection EventStore. Defaults to value of es tcp (-T) flag unless environment variable EQUINOX_ES_PROJ_TCP specifies 'true'."
                 | ProjHost _ ->             "specify Projection EventStore hostname to connect. Defaults to value of es host (-h) unless environment variable EQUINOX_ES__PROJ_HOST is specified."
                 | ProjPort _ ->             "specify Projection EventStore custom port. Defaults to value of es port (-x) unless environment variable EQUINOX_ES_PROJ_PORT is specified. "
                 | ProjUsername _ ->         "specify a username for Projection EventStore. Defaults to value of es user (-u) unless environment variable EQUINOX_ES_PROJ_USERNAME is specified."


### PR DESCRIPTION
Propulsion should read from projection ES when specified.
- Add new arguments for projection ES and connect using provided values
- When Projection ES attributes are not specified it should default to use values provided for cluster ES's values.