### PR TITLE
eqxShipping: Add Reservation stage for concurrency control

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ The `Unreleased` section name is replaced by the expected version of next releas
 ## [Unreleased]
 
 ### Added
+
+- `eqxShipping`: Add `Reserved` event/phase to `eqxShipping` [#63](https://github.com/jet/dotnet-templates/pull/63)
+
 ### Changed
 ### Removed
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -54,12 +54,12 @@ The specific behaviors carried out in reaction to incoming events often use `Equ
 
 - [`proSync`](propulsion-sync/README.md) - Boilerplate for a console app that that syncs events between [`Equinox.Cosmos` and `Equinox.EventStore` stores](https://github.com/jet/equinox) using the [relevant `Propulsion`.* libraries](https://github.com/jet/propulsion), filtering/enriching/mapping Events as necessary.
 
-<a name="eqxshipping"></a>
-- [`eqxShipping`](equinox-shipping/) - Example demonstrating the implementation of a [Process Manager](https://www.enterpriseintegrationpatterns.com/patterns/messaging/ProcessManager.html) using [`Equinox`](https://github.com/jet/equinox) that manages the enlistment of a set of `Shipment` Aggregate items into a separated `Container` Aggregate as an atomic operation. :pray: [@Kimserey](https://github.com/Kimserey)
+<a name="eqxShipping"></a>
+- [`eqxShipping`](equinox-shipping/README.md) - Example demonstrating the implementation of a [Process Manager](https://www.enterpriseintegrationpatterns.com/patterns/messaging/ProcessManager.html) using [`Equinox`](https://github.com/jet/equinox) that manages the enlistment of a set of `Shipment` Aggregate items into a separated `Container` Aggregate as an atomic operation. :pray: [@Kimserey](https://github.com/Kimserey)
  
-   - processing is fully idempotent; retries, concurrent or overlapping transactions are handled correctly
-   - if any `Shipment`s cannot be `Assigned`, those that have been get `Revoked`, and the failure is reported to the caller
-   - includes a `Watchdog` console app (based on `dotnet new proReactor --source changeFeedOnly --blank`) responsible for driving any abandoned transactions being carried out by e.g. Web Clients through to their conclusion.
+   - processing is fully idempotent; retries, concurrent or overlapping transactions are intended to be handled thoroughly and correctly
+   - if any `Shipment`s cannot be `Reserved`, those that have been get `Revoked`, and the failure is reported to the caller
+   - includes a `Watchdog` console app (based on `dotnet new proReactor --source changeFeedOnly --blank`) responsible for concluding abandoned transaction instances (e.g., where processing is carried out in response to a HTTP request and the Clients fails to retry after a transient failure leaves processing in a non-terminal state).
 
 ## Walkthrough
 

--- a/dotnet-templates.sln
+++ b/dotnet-templates.sln
@@ -83,6 +83,7 @@ EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "equinox-shipping", "equinox-shipping", "{DAE9E2B9-EDA2-4064-B0CE-FD5294549374}"
 ProjectSection(SolutionItems) = preProject
 	equinox-shipping\.template.config\template.json = equinox-shipping\.template.config\template.json
+	equinox-shipping\README.md = equinox-shipping\README.md
 EndProjectSection
 EndProject
 Project("{F2A71F9B-5D33-465A-A702-920D77279786}") = "Domain", "equinox-shipping\Domain\Domain.fsproj", "{7B96FCF8-0BB5-4494-A143-628882A6E50A}"

--- a/equinox-shipping/.template.config/template.json
+++ b/equinox-shipping/.template.config/template.json
@@ -5,7 +5,8 @@
     "Equinox",
     "Propulsion",
     "Event Sourcing",
-    "Process Manager"
+    "Process Manager",
+    "Watchdog"
   ],
   "tags": {
     "language": "F#"

--- a/equinox-shipping/Domain/FinalizationTransaction.fs
+++ b/equinox-shipping/Domain/FinalizationTransaction.fs
@@ -1,7 +1,5 @@
 module Shipping.Domain.FinalizationTransaction
 
-open System.Runtime.Serialization
-
 let [<Literal>] private Category = "FinalizationTransaction"
 let streamName (transactionId : TransactionId) = FsCodec.StreamName.create Category (TransactionId.toString transactionId)
 let (|Match|_|) = function FsCodec.StreamName.CategoryAndId (Category, TransactionId.Parse transId) -> Some transId | _ -> None
@@ -9,32 +7,32 @@ let (|Match|_|) = function FsCodec.StreamName.CategoryAndId (Category, Transacti
 // NB - these types and the union case names reflect the actual storage formats and hence need to be versioned with care
 module Events =
 
-    let [<Literal>] private CompletedEventName = "Completed"
     type Event =
-        | FinalizationRequested of {| containerId : ContainerId; shipmentIds : ShipmentId[] |}
+        | FinalizationRequested of {| container : ContainerId; shipments : ShipmentId[] |}
+        | ReservationCompleted
         /// Signifies we're switching focus to relinquishing any assignments we completed.
         /// The list includes any items we could possibly have touched (including via idempotent retries)
-        | RevertCommenced       of {| shipmentIds : ShipmentId[] |}
+        | RevertCommenced       of {| shipments : ShipmentId[] |}
         | AssignmentCompleted
         /// Signifies all processing for the transaction has completed - the Watchdog looks for this event
-        | [<DataMember(Name = CompletedEventName)>]Completed
+        | Completed
         | Snapshotted           of State
         interface TypeShape.UnionContract.IUnionContract
 
     and [<Newtonsoft.Json.JsonConverter(typeof<FsCodec.NewtonsoftJson.UnionConverter>)>]
         State =
         | Initial
-        | Assigning of TransactionState
-        | Reverting of TransactionState
-        | Assigned  of TransactionState
-        | Completed of success : bool
-    and TransactionState = { container : ContainerId; shipments : ShipmentId[] }
+        | Reserving of {| container : ContainerId; shipments : ShipmentId[] |}
+        | Reverting of {| shipments : ShipmentId[] |}
+        | Assigning of {| container : ContainerId; shipments : ShipmentId[] |}
+        | Assigned  of {| container : ContainerId; shipments : ShipmentId[] |}
+        | Completed of {| success : bool |}
 
     let codec = FsCodec.NewtonsoftJson.Codec.Create<Event>()
 
     /// Used by the Watchdog to infer whether a given event signifies that the processing has reached a terminal state
     let isTerminalEvent (encoded : FsCodec.ITimelineEvent<_>) =
-        encoded.EventType = CompletedEventName
+        encoded.EventType = "Completed" // TODO nameof("Completed")
 
 module Fold =
 
@@ -44,7 +42,8 @@ module Fold =
     let isValidTransition (event : Events.Event) (state : State) =
         match state, event with
         | State.Initial,     Events.FinalizationRequested _
-        | State.Assigning _, Events.RevertCommenced _
+        | State.Reserving _, Events.RevertCommenced _
+        | State.Reserving _, Events.ReservationCompleted _
         | State.Reverting _, Events.Completed
         | State.Assigning _, Events.AssignmentCompleted _
         | State.Assigned _,  Events.Completed -> true
@@ -53,11 +52,11 @@ module Fold =
     // The implementation trusts (does not spend time double checking) that events have passed an isValidTransition check
     let evolve (state : State) (event : Events.Event) : State =
         match state, event with
-        | _, Events.FinalizationRequested event                -> State.Assigning { container = event.containerId; shipments = event.shipmentIds }
-        | State.Assigning state,  Events.RevertCommenced event -> State.Reverting { state with shipments = event.shipmentIds }
-        | State.Reverting _state, Events.Completed             -> State.Completed false
-        | State.Assigning state,  Events.AssignmentCompleted   -> State.Assigned state
-        | State.Assigned _,       Events.Completed             -> State.Completed true
+        | _, Events.FinalizationRequested event                -> State.Assigning {| container = event.container; shipments = event.shipments |}
+        | State.Assigning state,  Events.RevertCommenced event -> State.Reverting {| shipments = event.shipments |}
+        | State.Reverting _state, Events.Completed             -> State.Completed {| success = false |}
+        | State.Assigning state,  Events.AssignmentCompleted   -> State.Assigned  {| container = state.container; shipments = state.shipments |}
+        | State.Assigned _,       Events.Completed             -> State.Completed {| success = true |}
         | _,                      Events.Snapshotted state     -> state
         // this shouldn't happen, but, if we did produce invalid events, we'll just ignore them
         | state, _                                             -> state
@@ -68,16 +67,18 @@ module Fold =
 
 [<RequireQualifiedAccess>]
 type Action =
-    | AssignShipments   of containerId : ContainerId * shipmentIds : ShipmentId[]
-    | RevertAssignment  of containerId : ContainerId * shipmentIds : ShipmentId[]
-    | FinalizeContainer of containerId : ContainerId * shipmentIds : ShipmentId[]
-    | Finish            of success : bool
+    | ReserveShipments   of shipmentIds : ShipmentId[]
+    | RevertReservations of shipmentIds : ShipmentId[]
+    | AssignShipments    of shipmentIds : ShipmentId[] * containerId : ContainerId
+    | FinalizeContainer  of containerId : ContainerId * shipmentIds : ShipmentId[]
+    | Finish             of success : bool
 
 let nextAction : Fold.State -> Action = function
-    | Fold.State.Assigning state      -> Action.AssignShipments   (state.container, state.shipments)
-    | Fold.State.Reverting state      -> Action.RevertAssignment  (state.container, state.shipments)
+    | Fold.State.Reserving state      -> Action.ReserveShipments   state.shipments
+    | Fold.State.Reverting state      -> Action.RevertReservations state.shipments
+    | Fold.State.Assigning state      -> Action.AssignShipments   (state.shipments, state.container)
     | Fold.State.Assigned state       -> Action.FinalizeContainer (state.container, state.shipments)
-    | Fold.State.Completed result     -> Action.Finish result
+    | Fold.State.Completed result     -> Action.Finish             result.success
     // As all state transitions are driven by members on the FinalizationProcessManager, we can rule this out
     | Fold.State.Initial as s         -> failwith (sprintf "Cannot interpret state %A" s)
 
@@ -94,7 +95,7 @@ let decide (update : Events.Event option) (state : Fold.State) : Action * Events
 
 type Service internal (resolve : TransactionId -> Equinox.Stream<Events.Event, Fold.State>) =
 
-    member __.Apply(transactionId, update) : Async<Action> =
+    member __.Record(transactionId, update) : Async<Action> =
         let stream = resolve transactionId
         stream.Transact(decide update)
 

--- a/equinox-shipping/Domain/Shipment.fs
+++ b/equinox-shipping/Domain/Shipment.fs
@@ -7,61 +7,59 @@ let streamName (shipmentId : ShipmentId) = FsCodec.StreamName.create Category (S
 module Events =
 
     type Event =
-        // TOCONSIDER: We could introduce a reserved state for a shipment if we needed to avoid multiple instances of the Assigned event
-        | Assigned    of {| containerId : ContainerId |}
+        | Reserved    of {| transaction : TransactionId |}
+        | Assigned    of {| container : ContainerId |}
         | Revoked
-        | Snapshotted of {| association : ContainerId option |}
+        | Snapshotted of {| reservation : TransactionId option; association : ContainerId option |}
         interface TypeShape.UnionContract.IUnionContract
 
     let codec = FsCodec.NewtonsoftJson.Codec.Create<Event>()
 
 module Fold =
 
-    type State = { association : ContainerId option }
-    let initial : State = { association = None }
+    type State = { reservation : TransactionId option; association : ContainerId option }
+    let initial : State = { reservation = None; association = None }
 
-    let evolve (_state: State) = function
-        | Events.Assigned event -> { association = Some event.containerId }
-        | Events.Revoked     -> { association = None }
-        | Events.Snapshotted event      -> { association = event.association }
+    let evolve (state: State) = function
+        | Events.Reserved event     -> { reservation = Some event.transaction; association = None }
+        | Events.Revoked            ->   initial
+        | Events.Assigned event     -> { state with                              association = Some event.container  }
+        | Events.Snapshotted event  -> { reservation = event.reservation;        association = event.association }
     let fold : State -> Events.Event seq -> State = Seq.fold evolve
 
     let isOrigin = function Events.Snapshotted _ -> true | _ -> false
-    let toSnapshot (state : State) = Events.Snapshotted {| association = state.association |}
+    let toSnapshot (state : State) = Events.Snapshotted {| reservation = state.reservation; association = state.association |}
 
-type Command =
-    | Assign
-    | Revoke
+let decideReserve transactionId : Fold.State -> bool * Events.Event list = function
+    | { reservation = r; association = a } ->
+        // validity is dependent on whether its a) open or b) an idempotent retry by the same transaction
+        let isValid = Option.forall (fun x -> x = transactionId) r
+        // if it's already Reserved (and/or assigned), there's no work to do
+        isValid, if isValid && Option.isNone a then [ Events.Reserved {| transaction = transactionId |} ] else []
 
-let interpret containerId (command : Command) (state : Fold.State) : bool * Events.Event list =
-    match command, state with
-    | Assign, { association = None } ->
-        true, [ Events.Assigned {| containerId = containerId |} ]
-    | Assign, { association = Some current } when current <> containerId ->
-        // Assignment fails if the shipment was already assigned to another container
-        false, []
-    | Assign, { association = _ } ->
-        // Idempotently ignore
-        true, []
+let interpretRevoke transactionId : Fold.State -> Events.Event list = function
+    | { reservation = Some current; association = None } when current = transactionId ->
+        [ Events.Revoked ]
+    | _ -> [] // Ignore if a) already revoked/never reserved b) not reserved for this transactionId
 
-    | Revoke, { association = Some current } when current <> containerId ->
-        // The assignment is not ours to revoke -> Denied
-        false, []
-    | Revoke, { association = Some _ } ->
-        true, [ Events.Revoked ]
-    | Revoke, { association = _ } ->
-        // Idempotently ignore
-        true, []
+let interpretAssign transactionId containerId : Fold.State -> Events.Event list = function
+    | { reservation = Some r; association = None } when r = transactionId ->
+        [ Events.Assigned {| container = containerId |} ]
+    | _ -> [] // Ignore if a) this transaction was not the one reserving it or b) it's already been assigned
 
 type Service internal (resolve : ShipmentId -> Equinox.Stream<Events.Event, Fold.State>) =
 
-    member __.TryAssign(shipmentId, containerId) : Async<bool> =
+    member __.TryReserve(shipmentId, transactionId) : Async<bool> =
         let stream = resolve shipmentId
-        stream.Transact(interpret containerId Assign)
+        stream.Transact(decideReserve transactionId)
 
-    member __.TryRevoke(shipmentId, containerId) : Async<bool> =
+    member __.Revoke(shipmentId, transactionId) : Async<unit> =
         let stream = resolve shipmentId
-        stream.Transact(interpret containerId Revoke)
+        stream.Transact(interpretRevoke transactionId)
+
+    member __.Assign(shipmentId, containerId, transactionId) : Async<unit> =
+        let stream = resolve shipmentId
+        stream.Transact(interpretAssign transactionId containerId)
 
 let private create resolve =
     let resolve id = Equinox.Stream(Serilog.Log.ForContext<Service>(), resolve (streamName id), maxAttempts = 3)

--- a/equinox-shipping/Domain/TransactionWatchdog.fs
+++ b/equinox-shipping/Domain/TransactionWatchdog.fs
@@ -29,7 +29,7 @@ module Fold =
     let fold : State -> Events.Categorization seq -> State = Seq.fold evolve
 
 type Status = Complete | Active | Stuck
-let categorize cutoffTime = function
+let toStatus cutoffTime = function
     | Fold.Initial -> failwith "Expected at least one valid event"
     | Fold.Active startTime when startTime < cutoffTime -> Stuck
     | Fold.Active _ -> Active

--- a/equinox-shipping/README.md
+++ b/equinox-shipping/README.md
@@ -1,0 +1,27 @@
+# Shipping / Process Manager / Watchdog example
+
+NOTE: In general, this is not intended to be the first example you touch when exploring Equinox (see https://github.com/jet/equinox#quickstart for a more progressive sequence of things to explore)
+
+This project was generated using:
+
+    dotnet new -i Equinox.Templates # just once, to install/update in the local templates store
+    dotnet new eqxShipping
+
+The purpose of this template is to demonstrate the implementation of a [Process Manager](https://www.enterpriseintegrationpatterns.com/patterns/messaging/ProcessManager.html) using [`Equinox`](https://github.com/jet/equinox) that manages the enlistment of a set of `Shipment` Aggregate Root items into a separated `Container` Aggregate Root as an atomic operation.
+
+Implementation notes: 
+   - processing is fully idempotent; retries, concurrent or overlapping transactions are intended to be handled thoroughly and correctly
+   - if any `Shipment`s cannot be `Reserved`, those that have been get `Revoked`, and the failure is reported to the caller
+   - includes a `Watchdog` console app (based on `dotnet new proReactor --source changeFeedOnly --blank`) responsible for `Drive`ing any abandoned / stuck transactions neglected by e.g. processing within a HTTP request that times out and is not retried by the client through to their conclusion.
+
+## Exercise / hole
+
+A remaining hole is that multiple concurrent Finalization transactions are not prevented (which I believe is different from the actual app semantics at the present time - Finalization is intended to be a final act 😸). It may be a interesting exercise for the reader to add processing to the FinalizationTransaction (and Container) such that one or more of the following behaviors apply: 
+- Gate the processing via a reservation on the container (you'll definitely need a Watchdog!)
+- Do an optimistic pre-flight check, visiting the Container to see if it's already Finalized
+- If one reaches the Finalize action but determine it has already been completed by a competing writer, switch to a reverting mode (but that would open the possibility of multiple Assigned events)
+- Register the Finalization intent on the Container once the Reservations have been attained, then mark it Finalized after that
+
+## Usage instructions
+
+See Watchdog/README.md for some minimal setup instructions.

--- a/equinox-shipping/Shipping.sln
+++ b/equinox-shipping/Shipping.sln
@@ -4,6 +4,11 @@ Project("{F2A71F9B-5D33-465A-A702-920D77279786}") = "Domain", "Domain\Domain.fsp
 EndProject
 Project("{F2A71F9B-5D33-465A-A702-920D77279786}") = "Watchdog", "Watchdog\Watchdog.fsproj", "{222D612E-51E0-4ED1-BB34-AF08E3BBF741}"
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = ".project", ".project", "{365F9F6D-BE32-46AA-B6CE-7751BE42FA51}"
+ProjectSection(SolutionItems) = preProject
+	README.md = README.md
+EndProjectSection
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU

--- a/equinox-shipping/Watchdog/Handler.fs
+++ b/equinox-shipping/Watchdog/Handler.fs
@@ -29,8 +29,8 @@ let tryHandle
         (stream, span : Propulsion.Streams.StreamSpan<_>) : Async<Outcome> = async {
     let processingStuckCutoff = let now = DateTimeOffset.UtcNow in now.Add(-processingTimeout)
     match stream, span.events with
-    | TransactionWatchdog.Finalization.MatchStatus (transId, status) ->
-        match TransactionWatchdog.categorize processingStuckCutoff status with
+    | TransactionWatchdog.Finalization.MatchStatus (transId, state) ->
+        match TransactionWatchdog.toStatus processingStuckCutoff state with
         | TransactionWatchdog.Complete ->
             return Outcome.Completed
         | TransactionWatchdog.Active ->

--- a/equinox-shipping/Watchdog/Program.fs
+++ b/equinox-shipping/Watchdog/Program.fs
@@ -111,7 +111,7 @@ module Args =
     and CosmosSourceArguments(a : ParseResults<CosmosSourceParameters>) =
         member __.FromTail =                a.Contains FromTail
         member __.MaxDocuments =            a.TryGetResult MaxDocuments
-        member __.LagFrequency =            a.TryGetResult LagFreqM |> Option.map TimeSpan.FromMinutes
+        member __.LagFrequency =            a.TryPostProcessResult(LagFreqM, TimeSpan.FromMinutes)
         member __.LeaseContainer =          a.TryGetResult LeaseContainer
 
         member __.Mode =                    a.GetResult(CosmosSourceParameters.ConnectionMode, Equinox.Cosmos.ConnectionMode.Direct)


### PR DESCRIPTION
Prompted by questions arising in overviews, this PR introduces an explicit Reservation event for the Shipment Category which adds the following properties/behaviors:
- a Shipment now will never see >1 Assigned event
- overlapping Transactions where >1 attempts to Finalize the transaction concurrently with overlapping shipmentId sets will now fail

NOTE added a README discussing a hole/weakness/potential exercise for the reader

cc @Kimserey @wantastic84 @svairagade @al3jandr0 