### PR TITLE
Add logging to Handlers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ The `Unreleased` section name is replaced by the expected version of next releas
 ### Added
 
 - `eqxShipping`: Add `Reserved` event/phase to `eqxShipping` [#63](https://github.com/jet/dotnet-templates/pull/63)
+- Added `Log.exceptions` for all ingestion/reaction logic [#65](https://github.com/jet/dotnet-templates/pull/65)
 
 ### Changed
 

--- a/equinox-shipping/Watchdog/Handler.fs
+++ b/equinox-shipping/Watchdog/Handler.fs
@@ -4,7 +4,7 @@ open System
 
 module Log =
 
-    let (|LogAsWarning|_|) = function (e : exn) -> Serilog.Log.Warning(e, "Unhandled"); None
+    let (|LogAsWarning|_|) = function (e : exn) -> Serilog.Log.Warning(e, "Unhandled exception"); None
     let exceptions f = async { try return! f with LogAsWarning -> return! invalidOp "not possible; Filter always returns None" }
 
 [<RequireQualifiedAccess>]

--- a/propulsion-reactor/Handler.fs
+++ b/propulsion-reactor/Handler.fs
@@ -2,7 +2,7 @@ module ReactorTemplate.Handler
 
 module Log =
 
-    let (|LogAsWarning|_|) = function (e : exn) -> Serilog.Log.Warning(e, "Unhandled"); None
+    let (|LogAsWarning|_|) = function (e : exn) -> Serilog.Log.Warning(e, "Unhandled exception"); None
     let exceptions f = async { try return! f with LogAsWarning -> return! invalidOp "not possible; Filter always returns None" }
 
 //#if multiSource

--- a/propulsion-reactor/Ingester.fs
+++ b/propulsion-reactor/Ingester.fs
@@ -2,7 +2,7 @@ module ReactorTemplate.Ingester
 
 module Log =
 
-    let (|LogAsWarning|_|) = function (e : exn) -> Serilog.Log.Warning(e, "Unhandled"); None
+    let (|LogAsWarning|_|) = function (e : exn) -> Serilog.Log.Warning(e, "Unhandled exception"); None
     let exceptions f = async { try return! f with LogAsWarning -> return! invalidOp "not possible; Filter always returns None" }
 
 [<RequireQualifiedAccess>]

--- a/propulsion-summary-consumer/Ingester.fs
+++ b/propulsion-summary-consumer/Ingester.fs
@@ -4,7 +4,7 @@ module ConsumerTemplate.Ingester
 
 module Log =
 
-    let (|LogAsWarning|_|) = function (e : exn) -> Serilog.Log.Warning(e, "Unhandled"); None
+    let (|LogAsWarning|_|) = function (e : exn) -> Serilog.Log.Warning(e, "Unhandled exception"); None
     let exceptions f = async { try return! f with LogAsWarning -> return! invalidOp "not possible; Filter always returns None" }
 
 /// Defines the contract we share with the proReactor --'s published feed

--- a/propulsion-tracking-consumer/Infrastructure.fs
+++ b/propulsion-tracking-consumer/Infrastructure.fs
@@ -2,6 +2,11 @@
 
 open FSharp.UMX // see https://github.com/fsprojects/FSharp.UMX - % operator and ability to apply units of measure to Guids+strings
 
+module Log =
+
+    let (|LogAsWarning|_|) = function (e : exn) -> Serilog.Log.Warning(e, "Unhandled"); None
+    let exceptions f = async { try return! f with LogAsWarning -> return! invalidOp "not possible; Filter always returns None" }
+    
 module EventCodec =
 
     /// Uses the supplied codec to decode the supplied event record `x` (iff at LogEventLevel.Debug, detail fails to `log` citing the `stream` and content)

--- a/propulsion-tracking-consumer/Infrastructure.fs
+++ b/propulsion-tracking-consumer/Infrastructure.fs
@@ -4,9 +4,9 @@ open FSharp.UMX // see https://github.com/fsprojects/FSharp.UMX - % operator and
 
 module Log =
 
-    let (|LogAsWarning|_|) = function (e : exn) -> Serilog.Log.Warning(e, "Unhandled"); None
+    let (|LogAsWarning|_|) = function (e : exn) -> Serilog.Log.Warning(e, "Unhandled exception"); None
     let exceptions f = async { try return! f with LogAsWarning -> return! invalidOp "not possible; Filter always returns None" }
-    
+
 module EventCodec =
 
     /// Uses the supplied codec to decode the supplied event record `x` (iff at LogEventLevel.Debug, detail fails to `log` citing the `stream` and content)

--- a/propulsion-tracking-consumer/Ingester.fs
+++ b/propulsion-tracking-consumer/Ingester.fs
@@ -34,7 +34,9 @@ type Stats(log, statsInterval, stateInterval) =
             ok <- 0; skipped <- 0
 
 /// Ingest queued events per sku - each time we handle all the incoming updates for a given stream as a single act
-let ingest (service : SkuSummary.Service) (FsCodec.StreamName.CategoryAndId (_,SkuId.Parse skuId), span : Propulsion.Streams.StreamSpan<_>) : Async<Outcome> = async {
+let ingest
+        (service : SkuSummary.Service)
+        (FsCodec.StreamName.CategoryAndId (_,SkuId.Parse skuId), span : Propulsion.Streams.StreamSpan<_>) : Async<Outcome> = Log.exceptions <| async {
     let items =
         [ for e in span.events do
             let x = Contract.parse e.Data


### PR DESCRIPTION
Propulsion does not do logging of exceptions for failed handling calls (it counts them and gathers latencies only).

While it's technically correct to hence expect folk to Just Do Some Logging, this has proved a common stumbling block, so adding this boilerplate as a a starter.

This adds lightweight placeholder logging to the templates, though its recommended that it be replaced with relevant domain-specific logging instead