### PR TITLE
proProjector: EventStoreDB support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ The `Unreleased` section name is replaced by the expected version of next releas
 ## [Unreleased]
 
 ### Added
+
+- `proProjector`: Add EventStore source [#73](https://github.com/jet/dotnet-templates/pull/73) 
+
 ### Changed
 
 - Cleanup `eqxShipping` [#71](https://github.com/jet/dotnet-templates/pull/71) 

--- a/README.md
+++ b/README.md
@@ -16,8 +16,8 @@ The following templates focus specifically on the usage of `Propulsion` componen
 
 - [`proProjector`](propulsion-projector/README.md) - Boilerplate for a Publisher application with support for consuming events from one of:
   
-  * `-s cosmos`: an Azure CosmosDb ChangeFeedProcessor (typically unrolling events from `Equinox.Cosmos` stores using `Propulsion.Cosmos`)
-  * `-s eventStore`: EventStoreDB's `$all` feed
+  * `--source cosmos`: an Azure CosmosDb ChangeFeedProcessor (typically unrolling events from `Equinox.Cosmos` stores using `Propulsion.Cosmos`)
+  * `--source eventStore`: EventStoreDB's `$all` feed
 
   `-k` adds publishing to Apache Kafka using [`Propulsion.Kafka`](https://github.com/jet/propulsion).
   

--- a/README.md
+++ b/README.md
@@ -14,16 +14,18 @@ These templates focus solely on Consistent Processing using Equinox Stores:
 
 The following templates focus specifically on the usage of `Propulsion` components:
 
-- [`proProjector`](propulsion-projector/README.md) - Boilerplate for a Publisher application with support for consuming events from one of:
-  
-  * `--source cosmos`: an Azure CosmosDb ChangeFeedProcessor (typically unrolling events from `Equinox.Cosmos` stores using `Propulsion.Cosmos`)
-  * `--source eventStore`: EventStoreDB's `$all` feed
+- [`proProjector`](propulsion-projector/README.md) - Boilerplate for a Publisher application that
 
-  `-k` adds publishing to Apache Kafka using [`Propulsion.Kafka`](https://github.com/jet/propulsion).
+  * consumes events from one of:
   
-  * `-p` schedule processing to operate in parallel at message (rather than stream) level
+    * `--source cosmos`: an Azure CosmosDb ChangeFeedProcessor (typically unrolling events from `Equinox.Cosmos` stores using `Propulsion.Cosmos`)
+    * `--source eventStore`: EventStoreDB's `$all` feed
 
-- [`proConsumer`](propulsion-consumer/README.md) - Boilerplate for an Apache Kafka Consumer using [`Propulsion.Kafka`](https://github.com/jet/propulsion). (typically consuming from an app produced with `dotnet new proProjector -k`)
+  * `-k` adds publishing to Apache Kafka using [`Propulsion.Kafka`](https://github.com/jet/propulsion).
+  
+  * `-k -p` schedule kafka processing to operate in parallel at document (rather than accumulated span of events for a stream) level
+
+- [`proConsumer`](propulsion-consumer/README.md) - Boilerplate for an Apache Kafka Consumer using [`Propulsion.Kafka`](https://github.com/jet/propulsion) (typically consuming from an app produced with `dotnet new proProjector -k`).
 
 ## Producer/Reactor Templates combining usage of Equinox and Propulsion
 

--- a/README.md
+++ b/README.md
@@ -19,12 +19,15 @@ The following templates focus specifically on the usage of `Propulsion` componen
   * consumes events from one of:
   
     * `--source cosmos`: an Azure CosmosDb ChangeFeedProcessor (typically unrolling events from `Equinox.Cosmos` stores using `Propulsion.Cosmos`)
+ 
+      * `-k` adds publishing to Apache Kafka using [`Propulsion.Kafka`](https://github.com/jet/propulsion).
+  
+      * `-k --parallelOnly` schedule kafka processing to operate in parallel at document (rather than accumulated span of events for a stream) level
+
     * `--source eventStore`: EventStoreDB's `$all` feed
 
-  * `-k` adds publishing to Apache Kafka using [`Propulsion.Kafka`](https://github.com/jet/propulsion).
-  
-  * `-k -p` schedule kafka processing to operate in parallel at document (rather than accumulated span of events for a stream) level
-
+      * `-k` adds publishing to Apache Kafka using [`Propulsion.Kafka`](https://github.com/jet/propulsion).
+      
 - [`proConsumer`](propulsion-consumer/README.md) - Boilerplate for an Apache Kafka Consumer using [`Propulsion.Kafka`](https://github.com/jet/propulsion) (typically consuming from an app produced with `dotnet new proProjector -k`).
 
 ## Producer/Reactor Templates combining usage of Equinox and Propulsion

--- a/README.md
+++ b/README.md
@@ -20,13 +20,11 @@ The following templates focus specifically on the usage of `Propulsion` componen
   
     * `--source cosmos`: an Azure CosmosDb ChangeFeedProcessor (typically unrolling events from `Equinox.Cosmos` stores using `Propulsion.Cosmos`)
  
-      * `-k` adds publishing to Apache Kafka using [`Propulsion.Kafka`](https://github.com/jet/propulsion).
-  
       * `-k --parallelOnly` schedule kafka processing to operate in parallel at document (rather than accumulated span of events for a stream) level
 
     * `--source eventStore`: EventStoreDB's `$all` feed
 
-      * `-k` adds publishing to Apache Kafka using [`Propulsion.Kafka`](https://github.com/jet/propulsion).
+  * `-k` adds publishing to Apache Kafka using [`Propulsion.Kafka`](https://github.com/jet/propulsion).
       
 - [`proConsumer`](propulsion-consumer/README.md) - Boilerplate for an Apache Kafka Consumer using [`Propulsion.Kafka`](https://github.com/jet/propulsion) (typically consuming from an app produced with `dotnet new proProjector -k`).
 

--- a/README.md
+++ b/README.md
@@ -14,11 +14,14 @@ These templates focus solely on Consistent Processing using Equinox Stores:
 
 The following templates focus specifically on the usage of `Propulsion` components:
 
-- [`proProjector`](propulsion-projector/README.md) - Boilerplate for an Azure CosmosDb ChangeFeedProcessor (typically unrolling events from `Equinox.Cosmos` stores using `Propulsion.Cosmos`)
-
-  `-k` adds Optional projection to Apache Kafka using [`Propulsion.Kafka`](https://github.com/jet/propulsion).
+- [`proProjector`](propulsion-projector/README.md) - Boilerplate for a Publisher application with support for consuming events from one of:
   
-  `-p` shows parallel consumption mode (where source is not stream-oriented; i.e. is not from `Equinox.Cosmos`)
+  * `-s cosmos`: an Azure CosmosDb ChangeFeedProcessor (typically unrolling events from `Equinox.Cosmos` stores using `Propulsion.Cosmos`)
+  * `-s eventStore`: EventStoreDB's `$all` feed
+
+  `-k` adds publishing to Apache Kafka using [`Propulsion.Kafka`](https://github.com/jet/propulsion).
+  
+  * `-p` schedule processing to operate in parallel at message (rather than stream) level
 
 - [`proConsumer`](propulsion-consumer/README.md) - Boilerplate for an Apache Kafka Consumer using [`Propulsion.Kafka`](https://github.com/jet/propulsion). (typically consuming from an app produced with `dotnet new proProjector -k`)
 

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ The following templates focus specifically on the usage of `Propulsion` componen
   
     1. _(default)_ `--source cosmos`: an Azure CosmosDb ChangeFeedProcessor (typically unrolling events from `Equinox.Cosmos` stores using `Propulsion.Cosmos`)
  
-       * `-k --parallelOnly` schedule kafka processing to operate in parallel at document (rather than accumulated span of events for a stream) level
+       * `-k --parallelOnly` schedule kafka emission to operate in parallel at document (rather than accumulated span of events for a stream) level
 
     2. `--source eventStore`: EventStoreDB's `$all` feed
 

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ The following templates focus specifically on the usage of `Propulsion` componen
   
     1. _(default)_ `--source cosmos`: an Azure CosmosDb ChangeFeedProcessor (typically unrolling events from `Equinox.Cosmos` stores using `Propulsion.Cosmos`)
  
-      * `-k --parallelOnly` schedule kafka processing to operate in parallel at document (rather than accumulated span of events for a stream) level
+       * `-k --parallelOnly` schedule kafka processing to operate in parallel at document (rather than accumulated span of events for a stream) level
 
     2. `--source eventStore`: EventStoreDB's `$all` feed
 

--- a/README.md
+++ b/README.md
@@ -18,11 +18,11 @@ The following templates focus specifically on the usage of `Propulsion` componen
 
   * consumes events from one of:
   
-    * `--source cosmos`: an Azure CosmosDb ChangeFeedProcessor (typically unrolling events from `Equinox.Cosmos` stores using `Propulsion.Cosmos`)
+    1. _(default)_ `--source cosmos`: an Azure CosmosDb ChangeFeedProcessor (typically unrolling events from `Equinox.Cosmos` stores using `Propulsion.Cosmos`)
  
       * `-k --parallelOnly` schedule kafka processing to operate in parallel at document (rather than accumulated span of events for a stream) level
 
-    * `--source eventStore`: EventStoreDB's `$all` feed
+    2. `--source eventStore`: EventStoreDB's `$all` feed
 
   * `-k` adds publishing to Apache Kafka using [`Propulsion.Kafka`](https://github.com/jet/propulsion).
       

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -4,13 +4,11 @@ jobs:
   pool:
     vmImage: 'windows-latest'
   steps:
-  - script: dotnet pack build.proj
-    displayName: dotnet pack build.proj
+  - script: dotnet build build.proj -v n
+    displayName: dotnet pack + test
     env:
       BUILD_PR: $(SYSTEM.PULLREQUEST.PULLREQUESTNUMBER)
-      BUILD_ID: $(BUILD.BUILDNUMBER) 
-  - script: dotnet test build.proj
-    displayName: dotnet test build.proj -v n
+      BUILD_ID: $(BUILD.BUILDNUMBER)
   - task: PublishTestResults@2
     inputs:
       testResultsFormat: 'VSTest'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -4,7 +4,8 @@ jobs:
   pool:
     vmImage: 'windows-latest'
   steps:
-  - script: dotnet build build.proj -v n
+  # for this repo, `dotnet test` implies pack as it validates the .nupkg file
+  - script: dotnet test build.proj -v n
     displayName: dotnet pack + test
     env:
       BUILD_PR: $(SYSTEM.PULLREQUEST.PULLREQUESTNUMBER)

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -10,7 +10,7 @@ jobs:
       BUILD_PR: $(SYSTEM.PULLREQUEST.PULLREQUESTNUMBER)
       BUILD_ID: $(BUILD.BUILDNUMBER) 
   - script: dotnet test build.proj
-    displayName: dotnet build build.proj -v n
+    displayName: dotnet test build.proj -v n
   - task: PublishTestResults@2
     inputs:
       testResultsFormat: 'VSTest'

--- a/build.proj
+++ b/build.proj
@@ -18,7 +18,8 @@
     <Exec Command="dotnet pack src/Equinox.Templates $(Cfg) $(PackOptions)" />
   </Target>
 
-  <Target Name="VSTest">
+  <!-- NOTE The tests unpack the nupkg-->
+  <Target Name="VSTest" DependsOnTargets="Pack">
     <Exec Command="dotnet test tests/Equinox.Templates.Tests $(Cfg) $(TestOptions)" />
   </Target>
 

--- a/build.proj
+++ b/build.proj
@@ -23,6 +23,4 @@
     <Exec Command="dotnet test tests/Equinox.Templates.Tests $(Cfg) $(TestOptions)" />
   </Target>
 
-  <Target Name="Build" DependsOnTargets="Pack;VSTest" />
-
 </Project>

--- a/propulsion-projector/.template.config/template.json
+++ b/propulsion-projector/.template.config/template.json
@@ -8,6 +8,7 @@
     "CosmosDb",
     "ChangeFeed",
     "ChangeFeedProcessor",
+    "EventStore",
     "Kafka"
   ],
   "tags": {
@@ -20,6 +21,30 @@
   "preferNameDirectory": true,
 
   "symbols": {
+    "source": {
+      "type": "parameter",
+      "defaultValue": "cosmos",
+      "description": "Define source the app is to be wired up for",
+      "datatype": "choice",
+      "choices": [
+        {
+          "choice": "cosmos",
+          "description": "Wire for CosmosDB ChangeFeedProcessor source"
+        },
+        {
+          "choice": "eventStore",
+          "description": "Wire for EventStoreDB $all source"
+        }
+      ]
+    },
+    "esdb": {
+      "type": "computed",
+      "value": "(source == \"eventStore\")"
+    },
+    "cosmos": {
+      "type": "computed",
+      "value": "(source == \"cosmos\")"
+    },
     "kafka": {
       "type": "parameter",
       "datatype": "bool",

--- a/propulsion-projector/Handler.fs
+++ b/propulsion-projector/Handler.fs
@@ -18,7 +18,8 @@ let mapToStreamItems (docs : Microsoft.Azure.Documents.Document seq) : Propulsio
     // TODO use Seq.filter and/or Seq.map to adjust what's being sent etc
     // |> Seq.map hackDropBigBodies
 #endif // !parallelOnly
-#else // !cosmos
+#endif // cosmos
+//#if esdb
 open Propulsion.EventStore
 
 /// Responsible for inspecting and then either dropping or tweaking events coming from EventStore
@@ -27,7 +28,7 @@ let tryMapEvent filterByStreamName (x : EventStore.ClientAPI.ResolvedEvent) =
     match x.Event with
     | e when not e.IsJson || e.EventStreamId.StartsWith "$" || not (filterByStreamName e.EventStreamId) -> None
     | PropulsionStreamEvent e -> Some e
-#endif // !cosmos
+//#endif // esdb
 
 #if kafka
 #if     (cosmos && parallelOnly) // kafka && cosmos && parallelOnly

--- a/propulsion-projector/Handler.fs
+++ b/propulsion-projector/Handler.fs
@@ -22,7 +22,7 @@ let mapToStreamItems (docs : Microsoft.Azure.Documents.Document seq) : Propulsio
 open Propulsion.EventStore
 
 /// Responsible for inspecting and then either dropping or tweaking events coming from EventStore
-// NB the `index` needs to be contiguous with existing events - IOW filtering needs to be at stream (and not event) level
+// NB the `Index` needs to be contiguous with existing events - IOW filtering needs to be at stream (and not event) level
 let tryMapEvent filterByStreamName (x : EventStore.ClientAPI.ResolvedEvent) =
     match x.Event with
     | e when not e.IsJson || e.EventStreamId.StartsWith "$" || not (filterByStreamName e.EventStreamId) -> None

--- a/propulsion-projector/Handler.fs
+++ b/propulsion-projector/Handler.fs
@@ -3,7 +3,7 @@ module ProjectorTemplate.Handler
 #if cosmos
 #if     parallelOnly
 // Here we pass the items directly through to the handler without parsing them
-let mapToStreamItems (x : System.Collections.Generic.IReadOnlyList<'a>) : seq<'a> = upcast
+let mapToStreamItems (x : System.Collections.Generic.IReadOnlyList<'a>) : seq<'a> = upcast x
 #else // cosmos && !parallelOnly
 //let replaceLongDataWithNull (x : FsCodec.ITimelineEvent<byte[]>) : FsCodec.ITimelineEvent<_> =
 //    if x.Data.Length < 900_000 then x

--- a/propulsion-projector/Handler.fs
+++ b/propulsion-projector/Handler.fs
@@ -1,6 +1,6 @@
 module ProjectorTemplate.Handler
-#if cosmos
 
+#if cosmos
 #if     parallelOnly
 // Here we pass the items directly through to the handler without parsing them
 let mapToStreamItems (x : System.Collections.Generic.IReadOnlyList<'a>) : seq<'a> = upcast
@@ -27,7 +27,6 @@ let tryMapEvent filterByStreamName (x : EventStore.ClientAPI.ResolvedEvent) =
     match x.Event with
     | e when not e.IsJson || e.EventStreamId.StartsWith "$" || not (filterByStreamName e.EventStreamId) -> None
     | PropulsionStreamEvent e -> Some e
-
 #endif // !cosmos
 
 #if kafka

--- a/propulsion-projector/Handler.fs
+++ b/propulsion-projector/Handler.fs
@@ -7,19 +7,23 @@ module ProjectorTemplate.Handler
 //let hackDropBigBodies (e : Propulsion.Streams.StreamEvent<_>) : Propulsion.Streams.StreamEvent<_> =
 //    { stream = e.stream; event = replaceLongDataWithNull e.event }
 
+#if cosmos
 let mapToStreamItems (docs : Microsoft.Azure.Documents.Document seq) : Propulsion.Streams.StreamEvent<_> seq =
     docs
     |> Seq.collect  Propulsion.Cosmos.EquinoxCosmosParser.enumStreamEvents
     // TODO use Seq.filter and/or Seq.map to adjust what's being sent etc
     // |> Seq.map hackDropBigBodies
+#endif
 
 #if kafka
 #if     parallelOnly
 type ExampleOutput = { Id : string }
 
+#if         cosmos
 let render (doc : Microsoft.Azure.Documents.Document) : string * string =
     let equinoxPartition, documentId = doc.GetPropertyValue "p", doc.Id
     equinoxPartition, FsCodec.NewtonsoftJson.Serdes.Serialize { Id = documentId }
+#endif
 #else
 // Each outcome from `handle` is passed to `HandleOk` or `HandleExn` by the scheduler, DumpStats is called at `statsInterval`
 // The incoming calls are all sequential - the logic does not need to consider concurrent incoming calls

--- a/propulsion-projector/Handler.fs
+++ b/propulsion-projector/Handler.fs
@@ -2,7 +2,7 @@ module ProjectorTemplate.Handler
 #if cosmos
 
 #if     parallelOnly
-let mapToStreamItems = id
+let mapToStreamItems : seq<'a> -> IReadOnlyList<'a> = upcast
 #else // cosmos && !parallelOnly
 //let replaceLongDataWithNull (x : FsCodec.ITimelineEvent<byte[]>) : FsCodec.ITimelineEvent<_> =
 //    if x.Data.Length < 900_000 then x

--- a/propulsion-projector/Handler.fs
+++ b/propulsion-projector/Handler.fs
@@ -2,7 +2,8 @@ module ProjectorTemplate.Handler
 #if cosmos
 
 #if     parallelOnly
-let mapToStreamItems : seq<'a> -> IReadOnlyList<'a> = upcast
+// Here we pass the items directly through to the handler without parsing them
+let mapToStreamItems (x : System.Collections.Generic.IReadOnlyList<'a>) : seq<'a> = upcast
 #else // cosmos && !parallelOnly
 //let replaceLongDataWithNull (x : FsCodec.ITimelineEvent<byte[]>) : FsCodec.ITimelineEvent<_> =
 //    if x.Data.Length < 900_000 then x

--- a/propulsion-projector/Program.fs
+++ b/propulsion-projector/Program.fs
@@ -1,4 +1,4 @@
-module ProjectorTemplate.Program
+﻿module ProjectorTemplate.Program
 
 #if cosmos
 open Propulsion.Cosmos
@@ -44,6 +44,11 @@ module Args =
     let private defaultWithEnvVar varName argName = function
         | None -> getEnvVarForArgumentOrThrow varName argName
         | Some x -> x
+#if !cosmos
+    let private isEnvVarTrue varName =
+         EnvVar.tryGet varName |> Option.exists (fun s -> String.Equals(s, bool.TrueString, StringComparison.OrdinalIgnoreCase))
+    let private seconds (x : TimeSpan) = x.TotalSeconds
+#endif
     open Argu
 #if cosmos
     type [<NoEquality; NoComparison>] CosmosParameters =
@@ -101,6 +106,140 @@ module Args =
                 (let t = x.Timeout in t.TotalSeconds), x.Retries, (let t = x.MaxRetryWaitTime in t.TotalSeconds))
             let connector = Connector(x.Timeout, x.Retries, x.MaxRetryWaitTime, Log.Logger, mode=x.Mode)
             discovery, { database = x.Database; container = x.Container }, connector
+#else
+    open Equinox.EventStore
+    type [<NoEquality; NoComparison>] EsSourceParameters =
+        | [<AltCommandLine "-Z"; Unique>]   FromTail
+        | [<AltCommandLine "-g"; Unique>]   Gorge of int
+        | [<AltCommandLine "-t"; Unique>]   Tail of intervalS: float
+        | [<AltCommandLine "--force"; Unique>] ForceRestart
+        | [<AltCommandLine "-m"; Unique>]   BatchSize of int
+        | [<AltCommandLine "-mim"; Unique>] MinBatchSize of int
+        | [<AltCommandLine "-pos"; Unique>] Position of int64
+        | [<AltCommandLine "-c"; Unique>]   Chunk of int
+        | [<AltCommandLine "-pct"; Unique>] Percent of float
+
+        | [<AltCommandLine "-V">]           Verbose
+        | [<AltCommandLine "-o">]           Timeout of float
+        | [<AltCommandLine "-r">]           Retries of int
+        | [<AltCommandLine "-oh">]          HeartbeatTimeout of float
+        | [<AltCommandLine "-T">]           Tcp
+        | [<AltCommandLine "-h">]           Host of string
+        | [<AltCommandLine "-x">]           Port of int
+        | [<AltCommandLine "-u">]           Username of string
+        | [<AltCommandLine "-p">]           Password of string
+        | [<AltCommandLine "-Tp">]          ProjTcp
+        | [<AltCommandLine "-hp">]          ProjHost of string
+        | [<AltCommandLine "-xp">]          ProjPort of int
+        | [<AltCommandLine "-up">]          ProjUsername of string
+        | [<AltCommandLine "-pp">]          ProjPassword of string
+
+        | [<CliPrefix(CliPrefix.None); Unique(*ExactlyOnce is not supported*); Last>] Cosmos of ParseResults<CosmosParameters>
+        interface IArgParserTemplate with
+            member a.Usage = a |> function
+                | FromTail ->               "Start the processing from the Tail"
+                | Gorge _ ->                "Request Parallel readers phase during initial catchup, running one chunk (256MB) apart. Default: off"
+                | Tail _ ->                 "attempt to read from tail at specified interval in Seconds. Default: 1"
+                | ForceRestart _ ->         "Forget the current committed position; start from (and commit) specified position. Default: start from specified position or resume from committed."
+                | BatchSize _ ->            "maximum item count to request from feed. Default: 4096"
+                | MinBatchSize _ ->         "minimum item count to drop down to in reaction to read failures. Default: 512"
+                | Position _ ->             "EventStore $all Stream Position to commence from"
+                | Chunk _ ->                "EventStore $all Chunk to commence from"
+                | Percent _ ->              "EventStore $all Stream Position to commence from (as a percentage of current tail position)"
+
+                | Verbose ->                "Include low level Store logging."
+                | Tcp ->                    "Request connecting EventStore direct to a TCP/IP endpoint. Default: Use Clustered mode with Gossip-driven discovery (unless environment variable EQUINOX_ES_TCP specifies 'true')."
+                | Host _ ->                 "TCP mode: specify EventStore hostname to connect to directly. Clustered mode: use Gossip protocol against all A records returned from DNS query. (optional if environment variable EQUINOX_ES_HOST specified)"
+                | Port _ ->                 "specify EventStore custom port. Uses value of environment variable EQUINOX_ES_PORT if specified. Defaults for Cluster and Direct TCP/IP mode are 30778 and 1113 respectively."
+                | Username _ ->             "specify username for EventStore. (optional if environment variable EQUINOX_ES_USERNAME specified)"
+                | Password _ ->             "specify Password for EventStore. (optional if environment variable EQUINOX_ES_PASSWORD specified)"
+                | ProjTcp ->                "Request connecting Projection EventStore direct to a TCP/IP endpoint. Default: Use Clustered mode with Gossip-driven discovery (unless environment variable EQUINOX_ES_PROJ_TCP specifies 'true')."
+                | ProjHost _ ->             "TCP mode: specify Projection EventStore hostname to connect to directly. Clustered mode: use Gossip protocol against all A records returned from DNS query. Defaults to value of es host (-h) unless environment variable EQUINOX_ES_PROJ_HOST is specified."
+                | ProjPort _ ->             "specify Projection EventStore custom port. Defaults to value of es port (-x) unless environment variable EQUINOX_ES_PROJ_PORT is specified."
+                | ProjUsername _ ->         "specify username for Projection EventStore. Defaults to value of es user (-u) unless environment variable EQUINOX_ES_PROJ_USERNAME is specified."
+                | ProjPassword _ ->         "specify Password for Projection EventStore. Defaults to value of es password (-p) unless environment variable EQUINOX_ES_PROJ_PASSWORD is specified."
+                | Timeout _ ->              "specify operation timeout in seconds. Default: 20."
+                | Retries _ ->              "specify operation retries. Default: 3."
+                | HeartbeatTimeout _ ->     "specify heartbeat timeout in seconds. Default: 1.5."
+
+                | Cosmos _ ->               "CosmosDB (Checkpoint) Store parameters."
+    and EsSourceArguments(a : ParseResults<EsSourceParameters>) =
+        let discovery (host, port, tcp) =
+            match tcp, port with
+            | false, None ->   Discovery.GossipDns            host
+            | false, Some p -> Discovery.GossipDnsCustomPort (host, p)
+            | true, None ->    Discovery.Uri                 (UriBuilder("tcp", host, 1113).Uri)
+            | true, Some p ->  Discovery.Uri                 (UriBuilder("tcp", host, p).Uri)
+        member __.Gorge =                   a.TryGetResult Gorge
+        member __.TailInterval =            a.GetResult(Tail, 1.) |> TimeSpan.FromSeconds
+        member __.ForceRestart =            a.Contains ForceRestart
+        member __.StartingBatchSize =       a.GetResult(BatchSize, 4096)
+        member __.MinBatchSize =            a.GetResult(MinBatchSize, 512)
+        member __.StartPos =
+            match a.TryGetResult Position, a.TryGetResult Chunk, a.TryGetResult Percent, a.Contains EsSourceParameters.FromTail with
+            | Some p, _, _, _ ->            Absolute p
+            | _, Some c, _, _ ->            StartPos.Chunk c
+            | _, _, Some p, _ ->            Percentage p
+            | None, None, None, true ->     StartPos.TailOrCheckpoint
+            | None, None, None, _ ->        StartPos.StartOrCheckpoint
+        member __.Tcp =                     a.Contains Tcp || isEnvVarTrue "EQUINOX_ES_TCP"
+        member __.Port =                    match a.TryGetResult Port with Some x -> Some x | None -> EnvVar.tryGet "EQUINOX_ES_PORT" |> Option.map int
+        member __.Host =                    a.TryGetResult Host     |> defaultWithEnvVar "EQUINOX_ES_HOST"     "Host"
+        member __.User =                    a.TryGetResult Username |> defaultWithEnvVar "EQUINOX_ES_USERNAME" "Username"
+        member __.Password =                a.TryGetResult Password |> defaultWithEnvVar "EQUINOX_ES_PASSWORD" "Password"
+        member __.Retries =                 a.GetResult(EsSourceParameters.Retries, 3)
+        member __.Timeout =                 a.GetResult(EsSourceParameters.Timeout, 20.) |> TimeSpan.FromSeconds
+        member __.Heartbeat =               a.GetResult(HeartbeatTimeout, 1.5) |> TimeSpan.FromSeconds
+
+        member x.Connect(log: ILogger, storeLog: ILogger, appName, nodePreference) =
+            let discovery = discovery (x.Host, x.Port, x.Tcp)
+            log.ForContext("host", x.Host).ForContext("port", x.Port)
+                .Information("EventStore {discovery} heartbeat: {heartbeat}s Timeout: {timeout}s Retries {retries}",
+                    discovery, seconds x.Heartbeat, seconds x.Timeout, x.Retries)
+            let log=if storeLog.IsEnabled Serilog.Events.LogEventLevel.Debug then Logger.SerilogVerbose storeLog else Logger.SerilogNormal storeLog
+            let tags=["M", Environment.MachineName; "I", Guid.NewGuid() |> string]
+            Connector(x.User, x.Password, x.Timeout, x.Retries, log=log, heartbeatTimeout=x.Heartbeat, tags=tags)
+                .Connect(appName, discovery, nodePreference) |> Async.RunSynchronously
+
+        member __.CheckpointInterval =  TimeSpan.FromHours 1.
+        member val Cosmos : CosmosArguments =
+            match a.TryGetSubCommand() with
+            | Some (EsSourceParameters.Cosmos cosmos) -> CosmosArguments cosmos
+            | _ -> raise (MissingArg "Must specify `cosmos` checkpoint store when source is `es`")
+    and [<NoEquality; NoComparison>] CosmosParameters =
+        | [<AltCommandLine "-s">]           Connection of string
+        | [<AltCommandLine "-m">]           ConnectionMode of Equinox.Cosmos.ConnectionMode
+        | [<AltCommandLine "-d">]           Database of string
+        | [<AltCommandLine "-c">]           Container of string
+        | [<AltCommandLine "-o">]           Timeout of float
+        | [<AltCommandLine "-r">]           Retries of int
+        | [<AltCommandLine "-rt">]          RetriesWaitTime of float
+        interface IArgParserTemplate with
+            member a.Usage =
+                match a with
+                | ConnectionMode _ ->       "override the connection mode. Default: Direct."
+                | Connection _ ->           "specify a connection string for a Cosmos account. (optional if environment variable EQUINOX_COSMOS_CONNECTION specified)"
+                | Database _ ->             "specify a database name for Cosmos store. (optional if environment variable EQUINOX_COSMOS_DATABASE specified)"
+                | Container _ ->            "specify a container name for Cosmos store. (optional if environment variable EQUINOX_COSMOS_CONTAINER specified)"
+                | Timeout _ ->              "specify operation timeout in seconds. Default: 5."
+                | Retries _ ->              "specify operation retries. Default: 1."
+                | RetriesWaitTime _ ->      "specify max wait-time for retry when being throttled by Cosmos in seconds. Default: 5."
+    and CosmosArguments(a : ParseResults<CosmosParameters>) =
+        member __.Mode =                    a.GetResult(CosmosParameters.ConnectionMode, Equinox.Cosmos.ConnectionMode.Direct)
+        member __.Connection =              a.TryGetResult CosmosParameters.Connection |> defaultWithEnvVar "EQUINOX_COSMOS_CONNECTION" "Connection"
+        member __.Database =                a.TryGetResult CosmosParameters.Database   |> defaultWithEnvVar "EQUINOX_COSMOS_DATABASE"   "Database"
+        member __.Container =               a.TryGetResult CosmosParameters.Container  |> defaultWithEnvVar "EQUINOX_COSMOS_CONTAINER"  "Container"
+        member __.Timeout =                 a.GetResult(CosmosParameters.Timeout, 5.) |> TimeSpan.FromSeconds
+        member __.Retries =                 a.GetResult(CosmosParameters.Retries, 1)
+        member __.MaxRetryWaitTime =        a.GetResult(CosmosParameters.RetriesWaitTime, 5.) |> TimeSpan.FromSeconds
+        member x.BuildConnectionDetails() =
+            let (Equinox.Cosmos.Discovery.UriAndKey (endpointUri, _) as discovery) = Equinox.Cosmos.Discovery.FromConnectionString x.Connection
+            Log.Information("CosmosDb {mode} {endpointUri} Database {database} Container {container}",
+                x.Mode, endpointUri, x.Database, x.Container)
+            Log.Information("CosmosDb timeout {timeout}s; Throttling retries {retries}, max wait {maxRetryWaitTime}s",
+                (let t = x.Timeout in t.TotalSeconds), x.Retries, (let t = x.MaxRetryWaitTime in t.TotalSeconds))
+            let connector = Equinox.Cosmos.Connector(x.Timeout, x.Retries, x.MaxRetryWaitTime, Log.Logger, mode=x.Mode)
+            discovery, x.Database, x.Container, connector
 #endif
 
     [<NoEquality; NoComparison>]
@@ -116,6 +255,8 @@ module Args =
 //#endif
 #if cosmos
         | [<CliPrefix(CliPrefix.None); Last>] Cosmos of ParseResults<CosmosParameters>
+#else
+        | [<CliPrefix(CliPrefix.None); Last>] Es of ParseResults<EsSourceParameters>
 #endif
         interface IArgParserTemplate with
             member a.Usage =
@@ -130,6 +271,8 @@ module Args =
 //#endif
 #if cosmos
                 | Cosmos _ ->               "specify CosmosDb input parameters"
+#else
+                | Es _ ->                   "specify EventStore input parameters."
 #endif
     and Arguments(a : ParseResults<Parameters>) =
         member __.Verbose =                 a.Contains Verbose
@@ -152,6 +295,19 @@ module Args =
             if c.FromTail then Log.Warning("(If new projector group) Skipping projection of all existing events.")
             c.LagFrequency |> Option.iter (fun s -> Log.Information("Dumping lag stats at {lagS:n0}s intervals", s.TotalSeconds))
             { database = c.Database; container = c.AuxContainerName }, __.ConsumerGroupName, c.FromTail, c.MaxDocuments, c.LagFrequency
+#else // esdb
+        member val Es =                     EsSourceArguments(a.GetResult Es)
+        member __.BuildEventStoreParams() =
+            let srcE = __.Es
+            let startPos, cosmos = srcE.StartPos, srcE.Cosmos
+            Log.Information("Processing Consumer Group {groupName} from {startPos} (force: {forceRestart}) in Database {db} Container {container}",
+                __.ConsumerGroupName, startPos, srcE.ForceRestart, cosmos.Database, cosmos.Container)
+            Log.Information("Ingesting in batches of [{minBatchSize}..{batchSize}], reading up to {maxReadAhead} uncommitted batches ahead",
+                srcE.MinBatchSize, srcE.StartingBatchSize, __.MaxReadAhead)
+            srcE, cosmos,
+                {   groupName = __.ConsumerGroupName; start = startPos; checkpointInterval = srcE.CheckpointInterval; tailInterval = srcE.TailInterval
+                    forceRestart = srcE.ForceRestart
+                    batchSize = srcE.StartingBatchSize; minBatchSize = srcE.MinBatchSize; gorge = srcE.Gorge; streamReaders = 0 }
 #endif
 //#if kafka
         member val Target =                 TargetInfo a
@@ -195,28 +351,47 @@ module Logging =
             |> fun c -> let t = "[{Timestamp:HH:mm:ss} {Level:u3}] {partitionKeyRangeId,2} {Message:lj} {NewLine}{Exception}"
                         c.WriteTo.Console(theme=Sinks.SystemConsole.Themes.AnsiConsoleTheme.Code, outputTemplate=t)
             |> fun c -> c.CreateLogger()
+#if !cosmos
+
+module Checkpoints =
+
+    // In this implementation, we keep the checkpoints in Cosmos when consuming from EventStore
+    module Cosmos =
+
+        let codec = FsCodec.NewtonsoftJson.Codec.Create<Checkpoint.Events.Event>()
+        let access = Equinox.Cosmos.AccessStrategy.Custom (Checkpoint.Fold.isOrigin, Checkpoint.Fold.transmute)
+        let create groupName (context, cache) =
+            let caching = Equinox.Cosmos.CachingStrategy.SlidingWindow (cache, TimeSpan.FromMinutes 20.)
+            let resolver = Equinox.Cosmos.Resolver(context, codec, Checkpoint.Fold.fold, Checkpoint.Fold.initial, caching, access)
+            let resolve streamName = resolver.Resolve(streamName, Equinox.AllowStale)
+            Checkpoint.CheckpointSeries(groupName, resolve)
+
+module CosmosContext =
+
+    let create appName (connector : Equinox.Cosmos.Connector) discovery (database, container) =
+        let connection = connector.Connect(appName, discovery) |> Async.RunSynchronously
+        Equinox.Cosmos.Context(connection, database, container)
+#endif
 
 let [<Literal>] AppName = "ProjectorTemplate"
 
 let build (args : Args.Arguments) =
     let maxReadAhead, maxConcurrentStreams = args.BuildProcessorParams()
-#if cosmos
-#if     kafka
+#if cosmos // cosmos
+#if     kafka // cosmos && kafka
     let (broker, topic) = args.Target.BuildTargetParams()
     let producer = Propulsion.Kafka.Producer(Log.Logger, AppName, broker, topic)
-#if         parallelOnly
+#if         parallelOnly // cosmos && kafka && parallelOnly
     let sink = Propulsion.Kafka.ParallelProducerSink.Start(maxReadAhead, maxConcurrentStreams, Handler.render, producer, args.StatsInterval)
-    let createObserver () = CosmosSource.CreateObserver(Log.Logger, sink.StartIngester, fun x -> upcast x)
-#else
+#else // cosmos && kafka && !parallelOnly
     let stats = Handler.ProductionStats(Log.Logger, args.StatsInterval, args.StateInterval)
     let sink = Propulsion.Kafka.StreamsProducerSink.Start(Log.Logger, maxReadAhead, maxConcurrentStreams, Handler.render, producer, stats, args.StatsInterval)
-    let createObserver () = CosmosSource.CreateObserver(Log.Logger, sink.StartIngester, Handler.mapToStreamItems)
-#endif
-#else
+#endif // cosmos && kafka && !parallelOnly
+#else // cosmos && !kafka
     let stats = Handler.ProjectorStats(Log.Logger, args.StatsInterval, args.StateInterval)
     let sink = Propulsion.Streams.StreamsProjector.Start(Log.Logger, maxReadAhead, maxConcurrentStreams, Handler.handle, stats, args.StatsInterval)
+#endif // cosmos && !kafka
     let createObserver () = CosmosSource.CreateObserver(Log.Logger, sink.StartIngester, Handler.mapToStreamItems)
-#endif
     let runSourcePipeline =
         let discovery, source, connector = args.Cosmos.BuildConnectionDetails()
         let aux, leaseId, startFromTail, maxDocuments, lagFrequency = args.BuildChangeFeedParams()
@@ -224,10 +399,34 @@ let build (args : Args.Arguments) =
             Log.Logger, connector.CreateClient(AppName, discovery), source,
             aux, leaseId, startFromTail, createObserver,
             ?maxDocuments=maxDocuments, ?lagReportFreq=lagFrequency)
+#else // !cosmos => i.e., esdb
+    let (srcE, cosmos, spec) = args.BuildEventStoreParams()
+
+    let connectEs () = srcE.Connect(Log.Logger, Log.Logger, AppName, Equinox.EventStore.NodePreference.Master)
+    let (discovery, database, container, connector) = cosmos.BuildConnectionDetails()
+
+    let context = CosmosContext.create AppName connector discovery (database, container)
+    let cache = Equinox.Cache(AppName, sizeMb=10)
+
+    let checkpoints = Checkpoints.Cosmos.create spec.groupName (context, cache)
+
+#if     kafka // !cosmos && kafka
+    let (broker, topic) = args.Target.BuildTargetParams()
+    let producer = Propulsion.Kafka.Producer(Log.Logger, AppName, broker, topic)
+    let stats = Handler.ProductionStats(Log.Logger, args.StatsInterval, args.StateInterval)
+    let sink = Propulsion.Kafka.StreamsProducerSink.Start(Log.Logger, maxReadAhead, maxConcurrentStreams, Handler.render, producer, stats, args.StatsInterval)
+#else // !cosmos && !kafka
+    let stats = Handler.ProjectorStats(Log.Logger, args.StatsInterval, args.StateInterval)
+    let sink = Propulsion.Streams.StreamsProjector.Start(Log.Logger, maxReadAhead, maxConcurrentStreams, Handler.handle, stats, args.StatsInterval)
+#endif // !cosmos && !kafka
+    let runSourcePipeline =
+        let filterByStreamName _ = true // see `dotnet new proReactor --filter` for an example of how to rig filtering arguments
+        EventStoreSource.Run(
+            Log.Logger, sink, checkpoints, connectEs, spec, Handler.tryMapEvent filterByStreamName,
+            args.MaxReadAhead, args.StatsInterval)
+#endif // !cosmos
     sink, runSourcePipeline
-#else // esdb
-    Unchecked.defaultof<Propulsion.ProjectorPipeline<_>>, Unchecked.defaultof<_>
-#endif
+
 let run args =
     let sink, runSourcePipeline = build args
     runSourcePipeline |> Async.Start

--- a/propulsion-projector/Program.fs
+++ b/propulsion-projector/Program.fs
@@ -1,7 +1,9 @@
-﻿module ProjectorTemplate.Program
+module ProjectorTemplate.Program
 
 #if cosmos
 open Propulsion.Cosmos
+#else
+open Propulsion.EventStore
 #endif
 open Serilog
 open System

--- a/propulsion-projector/Program.fs
+++ b/propulsion-projector/Program.fs
@@ -1,6 +1,8 @@
 ﻿module ProjectorTemplate.Program
 
+#if cosmos
 open Propulsion.Cosmos
+#endif
 open Serilog
 open System
 
@@ -41,6 +43,7 @@ module Args =
         | None -> getEnvVarForArgumentOrThrow varName argName
         | Some x -> x
     open Argu
+#if cosmos
     type [<NoEquality; NoComparison>] CosmosParameters =
         | [<AltCommandLine "-C"; Unique>]   CfpVerbose
         | [<AltCommandLine "-as"; Unique>]  LeaseContainerSuffix of string
@@ -96,6 +99,7 @@ module Args =
                 (let t = x.Timeout in t.TotalSeconds), x.Retries, (let t = x.MaxRetryWaitTime in t.TotalSeconds))
             let connector = Connector(x.Timeout, x.Retries, x.MaxRetryWaitTime, Log.Logger, mode=x.Mode)
             discovery, { database = x.Database; container = x.Container }, connector
+#endif
 
     [<NoEquality; NoComparison>]
     type Parameters =

--- a/propulsion-projector/Program.fs
+++ b/propulsion-projector/Program.fs
@@ -128,11 +128,6 @@ module Args =
         | [<AltCommandLine "-x">]           Port of int
         | [<AltCommandLine "-u">]           Username of string
         | [<AltCommandLine "-p">]           Password of string
-        | [<AltCommandLine "-Tp">]          ProjTcp
-        | [<AltCommandLine "-hp">]          ProjHost of string
-        | [<AltCommandLine "-xp">]          ProjPort of int
-        | [<AltCommandLine "-up">]          ProjUsername of string
-        | [<AltCommandLine "-pp">]          ProjPassword of string
 
         | [<CliPrefix(CliPrefix.None); Unique(*ExactlyOnce is not supported*); Last>] Cosmos of ParseResults<CosmosParameters>
         interface IArgParserTemplate with
@@ -153,11 +148,6 @@ module Args =
                 | Port _ ->                 "specify EventStore custom port. Uses value of environment variable EQUINOX_ES_PORT if specified. Defaults for Cluster and Direct TCP/IP mode are 30778 and 1113 respectively."
                 | Username _ ->             "specify username for EventStore. (optional if environment variable EQUINOX_ES_USERNAME specified)"
                 | Password _ ->             "specify Password for EventStore. (optional if environment variable EQUINOX_ES_PASSWORD specified)"
-                | ProjTcp ->                "Request connecting Projection EventStore direct to a TCP/IP endpoint. Default: Use Clustered mode with Gossip-driven discovery (unless environment variable EQUINOX_ES_PROJ_TCP specifies 'true')."
-                | ProjHost _ ->             "TCP mode: specify Projection EventStore hostname to connect to directly. Clustered mode: use Gossip protocol against all A records returned from DNS query. Defaults to value of es host (-h) unless environment variable EQUINOX_ES_PROJ_HOST is specified."
-                | ProjPort _ ->             "specify Projection EventStore custom port. Defaults to value of es port (-x) unless environment variable EQUINOX_ES_PROJ_PORT is specified."
-                | ProjUsername _ ->         "specify username for Projection EventStore. Defaults to value of es user (-u) unless environment variable EQUINOX_ES_PROJ_USERNAME is specified."
-                | ProjPassword _ ->         "specify Password for Projection EventStore. Defaults to value of es password (-p) unless environment variable EQUINOX_ES_PROJ_PASSWORD is specified."
                 | Timeout _ ->              "specify operation timeout in seconds. Default: 20."
                 | Retries _ ->              "specify operation retries. Default: 3."
                 | HeartbeatTimeout _ ->     "specify heartbeat timeout in seconds. Default: 1.5."

--- a/propulsion-projector/Projector.fsproj
+++ b/propulsion-projector/Projector.fsproj
@@ -15,13 +15,16 @@
   <ItemGroup>
     <PackageReference Include="Argu" Version="6.0.0" />
     <PackageReference Include="Destructurama.FSharp" Version="1.1.1-dev-00033" />
+    <!--#if esdb-->
+    <PackageReference Include="Equinox.Cosmos" Version="2.1.0" />
+    <!--#endif-->
     <!--#if cosmos-->
     <PackageReference Include="Propulsion.Cosmos" Version="2.6.0" />
     <!--#endif-->
     <!--#if esdb-->
     <PackageReference Include="Propulsion.EventStore" Version="2.6.0" />
     <!--#endif-->
-    <!--#if (kafka)-->
+    <!--#if kafka-->
     <PackageReference Include="Propulsion.Kafka" Version="2.6.0" />
     <!--#endif-->
     <PackageReference Include="Serilog.Sinks.Console" Version="3.1.1" />

--- a/propulsion-projector/Projector.fsproj
+++ b/propulsion-projector/Projector.fsproj
@@ -15,7 +15,12 @@
   <ItemGroup>
     <PackageReference Include="Argu" Version="6.0.0" />
     <PackageReference Include="Destructurama.FSharp" Version="1.1.1-dev-00033" />
+    <!--#if cosmos-->
     <PackageReference Include="Propulsion.Cosmos" Version="2.6.0" />
+    <!--#endif-->
+    <!--#if eventStore-->
+    <PackageReference Include="Propulsion.EventStore" Version="2.6.0" />
+    <!--#endif-->
     <!--#if (kafka)-->
     <PackageReference Include="Propulsion.Kafka" Version="2.6.0" />
     <!--#endif-->

--- a/propulsion-projector/Projector.fsproj
+++ b/propulsion-projector/Projector.fsproj
@@ -15,13 +15,13 @@
   <ItemGroup>
     <PackageReference Include="Argu" Version="6.0.0" />
     <PackageReference Include="Destructurama.FSharp" Version="1.1.1-dev-00033" />
-    <!--#if esdb-->
+    <!--#if (esdb)-->
     <PackageReference Include="Equinox.Cosmos" Version="2.1.0" />
     <!--#endif-->
     <!--#if cosmos-->
     <PackageReference Include="Propulsion.Cosmos" Version="2.6.0" />
     <!--#endif-->
-    <!--#if esdb-->
+    <!--#if (esdb)-->
     <PackageReference Include="Propulsion.EventStore" Version="2.6.0" />
     <!--#endif-->
     <!--#if kafka-->

--- a/propulsion-projector/Projector.fsproj
+++ b/propulsion-projector/Projector.fsproj
@@ -18,7 +18,7 @@
     <!--#if cosmos-->
     <PackageReference Include="Propulsion.Cosmos" Version="2.6.0" />
     <!--#endif-->
-    <!--#if eventStore-->
+    <!--#if esdb-->
     <PackageReference Include="Propulsion.EventStore" Version="2.6.0" />
     <!--#endif-->
     <!--#if (kafka)-->

--- a/propulsion-projector/README.md
+++ b/propulsion-projector/README.md
@@ -1,20 +1,39 @@
-//#if kafka
-# Propulsion CosmosDb -> Kafka Projector
-//#else
-# Propulsion CosmosDb Projector (without Kafka emission)
-//#endif
+//#if cosmos
+//#if   kafka // cosmos && kafka
+# Propulsion CosmosDB -> Kafka Projector
 
 This project was generated using:
-//#if kafka
 
     dotnet new -i Equinox.Templates # just once, to install/update in the local templates store
     dotnet new proProjector -k # -k => include Kafka projection logic
-//#else
+//#else // cosmos && !kafka
+# Propulsion CosmosDB Projector (without Kafka emission)
+
+This project was generated using:
 
     dotnet new -i Equinox.Templates # just once, to install/update in the local templates store
     # add -k to add Kafka Projection logic
     dotnet new proProjector # use --help to see options
-//#endif
+//#endif // cosmos && !kafka
+//#endif // cosmos
+//#if esdb
+//#if   kafka // esdb && kafka
+# Propulsion EventStoreDB -> Kafka Projector
+
+This project was generated using:
+
+    dotnet new -i Equinox.Templates # just once, to install/update in the local templates store
+    dotnet new proProjector -s eventStore -k # -k => include Kafka projection logic
+//#else // esdb && !kafka
+# Propulsion EventStoreDB Projector (without Kafka emission)
+
+This project was generated using:
+
+    dotnet new -i Equinox.Templates # just once, to install/update in the local templates store
+    # add -k to add Kafka Projection logic
+    dotnet new proProjector -s eventStore # use --help to see options
+//#endif // esdb && !kafka
+//#endif // esdb
 
 ## Usage instructions
 
@@ -24,7 +43,8 @@ This project was generated using:
         $env:EQUINOX_COSMOS_DATABASE="equinox-test" # or use -d
         $env:EQUINOX_COSMOS_CONTAINER="equinox-test" # or use -c
 
-1. Use the `eqx` tool to initialize and then run some transactions in a CosmosDb container
+//#if cosmos
+1a. Use the `eqx` tool to initialize and then run some transactions in a CosmosDB container
 
         dotnet tool install -g Equinox.Tool # only needed once
 
@@ -36,15 +56,41 @@ This project was generated using:
         # (either add environment variables as per step 0 or use -s/-d/-c to specify them)
         # `-t saveforlater` SaveForLater test produces uniform size events to project
         # `-C -f 200` constrains current writers to 100 and applies caching so RU consumption is constrained such that an allocation of 1000 is sufficient
-        eqx run -t saveforlater -C -f 100 cosmos 
-//#if kafka
+        eqx run -t saveforlater -C -f 100 cosmos
 
+1b. We'll be operating a ChangeFeedProcessor, so use `propulsion init` to make a `-aux` container (unless there already is one)
+
+        dotnet tool install -g Propulsion.Tool
+        
+        # (either add environment variables as per step 0 or use -s/-d/-c to specify them)
+        # default name is "($EQUINOX_COSMOS_CONTAINER)-aux"
+        propulsion init -ru 400 cosmos
+//#endif // cosmos
+//#if esdb
+1. Use the `eqx` tool to initialize the checkpoints container
+
+        dotnet tool install -g Equinox.Tool # only needed once
+
+        # (either add environment variables as per step 0 or use -s/-d/-c to specify them)
+
+        # generate a cosmos container to store checkpoints in
+        eqx init -ru 400 cosmos
+//#endif // esdb
+         
 2. To run an instance of the Projector:
 
+//#if esdb
+        $env:EQUINOX_ES_HOST="localhost" # or use -h after the `es` token in the arguments
+        $env:EQUINOX_ES_USERNAME="admin" # or use -u after the `es` token in the arguments
+        $env:EQUINOX_ES_PASSWORD="changeit" # or use -p after the `es` token in the arguments
+
+//#endif // esdb
+//#if kafka
         # (either add environment variables as per step 0 or use -s/-d/-c to specify them)
 
         $env:PROPULSION_KAFKA_BROKER="instance.kafka.example.com:9092" # or use -b
 
+//#if   cosmos // kafka && cosmos
         # `-g default` defines the Projector Group identity - each id has separated state in the aux container (aka LeaseId)
         # `-t topic0` identifies the Kafka topic to which the Projector should write
         # cosmos specifies the source (if you have specified 3x EQUINOX_COSMOS_* environment vars, no arguments are needed)
@@ -52,12 +98,18 @@ This project was generated using:
         dotnet run -- -g default -t topic0 cosmos -md 1000
 
         # (assuming you've scaled up enough to have >1 physical partition range, you can run a second instance [in a second console] with the same arguments)
+//#endif // kafka && cosmos
+//#if   esdb
+        # `-g default` defines the Projector Group identity - each id has a separate checkpoint in the EQUINOX_COSMOS_CONTAINER
+        # `-t topic0` identifies the Kafka topic to which the Projector should write
+        # es specifies the source details (if you have specified 3x EQUINOX_ES_* environment vars, no arguments are needed)
+        # cosmos specifies the checkpoint store details (if you have specified 3x EQUINOX_COSMOS_* environment vars, no arguments are needed)
+        dotnet run -- -g default -t topic0 es cosmos
+//#endif // kafka && esdb
 
 3. To create a Consumer, use `dotnet new proConsumer` or `dotnet new proReactor --source kafkaEventSpans`
-//#else
-
-2. To run an instance of the Projector:
-
+//#else // !kafka
+//#if   cosmos
         # (either add environment variables as per step 0 or use -s/-d/-c to specify them)
 
         # `-g default` defines the Projector Group identity - each id has separated state in the aux container (aka LeaseId)
@@ -66,4 +118,13 @@ This project was generated using:
        dotnet run -- -g default cosmos -md 1000 
 
         # NB (assuming you've scaled up enough to have >1 physical partition range, you can run a second instance in a second console with the same arguments)
-//#endif
+//#endif // !kafka && cosmos
+//#if   esdb
+        # (either add environment variables as per step 0 or use -s/-d/-c to specify them)
+
+        # `-g default` defines the Projector Group identity - each id has a separate checkpoint in the EQUINOX_COSMOS_CONTAINER
+        # es specifies the source details (if you have specified 3x EQUINOX_ES_* environment vars, no arguments are needed)
+        # cosmos specifies the checkpoint store details (if you have specified 3x EQUINOX_COSMOS_* environment vars, no arguments are needed)
+       dotnet run -- -g default es cosmos
+//#endif // !kafka && esdb       
+//#endif // !kafka

--- a/propulsion-projector/README.md
+++ b/propulsion-projector/README.md
@@ -46,14 +46,14 @@ This project was generated using:
         $env:PROPULSION_KAFKA_BROKER="instance.kafka.example.com:9092" # or use -b
 
         # `-g default` defines the Projector Group identity - each id has separated state in the aux container (aka LeaseId)
-        # `-m 1000` sets the change feed maximum document limit to 1000
         # `-t topic0` identifies the Kafka topic to which the Projector should write
         # cosmos specifies the source (if you have specified 3x EQUINOX_COSMOS_* environment vars, no arguments are needed)
-        dotnet run -- -g default -m 1000 -t topic0 cosmos
+        # `-md 1000` sets the change feed maximum document limit to 1000
+        dotnet run -- -g default -t topic0 cosmos -md 1000
 
-        # (assuming you've scaled up enough to have >1 physical partition range, you can run a second instance in a second console with the same arguments)
+        # (assuming you've scaled up enough to have >1 physical partition range, you can run a second instance [in a second console] with the same arguments)
 
-3. To create a Consumer, use `dotnet new proConsumer`
+3. To create a Consumer, use `dotnet new proConsumer` or `dotnet new proReactor --source kafkaEventSpans`
 //#else
 
 2. To run an instance of the Projector:
@@ -61,9 +61,9 @@ This project was generated using:
         # (either add environment variables as per step 0 or use -s/-d/-c to specify them)
 
         # `-g default` defines the Projector Group identity - each id has separated state in the aux container (aka LeaseId)
-        # `-m 1000` sets the max batch size to 1000
         # cosmos specifies the source (if you have specified 3x EQUINOX_COSMOS_* environment vars, no arguments are needed)
-        dotnet run -- -g default -m 1000 cosmos
+        # `-md 1000` sets the max batch size to 1000
+       dotnet run -- -g default cosmos -md 1000 
 
         # NB (assuming you've scaled up enough to have >1 physical partition range, you can run a second instance in a second console with the same arguments)
 //#endif

--- a/propulsion-reactor/README.md
+++ b/propulsion-reactor/README.md
@@ -84,11 +84,11 @@ This project was generated using:
 
 4. To run an instance of the Projector from EventStore
 
-        # (either add environment variables as per step 0 or use -s/-d/-c to specify them after the `cosmos` argument token)
+        # (either add environment variables like this, or use -h/-u/-p to specify them after the `es` argument token)
 
+        $env:EQUINOX_ES_HOST="localhost" # or use -h
         $env:EQUINOX_ES_USERNAME="admin" # or use -u
         $env:EQUINOX_ES_PASSWORD="changeit" # or use -p
-        $env:EQUINOX_ES_HOST="localhost" # or use -g
 
 //#if kafka
         $env:PROPULSION_KAFKA_BROKER="instance.kafka.example.com:9092" # or use -b

--- a/propulsion-sync/Program.fs
+++ b/propulsion-sync/Program.fs
@@ -226,7 +226,7 @@ module Args =
         | [<AltCommandLine "-g"; Unique>]   Gorge of int
         | [<AltCommandLine "-i"; Unique>]   StreamReaders of int
         | [<AltCommandLine "-t"; Unique>]   Tail of intervalS: float
-        | [<AltCommandLine "-force"; Unique>] ForceRestart
+        | [<AltCommandLine "--force"; Unique>] ForceRestart
         | [<AltCommandLine "-m"; Unique>]   BatchSize of int
         | [<AltCommandLine "-mim"; Unique>] MinBatchSize of int
         | [<AltCommandLine "-pos"; Unique>] Position of int64

--- a/tests/Equinox.Templates.Tests/DotnetBuild.fs
+++ b/tests/Equinox.Templates.Tests/DotnetBuild.fs
@@ -6,12 +6,15 @@ open Xunit.Abstractions
 type ProProjector() as this =
     inherit TheoryData<string list>()
 
-#if DEBUG
-    let variants = [ ["--kafka"] ]
-#else
-    let variants = [ []; ["--kafka"]; ["--kafka"; "--parallelOnly"] ]
-#endif
     do for source in ["cosmos"; (* <-default *) "eventStore"] do
+        let variants =
+            if source = "eventStore" then [ []; ["--kafka"] ]
+            else
+#if DEBUG
+                    [ ["--kafka"] ]
+#else
+                    [ []; ["--kafka"]; ["--kafka"; "--parallelOnly"] ]
+#endif
         for opts in variants do
             this.Add (["--source " + source] @ opts)
 

--- a/tests/Equinox.Templates.Tests/DotnetBuild.fs
+++ b/tests/Equinox.Templates.Tests/DotnetBuild.fs
@@ -4,7 +4,7 @@ open Xunit
 open Xunit.Abstractions
 
 type ProProjector() as this =
-    inherit TheoryData<string list>()
+    inherit TheoryData<string seq>()
 
     do for source in ["cosmos"; (* <-default *) "eventStore"] do
         let variants =
@@ -19,14 +19,14 @@ type ProProjector() as this =
             this.Add (["--source " + source] @ opts)
 
 type ProReactor() as this =
-    inherit TheoryData<string list>()
+    inherit TheoryData<string seq>()
 
     do for source in ["multiSource"; (* <-default *) "kafkaEventSpans"; "changeFeedOnly"] do
         for opts in [ []; ["--blank"]; ["--kafka"]; ["--kafka"; "--blank"] ] do
             this.Add (["--source " + source] @ opts)
 
 type EqxWebs() as this =
-    inherit TheoryData<string, string list>()
+    inherit TheoryData<string, string seq>()
 
     do for t in ["eqxweb"; "eqxwebcs"] do
         do this.Add(t, ["--todos"; "--cosmos"])
@@ -37,10 +37,10 @@ type EqxWebs() as this =
 
 type DotnetBuild(output : ITestOutputHelper, folder : EquinoxTemplatesFixture) =
 
-    let run template args =
+    let run template (args : string seq) =
         output.WriteLine(sprintf "using %s" folder.PackagePath)
         let folder = Dir.cleared template
-        Dotnet.instantiate folder template args
+        Dotnet.instantiate folder template (List.ofSeq args)
         Dotnet.build [folder]
 
     #if DEBUG // Use this one to trigger an individual test

--- a/tests/Equinox.Templates.Tests/DotnetBuild.fs
+++ b/tests/Equinox.Templates.Tests/DotnetBuild.fs
@@ -4,7 +4,7 @@ open Xunit
 open Xunit.Abstractions
 
 type ProProjector() as this =
-    inherit TheoryData<string seq>()
+    inherit TheoryData<string list>()
 
     do for source in ["cosmos"; (* <-default *) "eventStore"] do
         let variants =
@@ -16,17 +16,17 @@ type ProProjector() as this =
                     [ []; ["--kafka"]; ["--kafka"; "--parallelOnly"] ]
 #endif
         for opts in variants do
-            this.Add (["--source " + source] @ opts)
+            this.Add(["--source " + source] @ opts)
 
 type ProReactor() as this =
-    inherit TheoryData<string seq>()
+    inherit TheoryData<string list>()
 
     do for source in ["multiSource"; (* <-default *) "kafkaEventSpans"; "changeFeedOnly"] do
         for opts in [ []; ["--blank"]; ["--kafka"]; ["--kafka"; "--blank"] ] do
-            this.Add (["--source " + source] @ opts)
+            this.Add(["--source " + source] @ opts)
 
 type EqxWebs() as this =
-    inherit TheoryData<string, string seq>()
+    inherit TheoryData<string, string list>()
 
     do for t in ["eqxweb"; "eqxwebcs"] do
         do this.Add(t, ["--todos"; "--cosmos"])

--- a/tests/Equinox.Templates.Tests/DotnetBuild.fs
+++ b/tests/Equinox.Templates.Tests/DotnetBuild.fs
@@ -3,12 +3,24 @@ namespace Equinox.Templates.Tests
 open Xunit
 open Xunit.Abstractions
 
+type ProProjector() as this =
+    inherit TheoryData<string list>()
+
+#if DEBUG
+    let variants = [ ["--kafka"] ]
+#else
+    let variants = [ []; ["--kafka"]; ["--kafka"; "--parallelOnly"] ]
+#endif
+    do for source in ["cosmos"; (* <-default *) "eventStore"] do
+        for opts in variants do
+            this.Add (["--source " + source] @ opts)
+
 type ProReactor() as this =
     inherit TheoryData<string list>()
 
     do for source in ["multiSource"; (* <-default *) "kafkaEventSpans"; "changeFeedOnly"] do
         for opts in [ []; ["--blank"]; ["--kafka"]; ["--kafka"; "--blank"] ] do
-            do this.Add (["--source " + source; ] @ opts)
+            this.Add (["--source " + source] @ opts)
 
 type EqxWebs() as this =
     inherit TheoryData<string, string list>()
@@ -34,11 +46,8 @@ type DotnetBuild(output : ITestOutputHelper, folder : EquinoxTemplatesFixture) =
 
     let [<Fact>] eqxTestbed ()                  = run "eqxTestbed" []
     let [<Fact>] eqxShipping ()                 = run "eqxShipping" []
-    let [<Fact>] proProjector ()                = run "proProjector" []
-#if !DEBUG
-    let [<Fact>] proProjectorK ()               = run "proProjector" ["--kafka"]
-    let [<Fact>] proProjectorKP ()              = run "proProjector" ["--kafka"; "--parallelOnly"]
-#endif
+    [<ClassData(typeof<ProProjector>)>]
+    let [<Theory>] proProjector args            = run "proProjector" args
     let [<Fact>] proConsumer ()                 = run "proConsumer" []
     let [<Fact>] trackingConsumer ()            = run "trackingConsumer" []
     let [<Fact>] summaryConsumer ()             = run "summaryConsumer" []

--- a/tests/Equinox.Templates.Tests/DotnetBuild.fs
+++ b/tests/Equinox.Templates.Tests/DotnetBuild.fs
@@ -37,10 +37,10 @@ type EqxWebs() as this =
 
 type DotnetBuild(output : ITestOutputHelper, folder : EquinoxTemplatesFixture) =
 
-    let run template (args : string seq) =
+    let run template args =
         output.WriteLine(sprintf "using %s" folder.PackagePath)
         let folder = Dir.cleared template
-        Dotnet.instantiate folder template (List.ofSeq args)
+        Dotnet.instantiate folder template args
         Dotnet.build [folder]
 
     #if DEBUG // Use this one to trigger an individual test

--- a/tests/Equinox.Templates.Tests/Equinox.Templates.Tests.fsproj
+++ b/tests/Equinox.Templates.Tests/Equinox.Templates.Tests.fsproj
@@ -21,8 +21,4 @@
         </PackageReference>
     </ItemGroup>
 
-    <ItemGroup>
-      <ProjectReference Include="..\..\src\Equinox.Templates\Equinox.Templates.fsproj" />
-    </ItemGroup>
-
 </Project>


### PR DESCRIPTION
extends the `proProjector` template to support basic projections (including emitting `kafkaEventSpans`) from EventStoreDB [to go alongside the existing ChangeFeed support]