### PR TITLE
proProjector: Add SqlStreamStore support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ The `Unreleased` section name is replaced by the expected version of next releas
 ## [Unreleased]
 
 ### Added
+
+- `proProjector`: Add SqlStreamStore source [#74](https://github.com/jet/dotnet-templates/pull/74) :pray: [@scrwtp](https://github.com/scrwtp) 
+
 ### Changed
 ### Removed
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -23,6 +23,8 @@ The following templates focus specifically on the usage of `Propulsion` componen
        * `-k --parallelOnly` schedule kafka emission to operate in parallel at document (rather than accumulated span of events for a stream) level
 
     2. `--source eventStore`: EventStoreDB's `$all` feed
+    
+    3. `--source sqlStreamStore`: [`SqlStreamStore`](https://github.com/SQLStreamStore/SQLStreamStore)'s `$all` feed
 
   * `-k` adds publishing to Apache Kafka using [`Propulsion.Kafka`](https://github.com/jet/propulsion).
       

--- a/propulsion-projector/.template.config/template.json
+++ b/propulsion-projector/.template.config/template.json
@@ -34,12 +34,20 @@
         {
           "choice": "eventStore",
           "description": "Wire for EventStoreDB $all source"
+        },
+        {
+          "choice": "sqlStreamStore",
+          "description": "Wire for SqlStreamStore $all source"
         }
       ]
     },
     "esdb": {
       "type": "computed",
       "value": "(source == \"eventStore\")"
+    },
+    "sss": {
+      "type": "computed",
+      "value": "(source == \"sqlStreamStore\")"
     },
     "cosmos": {
       "type": "computed",

--- a/propulsion-projector/Program.fs
+++ b/propulsion-projector/Program.fs
@@ -259,7 +259,7 @@ module Args =
             |> Option.orElseWith (fun () -> EnvVar.tryGet "SQLSTREAMSTORE_CHECKPOINTS_CONNECTION")
             |> Option.defaultValue __.StoreConnectionString
 
-        member x.Connect(appName) =
+        member x.Connect() =
             let conn, creds, schema, autoCreate = x.StoreConnectionString, x.StoreCredentialsString, x.Schema, false
             let sssConnectionString = String.Join(";", conn, creds)
             Log.Information("SqlStreamStore MsSql Connection {connectionString} Schema {schema} AutoCreate {autoCreate}", conn, schema, autoCreate)

--- a/propulsion-projector/Program.fs
+++ b/propulsion-projector/Program.fs
@@ -284,7 +284,7 @@ module Args =
         | [<CliPrefix(CliPrefix.None); Last>] Es of ParseResults<EsSourceParameters>
 #endif
 //#if sss
-        | [<CliPrefix(CliPrefix.None); Last>] SqlMs of ParseResults<SqlStreamStoreSourceParameters>
+        | [<CliPrefix(CliPrefix.None); AltCommandLine "ms"; Last>] SqlMs of ParseResults<SqlStreamStoreSourceParameters>
 //#endif
         interface IArgParserTemplate with
             member a.Usage =

--- a/propulsion-projector/Program.fs
+++ b/propulsion-projector/Program.fs
@@ -42,10 +42,10 @@ module Args =
     let private defaultWithEnvVar varName argName = function
         | None -> getEnvVarForArgumentOrThrow varName argName
         | Some x -> x
-//#if esdb
+#if esdb
     let private isEnvVarTrue varName =
          EnvVar.tryGet varName |> Option.exists (fun s -> String.Equals(s, bool.TrueString, StringComparison.OrdinalIgnoreCase))
-//#endif
+#endif
     let private seconds (x : TimeSpan) = x.TotalSeconds
     open Argu
 #if cosmos
@@ -105,7 +105,7 @@ module Args =
             let connector = Connector(x.Timeout, x.Retries, x.MaxRetryWaitTime, Log.Logger, mode=x.Mode)
             discovery, { database = x.Database; container = x.Container }, connector
 #endif
-//#if esdb
+#if esdb
     open Equinox.EventStore
     open Propulsion.EventStore
     type [<NoEquality; NoComparison>] EsSourceParameters =
@@ -230,6 +230,40 @@ module Args =
                 seconds x.Timeout, x.Retries, seconds x.MaxRetryWaitTime)
             let connector = Equinox.Cosmos.Connector(x.Timeout, x.Retries, x.MaxRetryWaitTime, Log.Logger, mode=x.Mode)
             discovery, x.Database, x.Container, connector
+#endif
+//#if sss
+    /// TODO: add DB connectors other than MsSql
+    type [<NoEquality; NoComparison>] SqlStreamStoreSourceParameters =
+        | [<AltCommandLine "-t"; Unique>]   Tail of intervalS: float
+        | [<AltCommandLine "-m"; Unique>]   BatchSize of int
+        | [<AltCommandLine "-c"; Unique>]   Connection of string
+        | [<AltCommandLine "-s">]           Schema of string
+        | [<AltCommandLine "-p"; Unique>]   Credentials of string
+        | [<Unique>]                        Checkpoints of string
+        interface IArgParserTemplate with
+            member a.Usage = a |> function
+                | Tail _ ->          "Polling interval in Seconds. Default: 1"
+                | BatchSize _ ->     "Maximum events to request from feed. Default: 512"
+                | Connection _ ->    "Connection string for SqlStreamStore db. Optional if SQLSTREAMSTORE_CONNECTION specified"
+                | Schema _ ->        "Database schema name"
+                | Credentials _ ->   "Credentials string for SqlStreamStore db (Part of connection string, but NOT logged). Optional if SQLSTREAMSTORE_CREDENTIALS specified"
+                | Checkpoints _ ->   "Connection string for Checkpoints sql db. Optional if SQLSTREAMSTORE_CHECKPOINTS_CONNECTION specified. Default: same as `Connection`"
+    and SqlStreamStoreSourceArguments(a : ParseResults<SqlStreamStoreSourceParameters>) =
+        member __.TailInterval =            a.GetResult(Tail, 1.) |> TimeSpan.FromSeconds
+        member __.MaxBatchSize =            a.GetResult(BatchSize, 512)
+        member __.StoreConnectionString =   a.TryGetResult Connection |> defaultWithEnvVar "SQLSTREAMSTORE_CONNECTION" "Connection"
+        member __.StoreCredentialsString =  a.TryGetResult Connection |> Option.orElseWith (fun () -> EnvVar.tryGet "SQLSTREAMSTORE_CREDENTIALS")
+        member __.Schema =                  a.GetResult(Schema, null)
+        member __.CheckpointsConnectionString =
+            a.TryGetResult Checkpoints
+            |> Option.orElseWith (fun () -> EnvVar.tryGet "SQLSTREAMSTORE_CHECKPOINTS_CONNECTION")
+            |> Option.defaultValue __.StoreConnectionString
+
+        member x.Connect(appName) =
+            let conn, creds, schema, autoCreate = x.StoreConnectionString, x.StoreCredentialsString, x.Schema, false
+            let sssConnectionString = String.Join(";", conn, creds)
+            Log.Information("SqlStreamStore MsSql Connection {connectionString} Schema {schema} AutoCreate {autoCreate}", conn, schema, autoCreate)
+            Equinox.SqlStreamStore.MsSql.Connector(sssConnectionString, schema, autoCreate=autoCreate).Connect() |> Async.RunSynchronously
 //#endif
 
     [<NoEquality; NoComparison>]
@@ -246,8 +280,11 @@ module Args =
 #if cosmos
         | [<CliPrefix(CliPrefix.None); Last>] Cosmos of ParseResults<CosmosParameters>
 #endif
-//#if esdb
+#if esdb
         | [<CliPrefix(CliPrefix.None); Last>] Es of ParseResults<EsSourceParameters>
+#endif
+//#if sss
+        | [<CliPrefix(CliPrefix.None); Last>] SqlMs of ParseResults<SqlStreamStoreSourceParameters>
 //#endif
         interface IArgParserTemplate with
             member a.Usage =
@@ -263,8 +300,11 @@ module Args =
 #if cosmos
                 | Cosmos _ ->               "specify CosmosDb input parameters"
 #endif
-//#if esdb
+#if esdb
                 | Es _ ->                   "specify EventStore input parameters."
+#endif
+//#if sss
+                | SqlMs _ ->                "specify SqlStreamStore input parameters."
 //#endif
     and Arguments(a : ParseResults<Parameters>) =
         member __.Verbose =                 a.Contains Verbose
@@ -288,7 +328,7 @@ module Args =
             c.LagFrequency |> Option.iter (fun s -> Log.Information("Dumping lag stats at {lagS:n0}s intervals", s.TotalSeconds))
             { database = c.Database; container = c.AuxContainerName }, __.ConsumerGroupName, c.FromTail, c.MaxDocuments, c.LagFrequency
 #endif
-//#if esdb
+#if esdb
         member val Es =                     EsSourceArguments(a.GetResult Es)
         member __.BuildEventStoreParams() =
             let srcE = __.Es
@@ -301,6 +341,16 @@ module Args =
                 {   groupName = __.ConsumerGroupName; start = startPos; checkpointInterval = srcE.CheckpointInterval; tailInterval = srcE.TailInterval
                     forceRestart = srcE.ForceRestart
                     batchSize = srcE.StartingBatchSize; minBatchSize = srcE.MinBatchSize; gorge = srcE.Gorge; streamReaders = 0 }
+#endif
+//#if sss
+        member val SqlStreamStore =         SqlStreamStoreSourceArguments(a.GetResult SqlMs)
+        member __.BuildSqlStreamStoreParams() =
+            let src = __.SqlStreamStore
+            let spec : Propulsion.SqlStreamStore.ReaderSpec =
+                {    consumerGroup     = __.ConsumerGroupName
+                     maxBatchSize      = src.MaxBatchSize;
+                     tailSleepInterval = src.TailInterval }
+            src, spec
 //#endif
 //#if kafka
         member val Target =                 TargetInfo a
@@ -395,7 +445,7 @@ let build (args : Args.Arguments) =
             aux, leaseId, startFromTail, createObserver,
             ?maxDocuments=maxDocuments, ?lagReportFreq=lagFrequency)
 #endif // cosmos
-//#if esdb
+#if esdb
     let (srcE, cosmos, spec) = args.BuildEventStoreParams()
 
     let connectEs () = srcE.Connect(Log.Logger, Log.Logger, AppName, Equinox.EventStore.NodePreference.Master)
@@ -420,7 +470,25 @@ let build (args : Args.Arguments) =
         Propulsion.EventStore.EventStoreSource.Run(
             Log.Logger, sink, checkpoints, connectEs, spec, Handler.tryMapEvent filterByStreamName,
             args.MaxReadAhead, args.StatsInterval)
-//#endif // esdb
+#endif // esdb
+//#if sss
+    let (srcSql, spec) = args.BuildSqlStreamStoreParams()
+
+    let store = srcSql.Connect()
+
+    let checkpointer = Propulsion.SqlStreamStore.SqlCheckpointer(srcSql.CheckpointsConnectionString)
+
+#if     kafka // sss && kafka
+    let (broker, topic) = args.Target.BuildTargetParams()
+    let producer = Propulsion.Kafka.Producer(Log.Logger, AppName, broker, topic)
+    let stats = Handler.ProductionStats(Log.Logger, args.StatsInterval, args.StateInterval)
+    let sink = Propulsion.Kafka.StreamsProducerSink.Start(Log.Logger, maxReadAhead, maxConcurrentStreams, Handler.render, producer, stats, args.StatsInterval)
+#else // sss && !kafka
+    let stats = Handler.ProjectorStats(Log.Logger, args.StatsInterval, args.StateInterval)
+    let sink = Propulsion.Streams.StreamsProjector.Start(Log.Logger, maxReadAhead, maxConcurrentStreams, Handler.handle, stats, args.StatsInterval)
+#endif // sss && !kafka
+    let runSourcePipeline = Propulsion.SqlStreamStore.SqlStreamStoreSource.Run(Log.Logger, store, checkpointer, spec, sink, args.StatsInterval)
+//#endif // sss
     sink, runSourcePipeline
 
 let run args =

--- a/propulsion-projector/Program.fs
+++ b/propulsion-projector/Program.fs
@@ -242,12 +242,12 @@ module Args =
         | [<Unique>]                        Checkpoints of string
         interface IArgParserTemplate with
             member a.Usage = a |> function
-                | Tail _ ->          "Polling interval in Seconds. Default: 1"
-                | BatchSize _ ->     "Maximum events to request from feed. Default: 512"
-                | Connection _ ->    "Connection string for SqlStreamStore db. Optional if SQLSTREAMSTORE_CONNECTION specified"
-                | Schema _ ->        "Database schema name"
-                | Credentials _ ->   "Credentials string for SqlStreamStore db (Part of connection string, but NOT logged). Optional if SQLSTREAMSTORE_CREDENTIALS specified"
-                | Checkpoints _ ->   "Connection string for Checkpoints sql db. Optional if SQLSTREAMSTORE_CHECKPOINTS_CONNECTION specified. Default: same as `Connection`"
+                | Tail _ ->                 "Polling interval in Seconds. Default: 1"
+                | BatchSize _ ->            "Maximum events to request from feed. Default: 512"
+                | Connection _ ->           "Connection string for SqlStreamStore db. Optional if SQLSTREAMSTORE_CONNECTION specified"
+                | Schema _ ->               "Database schema name"
+                | Credentials _ ->          "Credentials string for SqlStreamStore db (Part of connection string, but NOT logged). Optional if SQLSTREAMSTORE_CREDENTIALS specified"
+                | Checkpoints _ ->          "Connection string for Checkpoints sql db. Optional if SQLSTREAMSTORE_CHECKPOINTS_CONNECTION specified. Default: same as `Connection`"
     and SqlStreamStoreSourceArguments(a : ParseResults<SqlStreamStoreSourceParameters>) =
         member __.TailInterval =            a.GetResult(Tail, 1.) |> TimeSpan.FromSeconds
         member __.MaxBatchSize =            a.GetResult(BatchSize, 512)
@@ -347,9 +347,9 @@ module Args =
         member __.BuildSqlStreamStoreParams() =
             let src = __.SqlStreamStore
             let spec : Propulsion.SqlStreamStore.ReaderSpec =
-                {    consumerGroup     = __.ConsumerGroupName
-                     maxBatchSize      = src.MaxBatchSize;
-                     tailSleepInterval = src.TailInterval }
+                {    consumerGroup         = __.ConsumerGroupName
+                     maxBatchSize          = src.MaxBatchSize
+                     tailSleepInterval     = src.TailInterval }
             src, spec
 //#endif
 //#if kafka

--- a/propulsion-projector/Projector.fsproj
+++ b/propulsion-projector/Projector.fsproj
@@ -24,6 +24,10 @@
     <!--#if (esdb)-->
     <PackageReference Include="Propulsion.EventStore" Version="2.6.0" />
     <!--#endif-->
+    <!--#if (sss)-->
+    <PackageReference Include="Equinox.SqlStreamStore.MsSql" Version="2.1.0" />
+    <PackageReference Include="Propulsion.SqlStreamStore" Version="2.7.0" />
+    <!--#endif-->
     <!--#if kafka-->
     <PackageReference Include="Propulsion.Kafka" Version="2.6.0" />
     <!--#endif-->

--- a/propulsion-projector/README.md
+++ b/propulsion-projector/README.md
@@ -34,14 +34,39 @@ This project was generated using:
     dotnet new proProjector -s eventStore # use --help to see options
 //#endif // esdb && !kafka
 //#endif // esdb
+//#if sss
+//#if   kafka // sss && kafka
+# Propulsion SqlStreamStore -> Kafka Projector
+
+This project was generated using:
+
+    dotnet new -i Equinox.Templates # just once, to install/update in the local templates store
+    dotnet new proProjector -s sqlStreamStore -k # -k => include Kafka projection logic
+//#else // sss && !kafka
+# Propulsion SqlStreamStore Projector (without Kafka emission)
+
+This project was generated using:
+
+    dotnet new -i Equinox.Templates # just once, to install/update in the local templates store
+    # add -k to add Kafka Projection logic
+    dotnet new proProjector -s sqlStreamStore # use --help to see options
+//#endif // sss && !kafka
+//#endif // sss
 
 ## Usage instructions
 
+//#if sss
+0. establish connection strings etc. per https://github.com/jet/equinox README
+
+        $env:SQLSTREAMSTORE_CONNECTION="..." # or use -c
+        $env:SQLSTREAMSTORE_CONNECTION_CHECKPOINTS="equinox-test" # or use --checkpoints
+//#else
 0. establish connection strings etc. per https://github.com/jet/equinox README
 
         $env:EQUINOX_COSMOS_CONNECTION="AccountEndpoint=https://....;AccountKey=....=;" # or use -s
         $env:EQUINOX_COSMOS_DATABASE="equinox-test" # or use -d
         $env:EQUINOX_COSMOS_CONTAINER="equinox-test" # or use -c
+//#endif
 
 //#if cosmos
 1a. Use the `eqx` tool to initialize and then run some transactions in a CosmosDB container
@@ -76,6 +101,16 @@ This project was generated using:
         # generate a cosmos container to store checkpoints in
         eqx init -ru 400 cosmos
 //#endif // esdb
+//#if sss
+1. Use the `propulsion` tool to initialize the Checkpoints Table
+
+        dotnet tool install -g Propulsion.Tool # only needed once
+
+        # (either add environment variables as per step 0 or use -c to specify them)
+
+        # generate a SQL Table to store checkpoints in
+        propulsion init sqlms
+//#endif // sss         
          
 2. To run an instance of the Projector:
 
@@ -106,6 +141,12 @@ This project was generated using:
         # cosmos specifies the checkpoint store details (if you have specified 3x EQUINOX_COSMOS_* environment vars, no arguments are needed)
         dotnet run -- -g default -t topic0 es cosmos
 //#endif // kafka && esdb
+//#if   sss
+        # `-g default` defines the Projector Group identity - each id has a separate checkpoint in the Checkpoints Table
+        # `-t topic0` identifies the Kafka topic to which the Projector should write
+        # sqlms specifies the source details (if you have specified SQLSTREAMSTORE_CONNECTION and/or SQLSTREAMSTORE_CONNECTION_CHECKPOINTS environment vars, no arguments are needed)
+        dotnet run -- -g default -t topic0 sqlms
+//#endif // kafka && sss
 
 3. To create a Consumer, use `dotnet new proConsumer` or `dotnet new proReactor --source kafkaEventSpans`
 //#else // !kafka
@@ -127,4 +168,11 @@ This project was generated using:
         # cosmos specifies the checkpoint store details (if you have specified 3x EQUINOX_COSMOS_* environment vars, no arguments are needed)
        dotnet run -- -g default es cosmos
 //#endif // !kafka && esdb       
+//#if   sss
+        # (either add environment variables as per step 0 or use -c/-p to specify them)
+        
+        # `-g default` defines the Projector Group identity - each id has a separate checkpoint in the Checkpoints Table
+        # sqlms specifies the source details (if you have specified SQLSTREAMSTORE_CONNECTION and/or SQLSTREAMSTORE_CONNECTION_CHECKPOINTS environment vars, no arguments are needed)
+        dotnet run -- -g default sqlms
+//#endif // !kafka && sss
 //#endif // !kafka

--- a/propulsion-projector/README.md
+++ b/propulsion-projector/README.md
@@ -59,7 +59,9 @@ This project was generated using:
 0. establish connection strings etc. per https://github.com/jet/equinox README
 
         $env:SQLSTREAMSTORE_CONNECTION="..." # or use -c
-        $env:SQLSTREAMSTORE_CONNECTION_CHECKPOINTS="equinox-test" # or use --checkpoints
+        $env:SQLSTREAMSTORE_CREDENTIALS="Password=secret;..." # or use -p # portion of connection string containing sensitive credentials (not logged)
+        $env:SQLSTREAMSTORE_CONNECTION_CHECKPOINTS="..." # or use -cc
+        $env:SQLSTREAMSTORE_CREDENTIALS_CHECKPOINTS="Password=secret;..." # or use -cp  # portion of connection string containing sensitive credentials (not logged)
 //#else
 0. establish connection strings etc. per https://github.com/jet/equinox README
 

--- a/propulsion-projector/README.md
+++ b/propulsion-projector/README.md
@@ -102,14 +102,24 @@ This project was generated using:
         eqx init -ru 400 cosmos
 //#endif // esdb
 //#if sss
-1. Use the `propulsion` tool to initialize the Checkpoints Table
+1a. Use the `eqx` tool to initialize and then run some transactions in a SqlStreamStore database
+
+        dotnet tool install -g Equinox.Tool # only needed once
+
+        # set up the DB/schema
+        eqx config ms -c "connectionstring" -p "u=un;p=password" -s "schema"
+
+        # (generate some events)
+        start https://github.com/jet/equinox#sqlstreamstore
+
+1b. Use the `propulsion` tool to initialize the Checkpoints Table
 
         dotnet tool install -g Propulsion.Tool # only needed once
 
         # (either add environment variables as per step 0 or use -c to specify them)
 
         # generate a SQL Table to store checkpoints in
-        propulsion init sqlms
+        propulsion init ms
 //#endif // sss         
          
 2. To run an instance of the Projector:
@@ -144,8 +154,8 @@ This project was generated using:
 //#if   sss
         # `-g default` defines the Projector Group identity - each id has a separate checkpoint in the Checkpoints Table
         # `-t topic0` identifies the Kafka topic to which the Projector should write
-        # sqlms specifies the source details (if you have specified SQLSTREAMSTORE_CONNECTION and/or SQLSTREAMSTORE_CONNECTION_CHECKPOINTS environment vars, no arguments are needed)
-        dotnet run -- -g default -t topic0 sqlms
+        # ms specifies the source details (if you have specified SQLSTREAMSTORE_CONNECTION and/or SQLSTREAMSTORE_CONNECTION_CHECKPOINTS environment vars, no arguments are needed)
+        dotnet run -- -g default -t topic0 ms
 //#endif // kafka && sss
 
 3. To create a Consumer, use `dotnet new proConsumer` or `dotnet new proReactor --source kafkaEventSpans`
@@ -172,7 +182,7 @@ This project was generated using:
         # (either add environment variables as per step 0 or use -c/-p to specify them)
         
         # `-g default` defines the Projector Group identity - each id has a separate checkpoint in the Checkpoints Table
-        # sqlms specifies the source details (if you have specified SQLSTREAMSTORE_CONNECTION and/or SQLSTREAMSTORE_CONNECTION_CHECKPOINTS environment vars, no arguments are needed)
-        dotnet run -- -g default sqlms
+        # ms specifies the source details (if you have specified SQLSTREAMSTORE_CONNECTION and/or SQLSTREAMSTORE_CONNECTION_CHECKPOINTS environment vars, no arguments are needed)
+        dotnet run -- -g default ms
 //#endif // !kafka && sss
 //#endif // !kafka

--- a/tests/Equinox.Templates.Tests/DotnetBuild.fs
+++ b/tests/Equinox.Templates.Tests/DotnetBuild.fs
@@ -6,9 +6,9 @@ open Xunit.Abstractions
 type ProProjector() as this =
     inherit TheoryData<string list>()
 
-    do for source in ["cosmos"; (* <-default *) "eventStore"] do
+    do for source in ["cosmos"; (* <-default *) "eventStore"; "sqlStreamStore"] do
         let variants =
-            if source = "eventStore" then [ []; ["--kafka"] ]
+            if source <> "cosmos" then [ []; ["--kafka"] ]
             else
 #if DEBUG
                     [ ["--kafka"] ]


### PR DESCRIPTION
Based on @scrwtp's https://github.com/scrwtp/dotnet-templates/tree/master/sqlstreamstore-draft, this adds code to allow

    dotnet new proProjector -s sqlStreamStore

Which wires up a projector to consume from a [`Propulsion.SqlStreamStore`](https://github.com/jet/propulsion/pull/72) source, feeding into any of the standard sinks 

Note the current wiring only provides for `SqlStreamStore.MsSql` out of the box atm, but there should obviously not much tweaking involved to use MySql/PgSql