### PR TITLE
module Logging -> type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ The `Unreleased` section name is replaced by the expected version of next releas
 ### Added
 ### Changed
 
+- Cleaned and moved `Logging` logic out to `Infrastructure.fs` [#76](https://github.com/jet/dotnet-templates/pull/76) 
 - Polished `SemaphoreSlim` extensions [#79](https://github.com/jet/dotnet-templates/pull/79) 
 
 ### Removed

--- a/README.md
+++ b/README.md
@@ -249,7 +249,7 @@ _Responsible for: mapping Environment Variables and the Command Line `argv` to a
 
 NOTE: there's a [medium term plan to submit a PR to Argu](https://github.com/fsprojects/Argu/issues/143) extending it to be able to fall back to environment variables where a value is not supplied, by means of declarative attributes on the Argument specification in the DU, _including having the `--help` message automatically include a reference to the name of the environment variable that one can supply the value through_
 
-### `module Logging`
+### `type Logging`
 
 _Responsible for applying logging config and setting up loggers for the application_
 
@@ -258,10 +258,10 @@ _Responsible for applying logging config and setting up loggers for the applicat
 #### example
 
 ```
-module Logging =
+type Logging() =
 
-    let initialize verbose =
-	Log.Logger <- LoggerConfiguration(….)
+    static member Initialize(?minimumLevel) =
+        Log.Logger <- LoggerConfiguration(….)
 ```
 
 ### `start` function

--- a/README.md
+++ b/README.md
@@ -260,10 +260,7 @@ _Responsible for applying logging config and setting up loggers for the applicat
 ```
 type Logging() =
 
-    static member Initialize(configure) =
-        let loggerConfiguration : LoggerConfiguration = LoggerConfiguration() |> configure
-        Log.Logger <- loggerConfiguration.CreateLogger()
-
+    [<Extension>]
     static member Configure(configuration : LoggingConfiguration, ?verbose) =
         configuration
             .Destructure.FSharpTypes()
@@ -306,8 +303,8 @@ let run args = async {
 [<EntryPoint>]
 let main argv =
     try let args = Args.parse argv
-        try Logging.Initialize(fun c -> Logging.Configure c, verbose=args.Verbose))
-            try Configuration.load ()
+        try Log.Logger <- LoggerConfiguration().Configure(verbose=args.Verbose).CreateLogger()
+            try Configuration.initialize ()
                 run args |> Async.RunSynchronously
                 0
             with e when not (e :? Args.MissingArg) -> Log.Fatal(e, "Exiting"); 2

--- a/README.md
+++ b/README.md
@@ -260,7 +260,7 @@ _Responsible for applying logging config and setting up loggers for the applicat
 ```
 type Logging() =
 
-    static member Initialize(?minimumLevel) =
+    static member Initialize(?verbose) =
         Log.Logger <- LoggerConfiguration(….)
 ```
 
@@ -298,7 +298,7 @@ let run args =
 [<EntryPoint>]
 let main argv =
     try let args = Args.parse argv
-        try Logging.initialize args.Verbose
+        try Logging.Initialize(verbose=args.Verbose)
             try Configuration.initialize ()
                 if run args then 0 else 3
             with e when not (e :? Args.MissingArg) -> Log.Fatal(e, "Exiting"); 2

--- a/equinox-shipping/Watchdog/Infrastructure.fs
+++ b/equinox-shipping/Watchdog/Infrastructure.fs
@@ -1,35 +1,9 @@
-﻿namespace ReactorTemplate
+[<AutoOpen>]
+module Shipping.Watchdog.Infrastructure
 
-open System.Runtime.CompilerServices
-open FSharp.UMX // see https://github.com/fsprojects/FSharp.UMX - % operator and ability to apply units of measure to Guids+strings
 open Serilog
-open System
+open System.Runtime.CompilerServices
 
-module EventCodec =
-
-    /// Uses the supplied codec to decode the supplied event record `x` (iff at LogEventLevel.Debug, detail fails to `log` citing the `stream` and content)
-    let tryDecode (codec : FsCodec.IEventCodec<_, _, _>) streamName (x : FsCodec.ITimelineEvent<byte[]>) =
-        match codec.TryDecode x with
-        | None ->
-            if Serilog.Log.IsEnabled Serilog.Events.LogEventLevel.Debug then
-                Serilog.Log.ForContext("event", System.Text.Encoding.UTF8.GetString(x.Data), true)
-                    .Debug("Codec {type} Could not decode {eventType} in {stream}", codec.GetType().FullName, x.EventType, streamName)
-            None
-        | x -> x
-
-module Guid =
-
-    let inline toStringN (x : Guid) = x.ToString "N"
-
-/// ClientId strongly typed id; represented internally as a Guid; not used for storage so rendering is not significant
-type ClientId = Guid<clientId>
-and [<Measure>] clientId
-module ClientId =
-    let toString (value : ClientId) : string = Guid.toStringN %value
-    let parse (value : string) : ClientId = let raw = Guid.Parse value in % raw
-    let (|Parse|) = parse
-
-#if (!kafkaEventSpans)
 [<Extension>]
 type LoggerConfigurationExtensions() =
 
@@ -49,23 +23,16 @@ type LoggerConfigurationExtensions() =
         c.MinimumLevel.Override("Microsoft.Azure.Documents.ChangeFeedProcessor", cfpl)
         |> fun c -> if verbose then c.ExcludeChangeFeedProcessorV2InternalDiagnostics() else c
 
-#endif
-// Application logic assumes the global `Serilog.Log` is initialized _immediately_ after a successful Args.parse
+// Application logic assumes the global `Serilog.Log` is initialized _immediately_ after a successful ArgumentParser.ParseCommandline
 type Logging() =
 
-#if (!kafkaEventSpans)
     static member Initialize(?minimumLevel, ?changeFeedProcessorVerbose) =
-#else
-    static member Initialize(?minimumLevel) =
-#endif
         Log.Logger <-
             LoggerConfiguration()
                 .Destructure.FSharpTypes()
                 .Enrich.FromLogContext()
             |> fun c -> match minimumLevel with Some m -> c.MinimumLevel.Is m | None -> c
-#if (!kafkaEventSpans)
             |> fun c -> c.ConfigureChangeFeedProcessorLogging((changeFeedProcessorVerbose = Some true))
-#endif
             |> fun c -> let t = "[{Timestamp:HH:mm:ss} {Level:u3}] {partitionKeyRangeId,2} {Message:lj} {NewLine}{Exception}"
                         c.WriteTo.Console(theme=Sinks.SystemConsole.Themes.AnsiConsoleTheme.Code, outputTemplate=t)
             |> fun c -> c.CreateLogger()

--- a/equinox-shipping/Watchdog/Infrastructure.fs
+++ b/equinox-shipping/Watchdog/Infrastructure.fs
@@ -23,13 +23,10 @@ type LoggerConfigurationExtensions() =
         c.MinimumLevel.Override("Microsoft.Azure.Documents.ChangeFeedProcessor", cfpl)
         |> fun c -> if verbose then c else c.ExcludeChangeFeedProcessorV2InternalDiagnostics()
 
-// Application logic assumes the global `Serilog.Log` is initialized _immediately_ after a successful ArgumentParser.ParseCommandline
+[<Extension>]
 type Logging() =
 
-    static member Initialize(configure) =
-        let loggerConfiguration : LoggerConfiguration = LoggerConfiguration() |> configure
-        Log.Logger <- loggerConfiguration.CreateLogger()
-
+    [<Extension>]
     static member Configure(configuration : LoggerConfiguration, ?verbose, ?changeFeedProcessorVerbose) =
         configuration
             .Destructure.FSharpTypes()

--- a/equinox-shipping/Watchdog/Infrastructure.fs
+++ b/equinox-shipping/Watchdog/Infrastructure.fs
@@ -26,12 +26,12 @@ type LoggerConfigurationExtensions() =
 // Application logic assumes the global `Serilog.Log` is initialized _immediately_ after a successful ArgumentParser.ParseCommandline
 type Logging() =
 
-    static member Initialize(?minimumLevel, ?changeFeedProcessorVerbose) =
+    static member Initialize(?verbose, ?changeFeedProcessorVerbose) =
         Log.Logger <-
             LoggerConfiguration()
                 .Destructure.FSharpTypes()
                 .Enrich.FromLogContext()
-            |> fun c -> match minimumLevel with Some m -> c.MinimumLevel.Is m | None -> c
+            |> fun c -> if verbose = Some true then c.MinimumLevel.Debug() else c
             |> fun c -> c.ConfigureChangeFeedProcessorLogging((changeFeedProcessorVerbose = Some true))
             |> fun c -> let t = "[{Timestamp:HH:mm:ss} {Level:u3}] {partitionKeyRangeId,2} {Message:lj} {NewLine}{Exception}"
                         c.WriteTo.Console(theme=Sinks.SystemConsole.Themes.AnsiConsoleTheme.Code, outputTemplate=t)

--- a/equinox-shipping/Watchdog/Infrastructure.fs
+++ b/equinox-shipping/Watchdog/Infrastructure.fs
@@ -21,18 +21,20 @@ type LoggerConfigurationExtensions() =
         // LibLog writes to the global logger, so we need to control the emission
         let cfpl = if verbose then Serilog.Events.LogEventLevel.Debug else Serilog.Events.LogEventLevel.Warning
         c.MinimumLevel.Override("Microsoft.Azure.Documents.ChangeFeedProcessor", cfpl)
-        |> fun c -> if verbose then c.ExcludeChangeFeedProcessorV2InternalDiagnostics() else c
+        |> fun c -> if verbose then c else c.ExcludeChangeFeedProcessorV2InternalDiagnostics()
 
 // Application logic assumes the global `Serilog.Log` is initialized _immediately_ after a successful ArgumentParser.ParseCommandline
 type Logging() =
 
-    static member Initialize(?verbose, ?changeFeedProcessorVerbose) =
-        Log.Logger <-
-            LoggerConfiguration()
-                .Destructure.FSharpTypes()
-                .Enrich.FromLogContext()
-            |> fun c -> if verbose = Some true then c.MinimumLevel.Debug() else c
-            |> fun c -> c.ConfigureChangeFeedProcessorLogging((changeFeedProcessorVerbose = Some true))
-            |> fun c -> let t = "[{Timestamp:HH:mm:ss} {Level:u3}] {partitionKeyRangeId,2} {Message:lj} {NewLine}{Exception}"
-                        c.WriteTo.Console(theme=Sinks.SystemConsole.Themes.AnsiConsoleTheme.Code, outputTemplate=t)
-            |> fun c -> c.CreateLogger()
+    static member Initialize(configure) =
+        let loggerConfiguration : LoggerConfiguration = LoggerConfiguration() |> configure
+        Log.Logger <- loggerConfiguration.CreateLogger()
+
+    static member Configure(configuration : LoggerConfiguration, ?verbose, ?changeFeedProcessorVerbose) =
+        configuration
+            .Destructure.FSharpTypes()
+            .Enrich.FromLogContext()
+        |> fun c -> if verbose = Some true then c.MinimumLevel.Debug() else c
+        |> fun c -> c.ConfigureChangeFeedProcessorLogging((changeFeedProcessorVerbose = Some true))
+        |> fun c -> let t = "[{Timestamp:HH:mm:ss} {Level:u3}] {partitionKeyRangeId,2} {Message:lj} {NewLine}{Exception}"
+                    c.WriteTo.Console(theme=Sinks.SystemConsole.Themes.AnsiConsoleTheme.Code, outputTemplate=t)

--- a/equinox-shipping/Watchdog/Program.fs
+++ b/equinox-shipping/Watchdog/Program.fs
@@ -221,8 +221,8 @@ let run args = async {
 [<EntryPoint>]
 let main argv =
     try let args = Args.parse argv
-        try Logging.Initialize(fun c -> Logging.Configure(c, verbose=args.Verbose, changeFeedProcessorVerbose=args.CfpVerbose))
-            try Configuration.load ()
+        try Log.Logger <- LoggerConfiguration().Configure(verbose=args.Verbose, changeFeedProcessorVerbose=args.CfpVerbose).CreateLogger()
+            try Configuration.initialize ()
                 run args |> Async.RunSynchronously
                 0
             with e when not (e :? Args.MissingArg) -> Log.Fatal(e, "Exiting"); 2

--- a/equinox-shipping/Watchdog/Program.fs
+++ b/equinox-shipping/Watchdog/Program.fs
@@ -16,7 +16,7 @@ module Configuration =
             printfn "Setting %s from %A" var key
             EnvVar.set var (loadF key)
 
-    let load () =
+    let initialize () =
         // e.g. initEnvVar     "EQUINOX_COSMOS_CONTAINER"    "CONSUL KEY" readFromConsul
         () // TODO add any custom logic preprocessing commandline arguments and/or gathering custom defaults from external sources, etc
 

--- a/equinox-shipping/Watchdog/Program.fs
+++ b/equinox-shipping/Watchdog/Program.fs
@@ -53,7 +53,7 @@ module Args =
                 | Cosmos _ ->               "specify CosmosDB input parameters."
     and Arguments(a : ParseResults<Parameters>) =
         member __.ConsumerGroupName =       a.GetResult ConsumerGroupName
-        member __.MinimumLevel =            if a.Contains Verbose then Some Events.LogEventLevel.Debug else None
+        member __.Verbose =                 a.Contains Verbose
         member __.CfpVerbose =              a.Contains CfpVerbose
         member __.MaxReadAhead =            a.GetResult(MaxReadAhead, 16)
         member __.MaxConcurrentStreams =    a.GetResult(MaxWriters, 8)
@@ -221,7 +221,7 @@ let run args =
 [<EntryPoint>]
 let main argv =
     try let args = Args.parse argv
-        try Logging.Initialize(?minimumLevel=args.MinimumLevel, changeFeedProcessorVerbose=args.CfpVerbose)
+        try Logging.Initialize(verbose=args.Verbose, changeFeedProcessorVerbose=args.CfpVerbose)
             try Configuration.initialize ()
                 if run args then 0 else 3
             with e when not (e :? Args.MissingArg) -> Log.Fatal(e, "Exiting"); 2

--- a/equinox-shipping/Watchdog/Watchdog.fsproj
+++ b/equinox-shipping/Watchdog/Watchdog.fsproj
@@ -8,6 +8,7 @@
 
     <ItemGroup>
         <None Include="README.md" />
+        <Compile Include="Infrastructure.fs" />
         <Compile Include="Handler.fs" />
         <Compile Include="Program.fs" />
     </ItemGroup>

--- a/equinox-testbed/Program.fs
+++ b/equinox-testbed/Program.fs
@@ -109,7 +109,8 @@ module Args =
 #endif
 
 let createStoreLog verbose verboseConsole maybeSeqEndpoint =
-    let c = LoggerConfiguration().Destructure.FSharpTypes()
+    let c = LoggerConfiguration()
+                .Destructure.FSharpTypes()
     let c = if verbose then c.MinimumLevel.Debug() else c
 //#if eventStore
     let c = c.WriteTo.Sink(Equinox.EventStore.Log.InternalMetrics.Stats.LogSink())

--- a/equinox-web-csharp/Web/Program.cs
+++ b/equinox-web-csharp/Web/Program.cs
@@ -8,19 +8,23 @@ using System.Threading.Tasks;
 
 namespace TodoBackendTemplate.Web
 {
+    static class Logging
+    {
+        public static LoggerConfiguration Configure(this LoggerConfiguration c) =>
+            c
+                .MinimumLevel.Debug()
+                .MinimumLevel.Override("Microsoft.AspNetCore", LogEventLevel.Warning)
+                // .MinimumLevel.Override("Microsoft", LogEventLevel.Warning)
+                .Enrich.FromLogContext()
+                .WriteTo.Console();
+    }
     static class Program
     {
         public static async Task<int> Main(string[] argv)
         {
             try
             {
-                Log.Logger = new LoggerConfiguration()
-                    .MinimumLevel.Debug()
-                    .MinimumLevel.Override("Microsoft.AspNetCore", LogEventLevel.Warning)
-                    // .MinimumLevel.Override("Microsoft", LogEventLevel.Warning)
-                    .Enrich.FromLogContext()
-                    .WriteTo.Console()
-                    .CreateLogger();
+                Log.Logger = new LoggerConfiguration().Configure().CreateLogger();
                 var host = WebHost
                     .CreateDefaultBuilder(argv)
                     .UseSerilog()

--- a/equinox-web/Web/Program.fs
+++ b/equinox-web/Web/Program.fs
@@ -4,14 +4,16 @@ open Microsoft.AspNetCore
 open Microsoft.AspNetCore.Hosting
 open Serilog
 
-let initLogging () =
-    Log.Logger <-
-        LoggerConfiguration()
+[<System.Runtime.CompilerServices.Extension>]
+type Logging() =
+
+    [<System.Runtime.CompilerServices.Extension>]
+    static member Configure(c : LoggerConfiguration) =
+        c
             .MinimumLevel.Debug()
             .MinimumLevel.Override("Microsoft.AspNetCore", Serilog.Events.LogEventLevel.Warning)
             .Enrich.FromLogContext()
             .WriteTo.Console()
-            .CreateLogger()
 
 let createWebHostBuilder args : IWebHostBuilder =
     WebHost
@@ -21,7 +23,7 @@ let createWebHostBuilder args : IWebHostBuilder =
 
 [<EntryPoint>]
 let main argv =
-    try initLogging ()
+    try Log.Logger <- LoggerConfiguration().Configure().CreateLogger()
         createWebHostBuilder(argv).Build().Run()
         0
     with e ->

--- a/propulsion-consumer/Infrastructure.fs
+++ b/propulsion-consumer/Infrastructure.fs
@@ -1,6 +1,7 @@
 ﻿[<AutoOpen>]
 module private ConsumerTemplate.Infrastructure
 
+open Serilog
 open System
 open System.Threading.Tasks
 
@@ -48,8 +49,6 @@ type System.Threading.SemaphoreSlim with
         try return! workflow
         finally semaphore.Release() |> ignore
     }
-
-open Serilog
 
 // Application logic assumes the global `Serilog.Log` is initialized _immediately_ after a successful ArgumentParser.ParseCommandline
 type Logging() =

--- a/propulsion-consumer/Infrastructure.fs
+++ b/propulsion-consumer/Infrastructure.fs
@@ -50,13 +50,10 @@ type System.Threading.SemaphoreSlim with
         finally semaphore.Release() |> ignore
     }
 
-// Application logic assumes the global `Serilog.Log` is initialized _immediately_ after a successful ArgumentParser.ParseCommandline
+[<System.Runtime.CompilerServices.Extension>]
 type Logging() =
 
-    static member Initialize(configure) =
-        let loggerConfiguration : LoggerConfiguration = LoggerConfiguration() |> configure
-        Log.Logger <- loggerConfiguration.CreateLogger()
-
+    [<System.Runtime.CompilerServices.Extension>]
     static member Configure(configuration : LoggerConfiguration, ?verbose) =
         configuration
             .Destructure.FSharpTypes()

--- a/propulsion-consumer/Infrastructure.fs
+++ b/propulsion-consumer/Infrastructure.fs
@@ -53,12 +53,14 @@ type System.Threading.SemaphoreSlim with
 // Application logic assumes the global `Serilog.Log` is initialized _immediately_ after a successful ArgumentParser.ParseCommandline
 type Logging() =
 
-    static member Initialize(?verbose) =
-        Log.Logger <-
-            LoggerConfiguration()
-                .Destructure.FSharpTypes()
-                .Enrich.FromLogContext()
-            |> fun c -> if verbose = Some true then c.MinimumLevel.Debug() else c
-            |> fun c -> let theme = Sinks.SystemConsole.Themes.AnsiConsoleTheme.Code
-                        c.WriteTo.Console(theme=theme, outputTemplate="[{Timestamp:HH:mm:ss} {Level:u3}] {Message:lj} {Properties}{NewLine}{Exception}")
-            |> fun c -> c.CreateLogger()
+    static member Initialize(configure) =
+        let loggerConfiguration : LoggerConfiguration = LoggerConfiguration() |> configure
+        Log.Logger <- loggerConfiguration.CreateLogger()
+
+    static member Configure(configuration : LoggerConfiguration, ?verbose) =
+        configuration
+            .Destructure.FSharpTypes()
+            .Enrich.FromLogContext()
+        |> fun c -> if verbose = Some true then c.MinimumLevel.Debug() else c
+        |> fun c -> let theme = Sinks.SystemConsole.Themes.AnsiConsoleTheme.Code
+                    c.WriteTo.Console(theme=theme, outputTemplate="[{Timestamp:HH:mm:ss} {Level:u3}] {Message:lj} {Properties}{NewLine}{Exception}")

--- a/propulsion-consumer/Infrastructure.fs
+++ b/propulsion-consumer/Infrastructure.fs
@@ -48,3 +48,18 @@ type System.Threading.SemaphoreSlim with
         try return! workflow
         finally semaphore.Release() |> ignore
     }
+
+open Serilog
+
+// Application logic assumes the global `Serilog.Log` is initialized _immediately_ after a successful ArgumentParser.ParseCommandline
+type Logging() =
+
+    static member Initialize(?minimumLevel) =
+        Log.Logger <-
+            LoggerConfiguration()
+                .Destructure.FSharpTypes()
+                .Enrich.FromLogContext()
+            |> fun c -> match minimumLevel with Some m -> c.MinimumLevel.Is m | None -> c
+            |> fun c -> let theme = Sinks.SystemConsole.Themes.AnsiConsoleTheme.Code
+                        c.WriteTo.Console(theme=theme, outputTemplate="[{Timestamp:HH:mm:ss} {Level:u3}] {Message:lj} {Properties}{NewLine}{Exception}")
+            |> fun c -> c.CreateLogger()

--- a/propulsion-consumer/Infrastructure.fs
+++ b/propulsion-consumer/Infrastructure.fs
@@ -53,12 +53,12 @@ type System.Threading.SemaphoreSlim with
 // Application logic assumes the global `Serilog.Log` is initialized _immediately_ after a successful ArgumentParser.ParseCommandline
 type Logging() =
 
-    static member Initialize(?minimumLevel) =
+    static member Initialize(?verbose) =
         Log.Logger <-
             LoggerConfiguration()
                 .Destructure.FSharpTypes()
                 .Enrich.FromLogContext()
-            |> fun c -> match minimumLevel with Some m -> c.MinimumLevel.Is m | None -> c
+            |> fun c -> if verbose = Some true then c.MinimumLevel.Debug() else c
             |> fun c -> let theme = Sinks.SystemConsole.Themes.AnsiConsoleTheme.Code
                         c.WriteTo.Console(theme=theme, outputTemplate="[{Timestamp:HH:mm:ss} {Level:u3}] {Message:lj} {Properties}{NewLine}{Exception}")
             |> fun c -> c.CreateLogger()

--- a/propulsion-consumer/Program.fs
+++ b/propulsion-consumer/Program.fs
@@ -18,7 +18,7 @@ module Configuration =
             printfn "Setting %s from %A" var key
             EnvVar.set var (loadF key)
 
-    let load () =
+    let initialize () =
         // e.g. initEnvVar     "EQUINOX_COSMOS_CONTAINER"    "CONSUL KEY" readFromConsul
         () // TODO add any custom logic preprocessing commandline arguments and/or gathering custom defaults from external sources, etc
 
@@ -98,7 +98,7 @@ let run args = async {
 [<EntryPoint>]
 let main argv =
     try let args = Args.parse argv
-        try Logging.Initialize(fun c-> Logging.Configure(c, verbose=args.Verbose))
+        try Logging.Initialize(fun c -> Logging.Configure(c, verbose=args.Verbose))
             try Configuration.load ()
                 run args |> Async.RunSynchronously
                 0

--- a/propulsion-consumer/Program.fs
+++ b/propulsion-consumer/Program.fs
@@ -98,8 +98,8 @@ let run args = async {
 [<EntryPoint>]
 let main argv =
     try let args = Args.parse argv
-        try Logging.Initialize(fun c -> Logging.Configure(c, verbose=args.Verbose))
-            try Configuration.load ()
+        try Log.Logger <- LoggerConfiguration().Configure(verbose=args.Verbose).CreateLogger()
+            try Configuration.initialize ()
                 run args |> Async.RunSynchronously
                 0
             with e when not (e :? Args.MissingArg) -> Log.Fatal(e, "Exiting"); 2

--- a/propulsion-consumer/Program.fs
+++ b/propulsion-consumer/Program.fs
@@ -69,27 +69,13 @@ module Args =
         member __.LagFrequency =            a.TryGetResult LagFreqM |> Option.map TimeSpan.FromMinutes
 
         member __.MaxDop =                  a.GetResult(MaxDop, 8)
-        member __.Verbose =                 a.Contains Verbose
+        member __.MinimumLevel =            if a.Contains Verbose then Some Events.LogEventLevel.Debug else None
 
     /// Parse the commandline; can throw exceptions in response to missing arguments and/or `-h`/`--help` args
     let parse argv =
         let programName = Reflection.Assembly.GetEntryAssembly().GetName().Name
         let parser = ArgumentParser.Create<Parameters>(programName = programName)
         parser.ParseCommandLine argv |> Arguments
-
-// TODO remove this entire comment after reading https://github.com/jet/dotnet-templates#module-logging
-// Application logic assumes the global `Serilog.Log` is initialized _immediately_ after a successful ArgumentParser.ParseCommandline
-module Logging =
-
-    let initialize verbose =
-        Log.Logger <-
-            LoggerConfiguration()
-                .Destructure.FSharpTypes()
-                .Enrich.FromLogContext()
-            |> fun c -> if verbose then c.MinimumLevel.Debug() else c
-            |> fun c -> let theme = Sinks.SystemConsole.Themes.AnsiConsoleTheme.Code
-                        c.WriteTo.Console(theme=theme, outputTemplate="[{Timestamp:HH:mm:ss} {Level:u3}] {Message:lj} {Properties}{NewLine}{Exception}")
-            |> fun c -> c.CreateLogger()
 
 let [<Literal>] AppName = "ConsumerTemplate"
 
@@ -112,7 +98,7 @@ let run args =
 [<EntryPoint>]
 let main argv =
     try let args = Args.parse argv
-        try Logging.initialize args.Verbose
+        try Logging.Initialize(?minimumLevel=args.MinimumLevel)
             try Configuration.initialize ()
                 if run args then 0 else 3
             with e when not (e :? Args.MissingArg) -> Log.Fatal(e, "Exiting"); 2

--- a/propulsion-consumer/Program.fs
+++ b/propulsion-consumer/Program.fs
@@ -69,7 +69,7 @@ module Args =
         member __.LagFrequency =            a.TryGetResult LagFreqM |> Option.map TimeSpan.FromMinutes
 
         member __.MaxDop =                  a.GetResult(MaxDop, 8)
-        member __.MinimumLevel =            if a.Contains Verbose then Some Events.LogEventLevel.Debug else None
+        member __.Verbose =                 a.Contains Verbose
 
     /// Parse the commandline; can throw exceptions in response to missing arguments and/or `-h`/`--help` args
     let parse argv =
@@ -98,7 +98,7 @@ let run args =
 [<EntryPoint>]
 let main argv =
     try let args = Args.parse argv
-        try Logging.Initialize(?minimumLevel=args.MinimumLevel)
+        try Logging.Initialize(verbose=args.Verbose)
             try Configuration.initialize ()
                 if run args then 0 else 3
             with e when not (e :? Args.MissingArg) -> Log.Fatal(e, "Exiting"); 2

--- a/propulsion-consumer/Program.fs
+++ b/propulsion-consumer/Program.fs
@@ -18,7 +18,7 @@ module Configuration =
             printfn "Setting %s from %A" var key
             EnvVar.set var (loadF key)
 
-    let initialize () =
+    let load () =
         // e.g. initEnvVar     "EQUINOX_COSMOS_CONTAINER"    "CONSUL KEY" readFromConsul
         () // TODO add any custom logic preprocessing commandline arguments and/or gathering custom defaults from external sources, etc
 
@@ -90,17 +90,18 @@ let start (args : Args.Arguments) =
     //NultiMessages.Parallel.Start(c, args.MaxDop)
     MultiStreams.start(c, args.MaxDop)
 
-let run args =
+let run args = async {
     use consumer = start args
-    consumer.AwaitCompletion() |> Async.RunSynchronously
-    consumer.RanToCompletion
+    return! consumer.AwaitCompletion()
+}
 
 [<EntryPoint>]
 let main argv =
     try let args = Args.parse argv
-        try Logging.Initialize(verbose=args.Verbose)
-            try Configuration.initialize ()
-                if run args then 0 else 3
+        try Logging.Initialize(fun c-> Logging.Configure(c, verbose=args.Verbose))
+            try Configuration.load ()
+                run args |> Async.RunSynchronously
+                0
             with e when not (e :? Args.MissingArg) -> Log.Fatal(e, "Exiting"); 2
         finally Log.CloseAndFlush()
     with Args.MissingArg msg -> eprintfn "%s" msg; 1

--- a/propulsion-projector/Infrastructure.fs
+++ b/propulsion-projector/Infrastructure.fs
@@ -31,13 +31,13 @@ type Logging() =
 #if cosmos
     static member Initialize(?minimumLevel, ?changeFeedProcessorVerbose) =
 #else
-    static member Initialize(?minimumLevel) =
+    static member Initialize(?verbose) =
 #endif
         Log.Logger <-
             LoggerConfiguration()
                 .Destructure.FSharpTypes()
                 .Enrich.FromLogContext()
-            |> fun c -> match minimumLevel with Some m -> c.MinimumLevel.Is m | None -> c
+            |> fun c -> if verbose = Some true then c.MinimumLevel.Debug() else c
 #if cosmos
             |> fun c -> c.ConfigureChangeFeedProcessorLogging((changeFeedProcessorVerbose = Some true))
 #endif

--- a/propulsion-projector/Infrastructure.fs
+++ b/propulsion-projector/Infrastructure.fs
@@ -34,12 +34,12 @@ type Logging() =
 #else
     static member Configure(configuration : LoggerConfiguration, ?verbose) =
 #endif
-            configuration
-                .Destructure.FSharpTypes()
-                .Enrich.FromLogContext()
-            |> fun c -> if verbose = Some true then c.MinimumLevel.Debug() else c
+        configuration
+            .Destructure.FSharpTypes()
+            .Enrich.FromLogContext()
+        |> fun c -> if verbose = Some true then c.MinimumLevel.Debug() else c
 #if cosmos
-            |> fun c -> c.ConfigureChangeFeedProcessorLogging((changeFeedProcessorVerbose = Some true))
+        |> fun c -> c.ConfigureChangeFeedProcessorLogging((changeFeedProcessorVerbose = Some true))
 #endif
-            |> fun c -> let t = "[{Timestamp:HH:mm:ss} {Level:u3}] {partitionKeyRangeId,2} {Message:lj} {NewLine}{Exception}"
-                        c.WriteTo.Console(theme=Sinks.SystemConsole.Themes.AnsiConsoleTheme.Code, outputTemplate=t)
+        |> fun c -> let t = "[{Timestamp:HH:mm:ss} {Level:u3}] {partitionKeyRangeId,2} {Message:lj} {NewLine}{Exception}"
+                    c.WriteTo.Console(theme=Sinks.SystemConsole.Themes.AnsiConsoleTheme.Code, outputTemplate=t)

--- a/propulsion-projector/Infrastructure.fs
+++ b/propulsion-projector/Infrastructure.fs
@@ -25,13 +25,10 @@ type LoggerConfigurationExtensions() =
         |> fun c -> if verbose then c else c.ExcludeChangeFeedProcessorV2InternalDiagnostics()
 
 #endif
-// Application logic assumes the global `Serilog.Log` is initialized _immediately_ after a successful ArgumentParser.ParseCommandline
+[<Extension>]
 type Logging() =
 
-    static member Initialize(configure) =
-        let loggerConfiguration : LoggerConfiguration = LoggerConfiguration() |> configure
-        Log.Logger <- loggerConfiguration.CreateLogger()
-
+    [<Extension>]
 #if cosmos
     static member Configure(configuration : LoggerConfiguration, ?minimumLevel, ?changeFeedProcessorVerbose) =
 #else

--- a/propulsion-projector/Infrastructure.fs
+++ b/propulsion-projector/Infrastructure.fs
@@ -30,7 +30,7 @@ type Logging() =
 
     [<Extension>]
 #if cosmos
-    static member Configure(configuration : LoggerConfiguration, ?minimumLevel, ?changeFeedProcessorVerbose) =
+    static member Configure(configuration : LoggerConfiguration, ?verbose, ?changeFeedProcessorVerbose) =
 #else
     static member Configure(configuration : LoggerConfiguration, ?verbose) =
 #endif

--- a/propulsion-projector/Infrastructure.fs
+++ b/propulsion-projector/Infrastructure.fs
@@ -31,10 +31,9 @@ type Logging() =
 #if cosmos
     static member Initialize(?minimumLevel, ?changeFeedProcessorVerbose) =
 #else
-    static member Initialize(?verbose) =
+    static member Configure(configuration : LoggerConfiguration, ?verbose) =
 #endif
-        Log.Logger <-
-            LoggerConfiguration()
+            configuration
                 .Destructure.FSharpTypes()
                 .Enrich.FromLogContext()
             |> fun c -> if verbose = Some true then c.MinimumLevel.Debug() else c
@@ -43,4 +42,3 @@ type Logging() =
 #endif
             |> fun c -> let t = "[{Timestamp:HH:mm:ss} {Level:u3}] {partitionKeyRangeId,2} {Message:lj} {NewLine}{Exception}"
                         c.WriteTo.Console(theme=Sinks.SystemConsole.Themes.AnsiConsoleTheme.Code, outputTemplate=t)
-            |> fun c -> c.CreateLogger()

--- a/propulsion-projector/Program.fs
+++ b/propulsion-projector/Program.fs
@@ -523,8 +523,8 @@ type ServiceMain() =
 [<EntryPoint>]
 let main argv =
 #if cosmos
-    let configLog (args : Args.Arguments) c = Logging.Configure(c, verbose=args.Verbose, changeFeedProcessorVerbose=args.Cosmos.CfpVerbose)
+    let configureLog (args : Args.Arguments) c = Logging.Configure(c, verbose=args.Verbose, changeFeedProcessorVerbose=args.Cosmos.CfpVerbose)
 #else
-    let configLog (args : Args.Arguments) c = Logging.Configure(c, verbose=args.Verbose)
+    let configureLog (args : Args.Arguments) c = Logging.Configure(c, verbose=args.Verbose)
 #endif
-    ServiceMain.Run(argv, Args.parse, configLog, Configuration.initialize, run)
+    ServiceMain.Run(argv, Args.parse, configureLog, Configuration.initialize, run)

--- a/propulsion-projector/Program.fs
+++ b/propulsion-projector/Program.fs
@@ -315,7 +315,7 @@ module Args =
                 | SqlMs _ ->                "specify SqlStreamStore input parameters."
 //#endif
     and Arguments(a : ParseResults<Parameters>) =
-        member __.MinimumLevel =            if a.Contains Verbose then Some Events.LogEventLevel.Debug else None
+        member __.Verbose =                 a.Contains Verbose
         member __.ConsumerGroupName =       a.GetResult ConsumerGroupName
         member __.MaxReadAhead =            a.GetResult(MaxReadAhead, 64)
         member __.MaxConcurrentProcessors = a.GetResult(MaxWriters, 1024)
@@ -482,9 +482,9 @@ let run args =
 let main argv =
     try let args = Args.parse argv
 #if cosmos
-        try Logging.Initialize(?minimumLevel=args.MinimumLevel, changeFeedProcessorVerbose=args.Cosmos.CfpVerbose)
+        try Logging.Initialize(verbose=args.Verbose, changeFeedProcessorVerbose=args.Cosmos.CfpVerbose)
 #else
-        try Logging.Initialize(?minimumLevel=args.MinimumLevel)
+        try Logging.Initialize(verbose=args.Verbose)
 #endif
             try Configuration.initialize ()
                 if run args then 0 else 3

--- a/propulsion-projector/Program.fs
+++ b/propulsion-projector/Program.fs
@@ -483,9 +483,9 @@ let run args = async {
 let main argv =
     try let args = Args.parse argv
 #if cosmos
-        try Logging.Initialize(fun c -> Logging.Configure(c, args.Verbose args.Cosmos.CfpVerbose)
+        try Log.Logger <- LoggerConfiguration().Configure(verbose=args.Verbose, changeFeedProcessorVerbose=args.CfpVerbose).CreateLogger()
 #else
-        try Logging.Initialize(fun c -> Logging.Configure(c, verbose=args.Verbose))
+        try Log.Logger <- LoggerConfiguration().Configure(verbose=args.Verbose).CreateLogger()
 #endif
             try Configuration.initialize ()
                 run args  |> Async.RunSynchronously

--- a/propulsion-projector/Program.fs
+++ b/propulsion-projector/Program.fs
@@ -482,7 +482,7 @@ let run args = async {
 let main argv =
     try let args = Args.parse argv
 #if cosmos
-        try Log.Logger <- LoggerConfiguration().Configure(verbose=args.Verbose, changeFeedProcessorVerbose=args.CfpVerbose).CreateLogger()
+        try Log.Logger <- LoggerConfiguration().Configure(verbose=args.Verbose, changeFeedProcessorVerbose=args.Cosmos.CfpVerbose).CreateLogger()
 #else
         try Log.Logger <- LoggerConfiguration().Configure(verbose=args.Verbose).CreateLogger()
 #endif

--- a/propulsion-projector/Program.fs
+++ b/propulsion-projector/Program.fs
@@ -315,7 +315,7 @@ module Args =
                 | SqlMs _ ->                "specify SqlStreamStore input parameters."
 //#endif
     and Arguments(a : ParseResults<Parameters>) =
-        member __.Verbose =                 a.Contains Verbose
+        member __.MinimumLevel =            if a.Contains Verbose then Some Events.LogEventLevel.Debug else None
         member __.ConsumerGroupName =       a.GetResult ConsumerGroupName
         member __.MaxReadAhead =            a.GetResult(MaxReadAhead, 64)
         member __.MaxConcurrentProcessors = a.GetResult(MaxWriters, 1024)
@@ -374,34 +374,6 @@ module Args =
         let parser = ArgumentParser.Create<Parameters>(programName=programName)
         parser.ParseCommandLine argv |> Arguments
 
-// TODO remove this entire comment after reading https://github.com/jet/dotnet-templates#module-logging
-// Application logic assumes the global `Serilog.Log` is initialized _immediately_ after a successful ArgumentParser.ParseCommandline
-module Logging =
-
-#if cosmos
-    let initialize verbose changeFeedProcessorVerbose =
-#else
-    let initialize verbose =
-#endif
-        Log.Logger <-
-            LoggerConfiguration()
-                .Destructure.FSharpTypes()
-                .Enrich.FromLogContext()
-            |> fun c -> if verbose then c.MinimumLevel.Debug() else c
-#if cosmos
-            // LibLog writes to the global logger, so we need to control the emission
-            |> fun c -> let cfpl = if changeFeedProcessorVerbose then Serilog.Events.LogEventLevel.Debug else Serilog.Events.LogEventLevel.Warning
-                        c.MinimumLevel.Override("Microsoft.Azure.Documents.ChangeFeedProcessor", cfpl)
-            |> fun c -> let isCfp429a = Filters.Matching.FromSource("Microsoft.Azure.Documents.ChangeFeedProcessor.LeaseManagement.DocumentServiceLeaseUpdater").Invoke
-                        let isCfp429b = Filters.Matching.FromSource("Microsoft.Azure.Documents.ChangeFeedProcessor.PartitionManagement.LeaseRenewer").Invoke
-                        let isCfp429c = Filters.Matching.FromSource("Microsoft.Azure.Documents.ChangeFeedProcessor.PartitionManagement.PartitionLoadBalancer").Invoke
-                        let isCfp429d = Filters.Matching.FromSource("Microsoft.Azure.Documents.ChangeFeedProcessor.FeedProcessing.PartitionProcessor").Invoke
-                        let isCfp x = isCfp429a x || isCfp429b x || isCfp429c x || isCfp429d x
-                        if changeFeedProcessorVerbose then c else c.Filter.ByExcluding(fun x -> isCfp x)
-#endif
-            |> fun c -> let t = "[{Timestamp:HH:mm:ss} {Level:u3}] {partitionKeyRangeId,2} {Message:lj} {NewLine}{Exception}"
-                        c.WriteTo.Console(theme=Sinks.SystemConsole.Themes.AnsiConsoleTheme.Code, outputTemplate=t)
-            |> fun c -> c.CreateLogger()
 //#if esdb
 
 module Checkpoints =
@@ -510,9 +482,9 @@ let run args =
 let main argv =
     try let args = Args.parse argv
 #if cosmos
-        try Logging.initialize args.Verbose args.Cosmos.CfpVerbose
+        try Logging.Initialize(?minimumLevel=args.MinimumLevel, changeFeedProcessorVerbose=args.Cosmos.CfpVerbose)
 #else
-        try Logging.initialize args.Verbose
+        try Logging.Initialize(?minimumLevel=args.MinimumLevel)
 #endif
             try Configuration.initialize ()
                 if run args then 0 else 3

--- a/propulsion-projector/Projector.fsproj
+++ b/propulsion-projector/Projector.fsproj
@@ -8,6 +8,7 @@
 
   <ItemGroup>
     <None Include="README.md" />
+    <Compile Include="Infrastructure.fs" />
     <Compile Include="Handler.fs" />
     <Compile Include="Program.fs" />
   </ItemGroup>

--- a/propulsion-reactor/.template.config/template.json
+++ b/propulsion-reactor/.template.config/template.json
@@ -81,7 +81,6 @@
         {
           "condition": "blank && !kafka",
           "exclude": [
-            "Infrastructure.fs",
             "Todo.fs",
             "Contract.fs"
           ]

--- a/propulsion-reactor/Infrastructure.fs
+++ b/propulsion-reactor/Infrastructure.fs
@@ -58,7 +58,7 @@ type LoggerConfigurationExtensions() =
 type Logging() =
 
 #if (!kafkaEventSpans)
-    static member Initialize(?minimumLevel, ?changeFeedProcessorVerbose) =
+    static member Initialize(?verbose, ?changeFeedProcessorVerbose) =
 #else
     static member Initialize(?minimumLevel) =
 #endif
@@ -66,7 +66,7 @@ type Logging() =
             LoggerConfiguration()
                 .Destructure.FSharpTypes()
                 .Enrich.FromLogContext()
-            |> fun c -> match minimumLevel with Some m -> c.MinimumLevel.Is m | None -> c
+            |> fun c -> if verbose = Some true then c.MinimumLevel.Debug() else c
 #if (!kafkaEventSpans)
             |> fun c -> c.ConfigureChangeFeedProcessorLogging((changeFeedProcessorVerbose = Some true))
 #endif

--- a/propulsion-reactor/Infrastructure.fs
+++ b/propulsion-reactor/Infrastructure.fs
@@ -54,13 +54,10 @@ type LoggerConfigurationExtensions() =
         |> fun c -> if verbose then c else c.ExcludeChangeFeedProcessorV2InternalDiagnostics()
 
 #endif
-// Application logic assumes the global `Serilog.Log` is initialized _immediately_ after a successful ArgumentParser.ParseCommandline
+[<Extension>]
 type Logging() =
 
-    static member Initialize(configure) =
-        let loggerConfiguration : LoggerConfiguration = LoggerConfiguration() |> configure
-        Log.Logger <- loggerConfiguration.CreateLogger()
-
+    [<Extension>]
 #if (!kafkaEventSpans)
     static member Configure(configuration : LoggerConfiguration, ?verbose, ?changeFeedProcessorVerbose) =
 #else

--- a/propulsion-reactor/Infrastructure.fs
+++ b/propulsion-reactor/Infrastructure.fs
@@ -61,7 +61,7 @@ type Logging() =
 #if (!kafkaEventSpans)
     static member Configure(configuration : LoggerConfiguration, ?verbose, ?changeFeedProcessorVerbose) =
 #else
-    static member Configure(configuration : LoggerConfiguration, ?minimumLevel) =
+    static member Configure(configuration : LoggerConfiguration, ?verbose) =
 #endif
         configuration
             .Destructure.FSharpTypes()

--- a/propulsion-reactor/Infrastructure.fs
+++ b/propulsion-reactor/Infrastructure.fs
@@ -1,10 +1,13 @@
 ﻿namespace ReactorTemplate
 
-open System.Runtime.CompilerServices
+#if (kafka || !blank)
 open FSharp.UMX // see https://github.com/fsprojects/FSharp.UMX - % operator and ability to apply units of measure to Guids+strings
+#endif
 open Serilog
 open System
+open System.Runtime.CompilerServices
 
+#if (kafka || !blank)
 module EventCodec =
 
     /// Uses the supplied codec to decode the supplied event record `x` (iff at LogEventLevel.Debug, detail fails to `log` citing the `stream` and content)
@@ -29,6 +32,7 @@ module ClientId =
     let parse (value : string) : ClientId = let raw = Guid.Parse value in % raw
     let (|Parse|) = parse
 
+#endif
 #if (!kafkaEventSpans)
 [<Extension>]
 type LoggerConfigurationExtensions() =

--- a/propulsion-reactor/Program.fs
+++ b/propulsion-reactor/Program.fs
@@ -686,11 +686,11 @@ let run args = async {
 let main argv =
     try let args = Args.parse argv
 #if (!kafkaEventSpans)
-        try Logging.Initialize(fun c -> Logging.Configure(c, verbose=args.Verbose, changeFeedProcessorVerbose=args.CfpVerbose))
+        try Log.Logger <- LoggerConfiguration().Configure(verbose=args.Verbose, changeFeedProcessorVerbose=args.CfpVerbose).CreateLogger()
 #else
-        try Logging.Initialize(fun c -> Logging.Configure(c, verbose=args.Verbose))
+        try Log.Logger <- LoggerConfiguration().Configure(verbose=args.Verbose).CreateLogger()
 #endif
-            try Configuration.load ()
+            try Configuration.initialize ()
                 run args |> Async.RunSynchronously
                 0
             with e when not (e :? Args.MissingArg) -> Log.Fatal(e, "Exiting"); 2

--- a/propulsion-reactor/Program.fs
+++ b/propulsion-reactor/Program.fs
@@ -27,7 +27,7 @@ module Configuration =
             printfn "Setting %s from %A" var key
             EnvVar.set var (loadF key)
 
-    let initialize () =
+    let load () =
         // e.g. initEnvVar     "EQUINOX_COSMOS_CONTAINER"    "CONSUL KEY" readFromConsul
         () // TODO add any custom logic preprocessing commandline arguments and/or gathering custom defaults from external sources, etc
 
@@ -672,26 +672,27 @@ let build (args : Args.Arguments) =
         sink, pipeline
 #endif // !kafkaEventSpans
 
-let run args =
+let run args = async {
 #if (!kafkaEventSpans)
     let sink, pipeline = build args
     pipeline |> Async.Start
 #else
     let sink = build args
 #endif
-    sink.AwaitCompletion() |> Async.RunSynchronously
-    sink.RanToCompletion
+    return! sink.AwaitCompletion()
+}
 
 [<EntryPoint>]
 let main argv =
     try let args = Args.parse argv
 #if (!kafkaEventSpans)
-        try Logging.Initialize(verbose=args.Verbose, changeFeedProcessorVerbose=args.CfpVerbose)
+        try Logging.Initialize(fun c -> Logging.Configure(c, verbose=args.Verbose, changeFeedProcessorVerbose=args.CfpVerbose))
 #else
-        try Logging.Initialize(verbose=args.Verbose)
+        try Logging.Initialize(fun c -> Logging.Configure(c, verbose=args.Verbose))
 #endif
-            try Configuration.initialize ()
-                if run args then 0 else 3
+            try Configuration.load ()
+                run args |> Async.RunSynchronously
+                0
             with e when not (e :? Args.MissingArg) -> Log.Fatal(e, "Exiting"); 2
         finally Log.CloseAndFlush()
     with Args.MissingArg msg -> eprintfn "%s" msg; 1

--- a/propulsion-reactor/Program.fs
+++ b/propulsion-reactor/Program.fs
@@ -27,7 +27,7 @@ module Configuration =
             printfn "Setting %s from %A" var key
             EnvVar.set var (loadF key)
 
-    let load () =
+    let initialize () =
         // e.g. initEnvVar     "EQUINOX_COSMOS_CONTAINER"    "CONSUL KEY" readFromConsul
         () // TODO add any custom logic preprocessing commandline arguments and/or gathering custom defaults from external sources, etc
 

--- a/propulsion-reactor/Program.fs
+++ b/propulsion-reactor/Program.fs
@@ -106,7 +106,7 @@ module Args =
 //#endif
         member __.MaxReadAhead =            a.GetResult(MaxReadAhead, 16)
         member __.MaxConcurrentStreams =    a.GetResult(MaxWriters, 8)
-        member __.MinimumLevel =            if a.Contains Parameters.Verbose then Some Events.LogEventLevel.Debug else None
+        member __.Verbose =                 a.Contains Parameters.Verbose
         member __.StatsInterval =           TimeSpan.FromMinutes 1.
         member __.StateInterval =           TimeSpan.FromMinutes 5.
 //#if filter
@@ -686,9 +686,9 @@ let run args =
 let main argv =
     try let args = Args.parse argv
 #if (!kafkaEventSpans)
-        try Logging.Initialize(?minimumLevel=args.MinimumLevel, changeFeedProcessorVerbose=args.CfpVerbose)
+        try Logging.Initialize(verbose=args.Verbose, changeFeedProcessorVerbose=args.CfpVerbose)
 #else
-        try Logging.Initialize(?minimumLevel=args.MinimumLevel)
+        try Logging.Initialize(verbose=args.Verbose)
 #endif
             try Configuration.initialize ()
                 if run args then 0 else 3

--- a/propulsion-reactor/Reactor.fsproj
+++ b/propulsion-reactor/Reactor.fsproj
@@ -10,9 +10,7 @@
         <!--#if (!kafkaEventSpans) -->
         <None Include="README.md" />
         <!--#endif-->
-        <!--#if (kafka || !blank) -->
         <Compile Include="Infrastructure.fs" />
-        <!--#endif-->
         <!--#if (!blank) -->
         <Compile Include="Todo.fs" />
         <!--#endif-->

--- a/propulsion-summary-consumer/Infrastructure.fs
+++ b/propulsion-summary-consumer/Infrastructure.fs
@@ -30,12 +30,12 @@ module ClientId =
 // Application logic assumes the global `Serilog.Log` is initialized _immediately_ after a successful ArgumentParser.ParseCommandline
 type Logging() =
 
-    static member Initialize(?minimumLevel) =
+    static member Initialize(?verbose) =
         Log.Logger <-
             LoggerConfiguration()
                 .Destructure.FSharpTypes()
                 .Enrich.FromLogContext()
-            |> fun c -> match minimumLevel with Some m -> c.MinimumLevel.Is m | None -> c
+            |> fun c -> if verbose = Some true then c.MinimumLevel.Debug() else c
             |> fun c -> let theme = Sinks.SystemConsole.Themes.AnsiConsoleTheme.Code
                         c.WriteTo.Console(theme=theme, outputTemplate="[{Timestamp:HH:mm:ss} {Level:u3}] {Message:lj} {Properties}{NewLine}{Exception}")
             |> fun c -> c.CreateLogger()

--- a/propulsion-summary-consumer/Infrastructure.fs
+++ b/propulsion-summary-consumer/Infrastructure.fs
@@ -30,12 +30,14 @@ module ClientId =
 // Application logic assumes the global `Serilog.Log` is initialized _immediately_ after a successful ArgumentParser.ParseCommandline
 type Logging() =
 
-    static member Initialize(?verbose) =
-        Log.Logger <-
-            LoggerConfiguration()
-                .Destructure.FSharpTypes()
-                .Enrich.FromLogContext()
-            |> fun c -> if verbose = Some true then c.MinimumLevel.Debug() else c
-            |> fun c -> let theme = Sinks.SystemConsole.Themes.AnsiConsoleTheme.Code
-                        c.WriteTo.Console(theme=theme, outputTemplate="[{Timestamp:HH:mm:ss} {Level:u3}] {Message:lj} {Properties}{NewLine}{Exception}")
-            |> fun c -> c.CreateLogger()
+    static member Initialize(configure) =
+        let loggerConfiguration : LoggerConfiguration = LoggerConfiguration() |> configure
+        Log.Logger <- loggerConfiguration.CreateLogger()
+
+    static member Configure(configuration : LoggerConfiguration, ?verbose) =
+        configuration
+            .Destructure.FSharpTypes()
+            .Enrich.FromLogContext()
+        |> fun c -> if verbose = Some true then c.MinimumLevel.Debug() else c
+        |> fun c -> let theme = Sinks.SystemConsole.Themes.AnsiConsoleTheme.Code
+                    c.WriteTo.Console(theme=theme, outputTemplate="[{Timestamp:HH:mm:ss} {Level:u3}] {Message:lj} {Properties}{NewLine}{Exception}")

--- a/propulsion-summary-consumer/Infrastructure.fs
+++ b/propulsion-summary-consumer/Infrastructure.fs
@@ -1,6 +1,7 @@
 ﻿namespace ConsumerTemplate
 
 open FSharp.UMX // see https://github.com/fsprojects/FSharp.UMX - % operator and ability to apply units of measure to Guids+strings
+open Serilog
 open System
 
 module EventCodec =
@@ -25,8 +26,6 @@ module ClientId =
     let toString (value : ClientId) : string = Guid.toStringN %value
     let parse (value : string) : ClientId = let raw = Guid.Parse value in % raw
     let (|Parse|) = parse
-
-open Serilog
 
 // Application logic assumes the global `Serilog.Log` is initialized _immediately_ after a successful ArgumentParser.ParseCommandline
 type Logging() =

--- a/propulsion-summary-consumer/Infrastructure.fs
+++ b/propulsion-summary-consumer/Infrastructure.fs
@@ -27,13 +27,10 @@ module ClientId =
     let parse (value : string) : ClientId = let raw = Guid.Parse value in % raw
     let (|Parse|) = parse
 
-// Application logic assumes the global `Serilog.Log` is initialized _immediately_ after a successful ArgumentParser.ParseCommandline
+[<System.Runtime.CompilerServices.Extension>]
 type Logging() =
 
-    static member Initialize(configure) =
-        let loggerConfiguration : LoggerConfiguration = LoggerConfiguration() |> configure
-        Log.Logger <- loggerConfiguration.CreateLogger()
-
+    [<System.Runtime.CompilerServices.Extension>]
     static member Configure(configuration : LoggerConfiguration, ?verbose) =
         configuration
             .Destructure.FSharpTypes()

--- a/propulsion-summary-consumer/Program.fs
+++ b/propulsion-summary-consumer/Program.fs
@@ -18,7 +18,7 @@ module Configuration =
             printfn "Setting %s from %A" var key
             EnvVar.set var (loadF key)
 
-    let initialize () =
+    let load () =
         // e.g. initEnvVar     "EQUINOX_COSMOS_CONTAINER"    "CONSUL KEY" readFromConsul
         () // TODO add any custom logic preprocessing commandline arguments and/or gathering custom defaults from external sources, etc
 
@@ -139,17 +139,18 @@ let start (args : Args.Arguments) =
         (   Log.Logger, config, parseStreamSummaries, Ingester.ingest service, args.MaxConcurrentStreams,
             stats, args.StateInterval)
 
-let run args =
+let run args = async {
     use consumer = start args
-    consumer.AwaitCompletion() |> Async.RunSynchronously
-    consumer.RanToCompletion
+    return! consumer.AwaitCompletion()
+}
 
 [<EntryPoint>]
 let main argv =
     try let args = Args.parse argv
-        try Logging.Initialize(verbose=args.Verbose)
-            try Configuration.initialize ()
-                if run args then 0 else 3
+        try Logging.Initialize(fun c -> Logging.Configure(c, verbose=args.Verbose))
+            try Configuration.load ()
+                run args |> Async.RunSynchronously
+                0
             with e when not (e :? Args.MissingArg) -> Log.Fatal(e, "Exiting"); 2
         finally Log.CloseAndFlush()
     with Args.MissingArg msg -> eprintfn "%s" msg; 1

--- a/propulsion-summary-consumer/Program.fs
+++ b/propulsion-summary-consumer/Program.fs
@@ -18,7 +18,7 @@ module Configuration =
             printfn "Setting %s from %A" var key
             EnvVar.set var (loadF key)
 
-    let load () =
+    let initialize () =
         // e.g. initEnvVar     "EQUINOX_COSMOS_CONTAINER"    "CONSUL KEY" readFromConsul
         () // TODO add any custom logic preprocessing commandline arguments and/or gathering custom defaults from external sources, etc
 

--- a/propulsion-summary-consumer/Program.fs
+++ b/propulsion-summary-consumer/Program.fs
@@ -112,7 +112,7 @@ module Args =
 
         member __.MaxConcurrentStreams =    a.GetResult(MaxWriters, 8)
 
-        member __.MinimumLevel =            if a.Contains Verbose then Some Events.LogEventLevel.Debug else None
+        member __.Verbose =                 a.Contains Verbose
         member __.StatsInterval =           TimeSpan.FromMinutes 1.
         member __.StateInterval =           TimeSpan.FromMinutes 5.
 
@@ -147,7 +147,7 @@ let run args =
 [<EntryPoint>]
 let main argv =
     try let args = Args.parse argv
-        try Logging.Initialize(?minimumLevel=args.MinimumLevel)
+        try Logging.Initialize(verbose=args.Verbose)
             try Configuration.initialize ()
                 if run args then 0 else 3
             with e when not (e :? Args.MissingArg) -> Log.Fatal(e, "Exiting"); 2

--- a/propulsion-summary-consumer/Program.fs
+++ b/propulsion-summary-consumer/Program.fs
@@ -147,8 +147,8 @@ let run args = async {
 [<EntryPoint>]
 let main argv =
     try let args = Args.parse argv
-        try Logging.Initialize(fun c -> Logging.Configure(c, verbose=args.Verbose))
-            try Configuration.load ()
+        try Log.Logger <- LoggerConfiguration().Configure(verbose=args.Verbose).CreateLogger()
+            try Configuration.initialize ()
                 run args |> Async.RunSynchronously
                 0
             with e when not (e :? Args.MissingArg) -> Log.Fatal(e, "Exiting"); 2

--- a/propulsion-sync/Infrastructure.fs
+++ b/propulsion-sync/Infrastructure.fs
@@ -31,10 +31,10 @@ type Logging() =
         configuration
             .Destructure.FSharpTypes()
             .Enrich.FromLogContext()
+        |> fun c -> if verbose then c.MinimumLevel.Debug() else c
         |> fun c -> c.ConfigureChangeFeedProcessorLogging(changeFeedProcessorVerbose)
         |> fun c -> let ingesterLevel = if changeFeedProcessorVerbose then LogEventLevel.Debug else LogEventLevel.Information
                     c.MinimumLevel.Override(typeof<Propulsion.Streams.Scheduling.StreamSchedulingEngine>.FullName, ingesterLevel)
-        |> fun c -> if verbose then c.MinimumLevel.Debug() else c
         |> fun c -> let generalLevel = if verbose then LogEventLevel.Information else LogEventLevel.Warning
                     c.MinimumLevel.Override(typeof<Propulsion.Cosmos.Internal.Writer.Result>.FullName, generalLevel)
                      .MinimumLevel.Override(typeof<Propulsion.EventStore.Internal.Writer.Result>.FullName, generalLevel)

--- a/propulsion-sync/Infrastructure.fs
+++ b/propulsion-sync/Infrastructure.fs
@@ -1,10 +1,8 @@
-[<AutoOpen>]
-module ProjectorTemplate.Infrastructure
+namespace SyncTemplate
 
 open Serilog
 open System.Runtime.CompilerServices
 
-#if cosmos
 [<Extension>]
 type LoggerConfigurationExtensions() =
 
@@ -23,26 +21,3 @@ type LoggerConfigurationExtensions() =
         let cfpl = if verbose then Serilog.Events.LogEventLevel.Debug else Serilog.Events.LogEventLevel.Warning
         c.MinimumLevel.Override("Microsoft.Azure.Documents.ChangeFeedProcessor", cfpl)
         |> fun c -> if verbose then c else c.ExcludeChangeFeedProcessorV2InternalDiagnostics()
-
-#endif
-// Application logic assumes the global `Serilog.Log` is initialized _immediately_ after a successful ArgumentParser.ParseCommandline
-type Logging() =
-
-    static member Initialize(configure) =
-        let loggerConfiguration : LoggerConfiguration = LoggerConfiguration() |> configure
-        Log.Logger <- loggerConfiguration.CreateLogger()
-
-#if cosmos
-    static member Configure(configuration : LoggerConfiguration, ?minimumLevel, ?changeFeedProcessorVerbose) =
-#else
-    static member Configure(configuration : LoggerConfiguration, ?verbose) =
-#endif
-            configuration
-                .Destructure.FSharpTypes()
-                .Enrich.FromLogContext()
-            |> fun c -> if verbose = Some true then c.MinimumLevel.Debug() else c
-#if cosmos
-            |> fun c -> c.ConfigureChangeFeedProcessorLogging((changeFeedProcessorVerbose = Some true))
-#endif
-            |> fun c -> let t = "[{Timestamp:HH:mm:ss} {Level:u3}] {partitionKeyRangeId,2} {Message:lj} {NewLine}{Exception}"
-                        c.WriteTo.Console(theme=Sinks.SystemConsole.Themes.AnsiConsoleTheme.Code, outputTemplate=t)

--- a/propulsion-sync/Infrastructure.fs
+++ b/propulsion-sync/Infrastructure.fs
@@ -1,6 +1,7 @@
 namespace SyncTemplate
 
 open Serilog
+open Serilog.Events
 open System.Runtime.CompilerServices
 
 [<Extension>]
@@ -21,3 +22,37 @@ type LoggerConfigurationExtensions() =
         let cfpl = if verbose then Serilog.Events.LogEventLevel.Debug else Serilog.Events.LogEventLevel.Warning
         c.MinimumLevel.Override("Microsoft.Azure.Documents.ChangeFeedProcessor", cfpl)
         |> fun c -> if verbose then c else c.ExcludeChangeFeedProcessorV2InternalDiagnostics()
+
+[<System.Runtime.CompilerServices.Extension>]
+type Logging() =
+
+    [<System.Runtime.CompilerServices.Extension>]
+    static member Configure(configuration : LoggerConfiguration, verbose, changeFeedProcessorVerbose, ?maybeSeqEndpoint) =
+        configuration
+            .Destructure.FSharpTypes()
+            .Enrich.FromLogContext()
+        |> fun c -> c.ConfigureChangeFeedProcessorLogging(changeFeedProcessorVerbose)
+        |> fun c -> let ingesterLevel = if changeFeedProcessorVerbose then LogEventLevel.Debug else LogEventLevel.Information
+                    c.MinimumLevel.Override(typeof<Propulsion.Streams.Scheduling.StreamSchedulingEngine>.FullName, ingesterLevel)
+        |> fun c -> if verbose then c.MinimumLevel.Debug() else c
+        |> fun c -> let generalLevel = if verbose then LogEventLevel.Information else LogEventLevel.Warning
+                    c.MinimumLevel.Override(typeof<Propulsion.Cosmos.Internal.Writer.Result>.FullName, generalLevel)
+                     .MinimumLevel.Override(typeof<Propulsion.EventStore.Internal.Writer.Result>.FullName, generalLevel)
+                     .MinimumLevel.Override(typeof<Propulsion.EventStore.Checkpoint.CheckpointSeries>.FullName, LogEventLevel.Information)
+        |> fun c -> let t = "[{Timestamp:HH:mm:ss} {Level:u3}] {partitionKeyRangeId} {Tranche} {Message:lj} {NewLine}{Exception}"
+                    let configure (a : Configuration.LoggerSinkConfiguration) : unit =
+                        a.Logger(fun l ->
+                            l.WriteTo.Sink(Equinox.EventStore.Log.InternalMetrics.Stats.LogSink())
+                             .WriteTo.Sink(Equinox.Cosmos.Store.Log.InternalMetrics.Stats.LogSink()) |> ignore) |> ignore
+                        a.Logger(fun l ->
+                            let isEqx = Filters.Matching.FromSource<Equinox.Cosmos.Core.Context>().Invoke
+                            let isWriterA = Filters.Matching.FromSource<Propulsion.EventStore.Internal.Writer.Result>().Invoke
+                            let isWriterB = Filters.Matching.FromSource<Propulsion.Cosmos.Internal.Writer.Result>().Invoke
+                            let isCp = Filters.Matching.FromSource<Propulsion.EventStore.Checkpoint.CheckpointSeries>().Invoke
+                            let l =
+                                if changeFeedProcessorVerbose then l
+                                else l.Filter.ByExcluding(fun x -> isEqx x || isWriterA x || isWriterB x || isCp x)
+                            l.WriteTo.Console(theme=Sinks.SystemConsole.Themes.AnsiConsoleTheme.Code, outputTemplate=t)
+                            |> ignore) |> ignore
+                    c.WriteTo.Async(bufferSize=65536, blockWhenFull=true, configure=System.Action<_> configure)
+        |> fun c -> match maybeSeqEndpoint with None -> c | Some endpoint -> c.WriteTo.Seq(endpoint)

--- a/propulsion-sync/Program.fs
+++ b/propulsion-sync/Program.fs
@@ -25,7 +25,7 @@ module Configuration =
             printfn "Setting %s from %A" var key
             EnvVar.set var (loadF key)
 
-    let load () =
+    let initialize () =
         // e.g. initEnvVar     "EQUINOX_COSMOS_CONTAINER"    "CONSUL KEY" readFromConsul
         () // TODO add any custom logic preprocessing commandline arguments and/or gathering custom defaults from external sources, etc
 

--- a/propulsion-sync/Program.fs
+++ b/propulsion-sync/Program.fs
@@ -440,7 +440,6 @@ module Args =
         let parser = ArgumentParser.Create<Parameters>(programName=programName)
         parser.ParseCommandLine argv |> Arguments
 
-// TODO remove this entire comment after reading https://github.com/jet/dotnet-templates#module-logging
 // Application logic assumes the global `Serilog.Log` is initialized _immediately_ after a successful ArgumentParser.ParseCommandline
 module Logging =
 

--- a/propulsion-sync/Program.fs
+++ b/propulsion-sync/Program.fs
@@ -25,7 +25,7 @@ module Configuration =
             printfn "Setting %s from %A" var key
             EnvVar.set var (loadF key)
 
-    let initialize () =
+    let load () =
         // e.g. initEnvVar     "EQUINOX_COSMOS_CONTAINER"    "CONSUL KEY" readFromConsul
         () // TODO add any custom logic preprocessing commandline arguments and/or gathering custom defaults from external sources, etc
 
@@ -440,47 +440,44 @@ module Args =
         let parser = ArgumentParser.Create<Parameters>(programName=programName)
         parser.ParseCommandLine argv |> Arguments
 
-// Application logic assumes the global `Serilog.Log` is initialized _immediately_ after a successful ArgumentParser.ParseCommandline
-module Logging =
+open Serilog.Events
 
-    open Serilog.Events
-    let initialize verbose changeFeedProcessorVerbose maybeSeqEndpoint =
-        Log.Logger <-
-            LoggerConfiguration()
-                .Destructure.FSharpTypes()
-                .Enrich.FromLogContext()
-            |> fun c -> // LibLog writes to the global logger, so we need to control the emission if we don't want to pass loggers everywhere
-                        let cfpLevel = if changeFeedProcessorVerbose then LogEventLevel.Debug else LogEventLevel.Warning
-                        c.MinimumLevel.Override("Microsoft.Azure.Documents.ChangeFeedProcessor", cfpLevel)
-            |> fun c -> let ingesterLevel = if changeFeedProcessorVerbose then LogEventLevel.Debug else LogEventLevel.Information
-                        c.MinimumLevel.Override(typeof<Propulsion.Streams.Scheduling.StreamSchedulingEngine>.FullName, ingesterLevel)
-            |> fun c -> if verbose then c.MinimumLevel.Debug() else c
-            |> fun c -> let generalLevel = if verbose then LogEventLevel.Information else LogEventLevel.Warning
-                        c.MinimumLevel.Override(typeof<Propulsion.Cosmos.Internal.Writer.Result>.FullName, generalLevel)
-                         .MinimumLevel.Override(typeof<Propulsion.EventStore.Internal.Writer.Result>.FullName, generalLevel)
-                         .MinimumLevel.Override(typeof<Checkpoint.CheckpointSeries>.FullName, LogEventLevel.Information)
-            |> fun c -> let t = "[{Timestamp:HH:mm:ss} {Level:u3}] {partitionKeyRangeId} {Tranche} {Message:lj} {NewLine}{Exception}"
-                        let configure (a : Configuration.LoggerSinkConfiguration) : unit =
-                            a.Logger(fun l ->
-                                l.WriteTo.Sink(Equinox.EventStore.Log.InternalMetrics.Stats.LogSink())
-                                 .WriteTo.Sink(Equinox.Cosmos.Store.Log.InternalMetrics.Stats.LogSink()) |> ignore) |> ignore
-                            a.Logger(fun l ->
-                                let isEqx = Filters.Matching.FromSource<Core.Context>().Invoke
-                                let isWriterA = Filters.Matching.FromSource<Propulsion.EventStore.Internal.Writer.Result>().Invoke
-                                let isWriterB = Filters.Matching.FromSource<Propulsion.Cosmos.Internal.Writer.Result>().Invoke
-                                let isCp = Filters.Matching.FromSource<Checkpoint.CheckpointSeries>().Invoke
-                                let isCfp429a = Filters.Matching.FromSource("Microsoft.Azure.Documents.ChangeFeedProcessor.LeaseManagement.DocumentServiceLeaseUpdater").Invoke
-                                let isCfp429b = Filters.Matching.FromSource("Microsoft.Azure.Documents.ChangeFeedProcessor.PartitionManagement.LeaseRenewer").Invoke
-                                let isCfp429c = Filters.Matching.FromSource("Microsoft.Azure.Documents.ChangeFeedProcessor.PartitionManagement.PartitionLoadBalancer").Invoke
-                                let isCfp429d = Filters.Matching.FromSource("Microsoft.Azure.Documents.ChangeFeedProcessor.FeedProcessing.PartitionProcessor").Invoke
-                                let isCfp x = isCfp429a x || isCfp429b x || isCfp429c x || isCfp429d x
-                                (if changeFeedProcessorVerbose then l else l.Filter.ByExcluding(fun x -> isEqx x || isWriterA x || isWriterB x || isCp x || isCfp x))
-                                    .WriteTo.Console(theme=Sinks.SystemConsole.Themes.AnsiConsoleTheme.Code, outputTemplate=t)
-                                    |> ignore) |> ignore
-                        c.WriteTo.Async(bufferSize=65536, blockWhenFull=true, configure=Action<_> configure)
-            |> fun c -> match maybeSeqEndpoint with None -> c | Some endpoint -> c.WriteTo.Seq(endpoint)
-            |> fun c -> c.CreateLogger()
-        Log.ForContext<Propulsion.Streams.Scheduling.StreamSchedulingEngine>(), Log.ForContext<Core.Context>()
+// Application logic assumes the global `Serilog.Log` is initialized _immediately_ after a successful ArgumentParser.ParseCommandline
+type Logging() =
+
+    static member Initialize(configure) =
+        let loggerConfiguration : LoggerConfiguration = LoggerConfiguration() |> configure
+        Log.Logger <- loggerConfiguration.CreateLogger()
+
+    static member Configure(configuration : LoggerConfiguration, verbose, changeFeedProcessorVerbose, ?maybeSeqEndpoint) =
+        configuration
+            .Destructure.FSharpTypes()
+            .Enrich.FromLogContext()
+        |> fun c -> c.ConfigureChangeFeedProcessorLogging(changeFeedProcessorVerbose)
+        |> fun c -> let ingesterLevel = if changeFeedProcessorVerbose then LogEventLevel.Debug else LogEventLevel.Information
+                    c.MinimumLevel.Override(typeof<Propulsion.Streams.Scheduling.StreamSchedulingEngine>.FullName, ingesterLevel)
+        |> fun c -> if verbose then c.MinimumLevel.Debug() else c
+        |> fun c -> let generalLevel = if verbose then LogEventLevel.Information else LogEventLevel.Warning
+                    c.MinimumLevel.Override(typeof<Propulsion.Cosmos.Internal.Writer.Result>.FullName, generalLevel)
+                     .MinimumLevel.Override(typeof<Propulsion.EventStore.Internal.Writer.Result>.FullName, generalLevel)
+                     .MinimumLevel.Override(typeof<Propulsion.EventStore.Checkpoint.CheckpointSeries>.FullName, LogEventLevel.Information)
+        |> fun c -> let t = "[{Timestamp:HH:mm:ss} {Level:u3}] {partitionKeyRangeId} {Tranche} {Message:lj} {NewLine}{Exception}"
+                    let configure (a : Configuration.LoggerSinkConfiguration) : unit =
+                        a.Logger(fun l ->
+                            l.WriteTo.Sink(Equinox.EventStore.Log.InternalMetrics.Stats.LogSink())
+                             .WriteTo.Sink(Equinox.Cosmos.Store.Log.InternalMetrics.Stats.LogSink()) |> ignore) |> ignore
+                        a.Logger(fun l ->
+                            let isEqx = Filters.Matching.FromSource<Equinox.Cosmos.Core.Context>().Invoke
+                            let isWriterA = Filters.Matching.FromSource<Propulsion.EventStore.Internal.Writer.Result>().Invoke
+                            let isWriterB = Filters.Matching.FromSource<Propulsion.Cosmos.Internal.Writer.Result>().Invoke
+                            let isCp = Filters.Matching.FromSource<Propulsion.EventStore.Checkpoint.CheckpointSeries>().Invoke
+                            let l =
+                                if changeFeedProcessorVerbose then l
+                                else l.Filter.ByExcluding(fun x -> isEqx x || isWriterA x || isWriterB x || isCp x)
+                            l.WriteTo.Console(theme=Sinks.SystemConsole.Themes.AnsiConsoleTheme.Code, outputTemplate=t)
+                            |> ignore) |> ignore
+                    c.WriteTo.Async(bufferSize=65536, blockWhenFull=true, configure=System.Action<_> configure)
+        |> fun c -> match maybeSeqEndpoint with None -> c | Some endpoint -> c.WriteTo.Seq(endpoint)
 
  //#if marveleqx
 [<RequireQualifiedAccess>]
@@ -646,18 +643,20 @@ let build (args : Args.Arguments, log, storeLog : ILogger) =
                 args.MaxReadAhead, args.StatsInterval)
         sink, runPipeline
 
-let run (args, log, storeLog) =
+let run args = async {
+    let log, storeLog = Log.ForContext<Propulsion.Streams.Scheduling.StreamSchedulingEngine>(), Log.ForContext<Equinox.Cosmos.Core.Context>()
     let sink, pipeline = build (args, log, storeLog)
     pipeline |> Async.Start
-    sink.AwaitCompletion() |> Async.RunSynchronously
-    sink.RanToCompletion
+    return! sink.AwaitCompletion()
+}
 
 [<EntryPoint>]
 let main argv =
     try let args = Args.parse argv
-        try let log, storeLog = Logging.initialize args.Verbose args.CfpVerbose args.MaybeSeqEndpoint
-            try Configuration.initialize ()
-                if run (args, log, storeLog) then 0 else 3
+        try Logging.Initialize(fun c -> Logging.Configure(c, args.Verbose, args.CfpVerbose, ?maybeSeqEndpoint = args.MaybeSeqEndpoint))
+            try Configuration.load ()
+                run args |> Async.RunSynchronously
+                0
             with e when not (e :? Args.MissingArg) -> Log.Fatal(e, "Exiting"); 2
         finally Log.CloseAndFlush()
     with Args.MissingArg msg -> eprintfn "%s" msg; 1

--- a/propulsion-sync/Program.fs
+++ b/propulsion-sync/Program.fs
@@ -440,42 +440,6 @@ module Args =
         let parser = ArgumentParser.Create<Parameters>(programName=programName)
         parser.ParseCommandLine argv |> Arguments
 
-open Serilog.Events
-
-[<System.Runtime.CompilerServices.Extension>]
-type Logging() =
-
-    [<System.Runtime.CompilerServices.Extension>]
-    static member Configure(configuration : LoggerConfiguration, verbose, changeFeedProcessorVerbose, ?maybeSeqEndpoint) =
-        configuration
-            .Destructure.FSharpTypes()
-            .Enrich.FromLogContext()
-        |> fun c -> c.ConfigureChangeFeedProcessorLogging(changeFeedProcessorVerbose)
-        |> fun c -> let ingesterLevel = if changeFeedProcessorVerbose then LogEventLevel.Debug else LogEventLevel.Information
-                    c.MinimumLevel.Override(typeof<Propulsion.Streams.Scheduling.StreamSchedulingEngine>.FullName, ingesterLevel)
-        |> fun c -> if verbose then c.MinimumLevel.Debug() else c
-        |> fun c -> let generalLevel = if verbose then LogEventLevel.Information else LogEventLevel.Warning
-                    c.MinimumLevel.Override(typeof<Propulsion.Cosmos.Internal.Writer.Result>.FullName, generalLevel)
-                     .MinimumLevel.Override(typeof<Propulsion.EventStore.Internal.Writer.Result>.FullName, generalLevel)
-                     .MinimumLevel.Override(typeof<Propulsion.EventStore.Checkpoint.CheckpointSeries>.FullName, LogEventLevel.Information)
-        |> fun c -> let t = "[{Timestamp:HH:mm:ss} {Level:u3}] {partitionKeyRangeId} {Tranche} {Message:lj} {NewLine}{Exception}"
-                    let configure (a : Configuration.LoggerSinkConfiguration) : unit =
-                        a.Logger(fun l ->
-                            l.WriteTo.Sink(Equinox.EventStore.Log.InternalMetrics.Stats.LogSink())
-                             .WriteTo.Sink(Equinox.Cosmos.Store.Log.InternalMetrics.Stats.LogSink()) |> ignore) |> ignore
-                        a.Logger(fun l ->
-                            let isEqx = Filters.Matching.FromSource<Equinox.Cosmos.Core.Context>().Invoke
-                            let isWriterA = Filters.Matching.FromSource<Propulsion.EventStore.Internal.Writer.Result>().Invoke
-                            let isWriterB = Filters.Matching.FromSource<Propulsion.Cosmos.Internal.Writer.Result>().Invoke
-                            let isCp = Filters.Matching.FromSource<Propulsion.EventStore.Checkpoint.CheckpointSeries>().Invoke
-                            let l =
-                                if changeFeedProcessorVerbose then l
-                                else l.Filter.ByExcluding(fun x -> isEqx x || isWriterA x || isWriterB x || isCp x)
-                            l.WriteTo.Console(theme=Sinks.SystemConsole.Themes.AnsiConsoleTheme.Code, outputTemplate=t)
-                            |> ignore) |> ignore
-                    c.WriteTo.Async(bufferSize=65536, blockWhenFull=true, configure=System.Action<_> configure)
-        |> fun c -> match maybeSeqEndpoint with None -> c | Some endpoint -> c.WriteTo.Seq(endpoint)
-
  //#if marveleqx
 [<RequireQualifiedAccess>]
 module EventV0Parser =

--- a/propulsion-sync/Sync.fsproj
+++ b/propulsion-sync/Sync.fsproj
@@ -7,6 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <Compile Include="Infrastructure.fs" />
     <Compile Include="Program.fs" />
     <Content Include="README.md" />
   </ItemGroup>

--- a/propulsion-tracking-consumer/Infrastructure.fs
+++ b/propulsion-tracking-consumer/Infrastructure.fs
@@ -2,6 +2,7 @@
 
 open FSharp.UMX // see https://github.com/fsprojects/FSharp.UMX - % operator and ability to apply units of measure to Guids+strings
 open Serilog
+open System.Runtime.CompilerServices
 
 module EventCodec =
 
@@ -23,13 +24,10 @@ module SkuId =
     let parse (value : string) : SkuId = let raw = value in % raw
     let (|Parse|) = parse
 
-// Application logic assumes the global `Serilog.Log` is initialized _immediately_ after a successful ArgumentParser.ParseCommandline
+[<Extension>]
 type Logging() =
 
-    static member Initialize(configure) =
-        let loggerConfiguration : LoggerConfiguration = LoggerConfiguration() |> configure
-        Log.Logger <- loggerConfiguration.CreateLogger()
-
+    [<Extension>]
     static member Configure(configuration : LoggerConfiguration, ?verbose) =
         configuration
             .Destructure.FSharpTypes()

--- a/propulsion-tracking-consumer/Infrastructure.fs
+++ b/propulsion-tracking-consumer/Infrastructure.fs
@@ -26,12 +26,12 @@ module SkuId =
 // Application logic assumes the global `Serilog.Log` is initialized _immediately_ after a successful ArgumentParser.ParseCommandline
 type Logging() =
 
-    static member Initialize(?minimumLevel) =
+    static member Initialize(?verbose) =
         Log.Logger <-
             LoggerConfiguration()
                 .Destructure.FSharpTypes()
                 .Enrich.FromLogContext()
-            |> fun c -> match minimumLevel with Some m -> c.MinimumLevel.Is m | None -> c
+            |> fun c -> if verbose = Some true then c.MinimumLevel.Debug() else c
             |> fun c -> let theme = Sinks.SystemConsole.Themes.AnsiConsoleTheme.Code
                         c.WriteTo.Console(theme=theme, outputTemplate="[{Timestamp:HH:mm:ss} {Level:u3}] {Message:lj} {Properties}{NewLine}{Exception}")
             |> fun c -> c.CreateLogger()

--- a/propulsion-tracking-consumer/Infrastructure.fs
+++ b/propulsion-tracking-consumer/Infrastructure.fs
@@ -21,3 +21,18 @@ module SkuId =
     let toString (value : SkuId) : string = % value
     let parse (value : string) : SkuId = let raw = value in % raw
     let (|Parse|) = parse
+
+open Serilog
+
+// Application logic assumes the global `Serilog.Log` is initialized _immediately_ after a successful ArgumentParser.ParseCommandline
+type Logging() =
+
+    static member Initialize(?minimumLevel) =
+        Log.Logger <-
+            LoggerConfiguration()
+                .Destructure.FSharpTypes()
+                .Enrich.FromLogContext()
+            |> fun c -> match minimumLevel with Some m -> c.MinimumLevel.Is m | None -> c
+            |> fun c -> let theme = Sinks.SystemConsole.Themes.AnsiConsoleTheme.Code
+                        c.WriteTo.Console(theme=theme, outputTemplate="[{Timestamp:HH:mm:ss} {Level:u3}] {Message:lj} {Properties}{NewLine}{Exception}")
+            |> fun c -> c.CreateLogger()

--- a/propulsion-tracking-consumer/Infrastructure.fs
+++ b/propulsion-tracking-consumer/Infrastructure.fs
@@ -26,12 +26,14 @@ module SkuId =
 // Application logic assumes the global `Serilog.Log` is initialized _immediately_ after a successful ArgumentParser.ParseCommandline
 type Logging() =
 
-    static member Initialize(?verbose) =
-        Log.Logger <-
-            LoggerConfiguration()
-                .Destructure.FSharpTypes()
-                .Enrich.FromLogContext()
-            |> fun c -> if verbose = Some true then c.MinimumLevel.Debug() else c
-            |> fun c -> let theme = Sinks.SystemConsole.Themes.AnsiConsoleTheme.Code
-                        c.WriteTo.Console(theme=theme, outputTemplate="[{Timestamp:HH:mm:ss} {Level:u3}] {Message:lj} {Properties}{NewLine}{Exception}")
-            |> fun c -> c.CreateLogger()
+    static member Initialize(configure) =
+        let loggerConfiguration : LoggerConfiguration = LoggerConfiguration() |> configure
+        Log.Logger <- loggerConfiguration.CreateLogger()
+
+    static member Configure(configuration : LoggerConfiguration, ?verbose) =
+        configuration
+            .Destructure.FSharpTypes()
+            .Enrich.FromLogContext()
+        |> fun c -> if verbose = Some true then c.MinimumLevel.Debug() else c
+        |> fun c -> let theme = Sinks.SystemConsole.Themes.AnsiConsoleTheme.Code
+                    c.WriteTo.Console(theme=theme, outputTemplate="[{Timestamp:HH:mm:ss} {Level:u3}] {Message:lj} {Properties}{NewLine}{Exception}")

--- a/propulsion-tracking-consumer/Infrastructure.fs
+++ b/propulsion-tracking-consumer/Infrastructure.fs
@@ -1,6 +1,7 @@
 ﻿namespace ConsumerTemplate
 
 open FSharp.UMX // see https://github.com/fsprojects/FSharp.UMX - % operator and ability to apply units of measure to Guids+strings
+open Serilog
 
 module EventCodec =
 
@@ -21,8 +22,6 @@ module SkuId =
     let toString (value : SkuId) : string = % value
     let parse (value : string) : SkuId = let raw = value in % raw
     let (|Parse|) = parse
-
-open Serilog
 
 // Application logic assumes the global `Serilog.Log` is initialized _immediately_ after a successful ArgumentParser.ParseCommandline
 type Logging() =

--- a/propulsion-tracking-consumer/Program.fs
+++ b/propulsion-tracking-consumer/Program.fs
@@ -112,7 +112,7 @@ module Args =
 
         member __.MaxConcurrentStreams =    a.GetResult(MaxWriters, 8)
 
-        member __.MinimumLevel =            if a.Contains Verbose then Some Events.LogEventLevel.Debug else None
+        member __.Verbose =                 a.Contains Verbose
         member __.StatsInterval =           TimeSpan.FromMinutes 1.
         member __.StateInterval =           TimeSpan.FromMinutes 5.
 
@@ -151,7 +151,7 @@ let run args =
 [<EntryPoint>]
 let main argv =
     try let args = Args.parse argv
-        try Logging.Initialize(?minimumLevel=args.MinimumLevel)
+        try Logging.Initialize(verbose=args.Verbose)
             try Configuration.initialize ()
                 run args
             with e when not (e :? Args.MissingArg) -> Log.Fatal(e, "Exiting"); 2

--- a/propulsion-tracking-consumer/Program.fs
+++ b/propulsion-tracking-consumer/Program.fs
@@ -151,8 +151,8 @@ let run args = async {
 [<EntryPoint>]
 let main argv =
     try let args = Args.parse argv
-        try Logging.Initialize(fun c -> Logging.Configure(c, verbose=args.Verbose))
-            try Configuration.load ()
+        try Log.Logger <- LoggerConfiguration().Configure(verbose=args.Verbose).CreateLogger()
+            try Configuration.initialize ()
                 run args |> Async.RunSynchronously
                 0
             with e when not (e :? Args.MissingArg) -> Log.Fatal(e, "Exiting"); 2

--- a/propulsion-tracking-consumer/Program.fs
+++ b/propulsion-tracking-consumer/Program.fs
@@ -18,7 +18,7 @@ module Configuration =
             printfn "Setting %s from %A" var key
             EnvVar.set var (loadF key)
 
-    let load () =
+    let initialize () =
         // e.g. initEnvVar     "EQUINOX_COSMOS_CONTAINER"    "CONSUL KEY" readFromConsul
         () // TODO add any custom logic preprocessing commandline arguments and/or gathering custom defaults from external sources, etc
 

--- a/propulsion-tracking-consumer/Program.fs
+++ b/propulsion-tracking-consumer/Program.fs
@@ -111,8 +111,8 @@ module Args =
         member __.LagFrequency =            a.TryGetResult LagFreqM |> Option.map TimeSpan.FromMinutes
 
         member __.MaxConcurrentStreams =    a.GetResult(MaxWriters, 8)
-        member __.Verbose =                 a.Contains Verbose
 
+        member __.MinimumLevel =            if a.Contains Verbose then Some Events.LogEventLevel.Debug else None
         member __.StatsInterval =           TimeSpan.FromMinutes 1.
         member __.StateInterval =           TimeSpan.FromMinutes 5.
 
@@ -121,21 +121,6 @@ module Args =
         let programName = Reflection.Assembly.GetEntryAssembly().GetName().Name
         let parser = ArgumentParser.Create<Parameters>(programName=programName)
         parser.ParseCommandLine argv |> Arguments
-
-// TODO remove this entire comment after reading https://github.com/jet/dotnet-templates#module-logging
-// Application logic assumes the global `Serilog.Log` is initialized _immediately_ after a successful ArgumentParser.ParseCommandline
-module Logging =
-
-    let initialize verbose =
-        Log.Logger <-
-            LoggerConfiguration()
-                .Destructure.FSharpTypes()
-                .Enrich.FromLogContext()
-            |> fun c -> if verbose then c.MinimumLevel.Debug() else c
-            |> fun c -> let theme = Sinks.SystemConsole.Themes.AnsiConsoleTheme.Code
-                        if not verbose then c.WriteTo.Console(theme=theme)
-                        else c.WriteTo.Console(theme=theme, outputTemplate="[{Timestamp:HH:mm:ss} {Level:u3}] {Message:lj} {Properties}{NewLine}{Exception}")
-            |> fun c -> c.CreateLogger()
 
 let [<Literal>] AppName = "ConsumerTemplate"
 
@@ -166,7 +151,7 @@ let run args =
 [<EntryPoint>]
 let main argv =
     try let args = Args.parse argv
-        try Logging.initialize args.Verbose
+        try Logging.Initialize(?minimumLevel=args.MinimumLevel)
             try Configuration.initialize ()
                 run args
             with e when not (e :? Args.MissingArg) -> Log.Fatal(e, "Exiting"); 2


### PR DESCRIPTION
This extracts the `module Logging`, which currently is a slab of boilerplate code in `Program.fs` into a static class, with more granular helper methods implementing the relevant logic.

The overall objective is to chop up logging configuration such that it can easily be shifted off and coalesced into infrastructure helper modules when one is integrating a fresh Service into the overall codebase for a given set of services in a code repository

- [x] Initial skeleton
- [x] Cross-validate with internal variations with @enricosada 