### PR TITLE
Cleanup MemoryStoreProjector

### DIFF
--- a/equinox-shipping/Watchdog.Integration/PropulsionInfrastructure.fs
+++ b/equinox-shipping/Watchdog.Integration/PropulsionInfrastructure.fs
@@ -45,13 +45,12 @@ type MemoryStoreProjector<'F, 'B> private (inner : Propulsion.ProjectorPipeline<
 
     /// Waits until all <c>Submit</c>ted batches have been fed into the <c>inner</c> Projector
     member __.AwaitCompletion
-        (   /// sleep time while awaiting completion
+        (   /// Log for completion status info
+            log : Serilog.ILogger,
+            /// sleep time while awaiting completion
             ?delay,
             /// interval at which to log progress of Projector loop
-            ?logInterval,
-            /// Destination log. Default: <c>Serilog.Log.Logger</c>
-            ?log) = async {
-        let log = defaultArg log Serilog.Log.Logger
+            ?logInterval) = async {
         if -1L = Volatile.Read(&epoch) then
             log.Warning("No events submitted; completing immediately")
         else

--- a/equinox-shipping/Watchdog.Integration/PropulsionInfrastructure.fs
+++ b/equinox-shipping/Watchdog.Integration/PropulsionInfrastructure.fs
@@ -2,7 +2,6 @@
 module Shipping.Watchdog.Integration.PropulsionInfrastructure
 
 open System
-open System.Collections.Concurrent
 open System.Threading
 
 type Async with
@@ -20,7 +19,7 @@ type MemoryStoreProjector<'F, 'B> private (log, inner : Propulsion.ProjectorPipe
     let mutable completed = None
     let mutable checkpointed = None
 
-    let queue = new BlockingCollection<_>(1024)
+    let queue = new System.Collections.Concurrent.BlockingCollection<_>(1024)
     member __.Pump = async {
         for epoch, checkpoint, events, markCompleted in queue.GetConsumingEnumerable() do
             let! _ = ingester.Submit(epoch, checkpoint, events, markCompleted) in ()

--- a/equinox-shipping/Watchdog.Integration/WatchdogIntegrationTests.fs
+++ b/equinox-shipping/Watchdog.Integration/WatchdogIntegrationTests.fs
@@ -19,13 +19,11 @@ type WatchdogIntegrationTests(output) =
         let maxReadAhead, maxConcurrentStreams = Int32.MaxValue, 4
 
         let stats = Handler.Stats(log, TimeSpan.FromSeconds 10., TimeSpan.FromMinutes 1.)
-        let watchdogSink = Program.createSink log (processingTimeout, stats) (maxReadAhead, maxConcurrentStreams) processManager.Drive
+        let watchdog = Program.startWatchdog log (processingTimeout, stats) (maxReadAhead, maxConcurrentStreams) processManager.Drive
         Async.RunSynchronously <| async {
-            let source = MemoryStoreSource(watchdogSink)
-            use __ =
-                store.Committed
-                |> Observable.filter (fun (s,_e) -> Handler.isRelevant s)
-                |> Observable.subscribe source.Submit
+            //
+            let projector = MemoryStoreProjector.Start(watchdog)
+            use __ = projector.Subscribe(store.Committed |> Observable.filter (fun (s,_e) -> Handler.isRelevant s))
 
             let counts = System.Collections.Generic.Stack()
             let mutable timeouts = 0
@@ -37,7 +35,7 @@ type WatchdogIntegrationTests(output) =
                 with :? TimeoutException -> timeouts <- timeouts + 1
 
             log.Information("Awaiting batches: {counts} ({timeouts}/{total} timeouts)", counts, timeouts, counts.Count)
-            do! source.AwaitCompletion(logInterval=TimeSpan.FromSeconds 0.5, log=log)
+            do! projector.AwaitCompletion(log=log)
             stats.DumpStats()
         }
 

--- a/equinox-shipping/Watchdog.Integration/WatchdogIntegrationTests.fs
+++ b/equinox-shipping/Watchdog.Integration/WatchdogIntegrationTests.fs
@@ -35,7 +35,7 @@ type WatchdogIntegrationTests(output) =
                 with :? TimeoutException -> timeouts <- timeouts + 1
 
             log.Information("Awaiting batches: {counts} ({timeouts}/{total} timeouts)", counts, timeouts, counts.Count)
-            do! projector.AwaitCompletion(log=log)
+            do! projector.AwaitCompletion(log)
             stats.DumpStats()
         }
 

--- a/equinox-shipping/Watchdog/Program.fs
+++ b/equinox-shipping/Watchdog/Program.fs
@@ -198,7 +198,7 @@ module Logging =
 
 let [<Literal>] AppName = "Watchdog"
 
-let createSink log (processingTimeout, stats : Handler.Stats) (maxReadAhead, maxConcurrentStreams) driveTransaction
+let startWatchdog log (processingTimeout, stats : Handler.Stats) (maxReadAhead, maxConcurrentStreams) driveTransaction
     : Propulsion.ProjectorPipeline<Propulsion.Ingestion.Ingester<_, _>> =
     let handle = Handler.handle processingTimeout driveTransaction
     Propulsion.Streams.StreamsProjector.Start(log, maxReadAhead, maxConcurrentStreams, handle, stats, stats.StatsInterval)
@@ -224,7 +224,7 @@ let build (args : Args.Arguments) =
 
     let sink =
         let stats = Handler.Stats(Serilog.Log.Logger, statsInterval=args.StatsInterval, stateInterval=args.StateInterval)
-        createSink Log.Logger (args.ProcessingTimeout, stats) (args.MaxReadAhead, args.MaxConcurrentStreams) processManager.Drive
+        startWatchdog Log.Logger (args.ProcessingTimeout, stats) (args.MaxReadAhead, args.MaxConcurrentStreams) processManager.Drive
 
     // Wire up the CFP to feed in the items
     let mapToStreamItems (docs : Microsoft.Azure.Documents.Document seq) : Propulsion.Streams.StreamEvent<_> seq =


### PR DESCRIPTION
- Completes the implementation, clarifies naming and API for MemoryStoreProjector in response to validation by @fnipo 
- Adds missing `Ingester.Stop()`
- Adds logging useful for diagnosing hang scenarios (e.g. https://github.com/jet/propulsion/pull/74)