### PR TITLE
proProjector: Add cosmos kafka --synthesizeSequence

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ The `Unreleased` section name is replaced by the expected version of next releas
 
 ### Added
 
-- `eqxProjector --source cosmos --kafka --synthesizeSequence`: Sample code for custom parsing of document changes:  [#83](https://github.com/jet/dotnet-templates/pull/83)
+- `eqxProjector --source cosmos --kafka --synthesizeSequence`: Sample code for custom parsing of document changes [#84](https://github.com/jet/dotnet-templates/pull/84)
 
 ### Changed
 ### Removed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ The `Unreleased` section name is replaced by the expected version of next releas
 ## [Unreleased]
 
 ### Added
+
+- `eqxProjector --source cosmos --kafka --synthesizeSequence`: Sample code for custom parsing of document changes:  [#83](https://github.com/jet/dotnet-templates/pull/83)
+
 ### Changed
 ### Removed
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -22,6 +22,8 @@ The following templates focus specifically on the usage of `Propulsion` componen
  
        * `-k --parallelOnly` schedule kafka emission to operate in parallel at document (rather than accumulated span of events for a stream) level
 
+       * `-k --synthesizeSequence` parse documents, preserving input order as items are produced to Kafka
+
     2. `--source eventStore`: EventStoreDB's `$all` feed
     
     3. `--source sqlStreamStore`: [`SqlStreamStore`](https://github.com/SQLStreamStore/SQLStreamStore)'s `$all` feed

--- a/propulsion-projector/.template.config/template.json
+++ b/propulsion-projector/.template.config/template.json
@@ -58,7 +58,7 @@
       "datatype": "bool",
       "isRequired": false,
       "defaultValue": "false",
-      "description": "(--source=cosmos only) Include example custom parsing / sequence generation logic for projecting arbitrary CosmosDB document changes."
+      "description": "(--source=cosmos only) Include custom parsing / sequence generation logic for projecting arbitrary CosmosDB document changes, maintaining ordering."
     },
     "kafka": {
       "type": "parameter",

--- a/propulsion-projector/.template.config/template.json
+++ b/propulsion-projector/.template.config/template.json
@@ -53,6 +53,13 @@
       "type": "computed",
       "value": "(source == \"cosmos\")"
     },
+    "synthesizeSequence": {
+      "type": "parameter",
+      "datatype": "bool",
+      "isRequired": false,
+      "defaultValue": "false",
+      "description": "(--source=cosmos only) Include example custom parsing / sequence generation logic for projecting arbitrary CosmosDB document changes."
+    },
     "kafka": {
       "type": "parameter",
       "datatype": "bool",

--- a/propulsion-projector/Handler.fs
+++ b/propulsion-projector/Handler.fs
@@ -6,20 +6,7 @@ module ProjectorTemplate.Handler
 let mapToStreamItems (x : System.Collections.Generic.IReadOnlyList<'a>) : seq<'a> = upcast x
 #else // cosmos && !parallelOnly
 #if    synthesizeSequence // cosmos && !parallelOnly && !synthesizeSequence
-/// StreamsProjector buffers and deduplicates messages from a contiguous stream with each event bearing an `index`.
-/// Where the messages we consume don't have such characteristics, we need to maintain a fake `index` by keeping an int per stream in a dictionary
-/// Thread-safe, as it needs to be given batches of incoming events can be parsed in parallel
-type StreamNameSequenceGenerator() =
-
-    // Last-used index per streamName
-    let indices = System.Collections.Concurrent.ConcurrentDictionary()
-
-    /// Generates an index for the specified StreamName. Sequence starts at 0, incrementing per call.
-    member __.GenerateIndex(streamName : FsCodec.StreamName) =
-        let streamName = FsCodec.StreamName.toString streamName
-        indices.AddOrUpdate(streamName, 0L, fun _k v -> v + 1L)
-
-let indices = StreamNameSequenceGenerator()
+let indices = Propulsion.Kafka.Core.StreamNameSequenceGenerator()
 
 let parseDocumentAsEvent (doc : Microsoft.Azure.Documents.Document) : Propulsion.Streams.StreamEvent<byte[]> =
     let docId = doc.Id

--- a/propulsion-projector/Handler.fs
+++ b/propulsion-projector/Handler.fs
@@ -41,6 +41,8 @@ let parseDocumentAsEvent (doc : Microsoft.Azure.Documents.Document) : Propulsion
     let ts = let raw = doc.Timestamp in raw.ToUniversalTime() |> System.DateTimeOffset
     let docType = "DocumentTypeA" // each Event requires an EventType - enables the handler to route without having to parse the Data first
     let data = string doc |> System.Text.Encoding.UTF8.GetBytes
+    // Ideally, we'd extract a monotonically incrementing index/version from the source and use that
+    // (Using this technique neuters the deduplication mechanism)
     let streamIndex = indices.GenerateIndex streamName
     { stream = streamName; event = FsCodec.Core.TimelineEvent.Create(streamIndex, docType, data, timestamp=ts) }
 

--- a/propulsion-projector/Handler.fs
+++ b/propulsion-projector/Handler.fs
@@ -6,7 +6,7 @@ module ProjectorTemplate.Handler
 let mapToStreamItems (x : System.Collections.Generic.IReadOnlyList<'a>) : seq<'a> = upcast x
 #else // cosmos && !parallelOnly
 #if    synthesizeSequence // cosmos && !parallelOnly && !synthesizeSequence
-let indices = Propulsion.Kafka.Core.StreamNameSequenceGenerator()
+let indices = Propulsion.Kafka.StreamNameSequenceGenerator()
 
 let parseDocumentAsEvent (doc : Microsoft.Azure.Documents.Document) : Propulsion.Streams.StreamEvent<byte[]> =
     let docId = doc.Id

--- a/tests/Equinox.Templates.Tests/DotnetBuild.fs
+++ b/tests/Equinox.Templates.Tests/DotnetBuild.fs
@@ -44,7 +44,7 @@ type DotnetBuild(output : ITestOutputHelper, folder : EquinoxTemplatesFixture) =
         Dotnet.build [folder]
 
     #if DEBUG // Use this one to trigger an individual test
-    let [<Fact>] ``*pending*`` ()               = run "proReactor" ["--source changeFeedOnly"; "--kafka"]
+    let [<Fact>] ``*pending*`` ()               = run "proProjector" ["--source cosmos"; "--kafka"; "--synthesizeSequence"]
     #endif
 
     let [<Fact>] eqxTestbed ()                  = run "eqxTestbed" []

--- a/tests/Equinox.Templates.Tests/DotnetBuild.fs
+++ b/tests/Equinox.Templates.Tests/DotnetBuild.fs
@@ -51,6 +51,7 @@ type DotnetBuild(output : ITestOutputHelper, folder : EquinoxTemplatesFixture) =
     let [<Fact>] eqxShipping ()                 = run "eqxShipping" []
     [<ClassData(typeof<ProProjector>)>]
     let [<Theory>] proProjector args            = run "proProjector" args
+    let [<Fact>] proProjectorSynth ()           = run "proProjector" ["--source cosmos"; "--kafka"; "--synthesizeSequence"]
     let [<Fact>] proConsumer ()                 = run "proConsumer" []
     let [<Fact>] trackingConsumer ()            = run "trackingConsumer" []
     let [<Fact>] summaryConsumer ()             = run "summaryConsumer" []


### PR DESCRIPTION
Provides example code for projection from a CosmosDB ChangeFeed over arbitrary (i.e. not Equinox) documents.

A key aspect is that the projection uses the `StreamsProjector` in order that messages can be produced to Kafka in the same order as the changes happened.