### PR TITLE
Clean up configuration management

### DIFF
--- a/equinox-shipping/Domain.Tests/Infrastructure.fs
+++ b/equinox-shipping/Domain.Tests/Infrastructure.fs
@@ -6,17 +6,17 @@ open System.Collections.Concurrent
 type EventAccumulator<'E>() =
     let messages = ConcurrentDictionary<FsCodec.StreamName, ConcurrentQueue<'E>>()
 
-    member __.Record(stream, events : 'E seq) =
+    member _.Record(stream, events : 'E seq) =
         let initStreamQueue _ = ConcurrentQueue events
         let appendToQueue _ (queue : ConcurrentQueue<'E>) = events |> Seq.iter queue.Enqueue; queue
         messages.AddOrUpdate(stream, initStreamQueue, appendToQueue) |> ignore
 
-    member __.Queue stream =
+    member _.Queue stream =
         match messages.TryGetValue stream with
         | false, _ -> Seq.empty<'E>
         | true, xs -> xs :> _
 
-    member __.All() = seq { for KeyValue (_, xs) in messages do yield! xs }
+    member _.All() = seq { for KeyValue (_, xs) in messages do yield! xs }
 
-    member __.Clear() =
+    member _.Clear() =
         messages.Clear()

--- a/equinox-shipping/Domain/Container.fs
+++ b/equinox-shipping/Domain/Container.fs
@@ -32,12 +32,12 @@ let interpretFinalize shipmentIds (state : Fold.State): Events.Event list =
 
 type Service internal (resolve : ContainerId -> Equinox.Stream<Events.Event, Fold.State>) =
 
-    member __.Finalize(containerId, shipmentIds) : Async<unit> =
-        let stream = resolve containerId
-        stream.Transact(interpretFinalize shipmentIds)
+    member _.Finalize(containerId, shipmentIds) : Async<unit> =
+        let decider = resolve containerId
+        decider.Transact(interpretFinalize shipmentIds)
 
-let create resolve =
-    let resolve id = Equinox.Stream(Serilog.Log.ForContext<Service>(), resolve (streamName id), maxAttempts=3)
+let create resolveStream =
+    let resolve id = Equinox.Stream(Serilog.Log.ForContext<Service>(), resolveStream (streamName id), maxAttempts=3)
     Service(resolve)
 
 module Cosmos =

--- a/equinox-shipping/Domain/FinalizationProcessManager.fs
+++ b/equinox-shipping/Domain/FinalizationProcessManager.fs
@@ -49,11 +49,11 @@ type Service
         loop
 
     // Caller should generate the TransactionId via a deterministic hash of the shipmentIds in order to ensure idempotency (and sharing of fate) of identical requests
-    member __.TryFinalizeContainer(transactionId, containerId, shipmentIds) : Async<bool> =
+    member _.TryFinalizeContainer(transactionId, containerId, shipmentIds) : Async<bool> =
         if Array.isEmpty shipmentIds then invalidArg "shipmentIds" "must not be empty"
         let initialRequest = Events.FinalizationRequested {| container = containerId; shipments = shipmentIds |}
         execute transactionId (Some initialRequest)
 
     /// Used by watchdog service to drive processing to a conclusion where a given request was orphaned
-    member __.Drive(transactionId : TransactionId) =
+    member _.Drive(transactionId : TransactionId) =
         execute transactionId None

--- a/equinox-shipping/Domain/FinalizationTransaction.fs
+++ b/equinox-shipping/Domain/FinalizationTransaction.fs
@@ -96,12 +96,12 @@ let decide (update : Events.Event option) (state : Fold.State) : Action * Events
 
 type Service internal (resolve : TransactionId -> Equinox.Stream<Events.Event, Fold.State>) =
 
-    member __.Record(transactionId, update) : Async<Action> =
-        let stream = resolve transactionId
-        stream.Transact(decide update)
+    member _.Record(transactionId, update) : Async<Action> =
+        let decider = resolve transactionId
+        decider.Transact(decide update)
 
-let create resolve =
-    let resolve id = Equinox.Stream(Serilog.Log.ForContext<Service>(), resolve (streamName id), maxAttempts=3)
+let create resolveStream =
+    let resolve id = Equinox.Stream(Serilog.Log.ForContext<Service>(), resolveStream (streamName id), maxAttempts=3)
     Service(resolve)
 
 module Cosmos =

--- a/equinox-shipping/Domain/Shipment.fs
+++ b/equinox-shipping/Domain/Shipment.fs
@@ -47,20 +47,20 @@ let interpretAssign transactionId containerId : Fold.State -> Events.Event list 
 
 type Service internal (resolve : ShipmentId -> Equinox.Stream<Events.Event, Fold.State>) =
 
-    member __.TryReserve(shipmentId, transactionId) : Async<bool> =
-        let stream = resolve shipmentId
-        stream.Transact(decideReserve transactionId)
+    member _.TryReserve(shipmentId, transactionId) : Async<bool> =
+        let decider = resolve shipmentId
+        decider.Transact(decideReserve transactionId)
 
-    member __.Revoke(shipmentId, transactionId) : Async<unit> =
-        let stream = resolve shipmentId
-        stream.Transact(interpretRevoke transactionId)
+    member _.Revoke(shipmentId, transactionId) : Async<unit> =
+        let decider = resolve shipmentId
+        decider.Transact(interpretRevoke transactionId)
 
-    member __.Assign(shipmentId, containerId, transactionId) : Async<unit> =
-        let stream = resolve shipmentId
-        stream.Transact(interpretAssign transactionId containerId)
+    member _.Assign(shipmentId, containerId, transactionId) : Async<unit> =
+        let decider = resolve shipmentId
+        decider.Transact(interpretAssign transactionId containerId)
 
-let create resolve =
-    let resolve id = Equinox.Stream(Serilog.Log.ForContext<Service>(), resolve (streamName id), maxAttempts=3)
+let create resolveStream =
+    let resolve id = Equinox.Stream(Serilog.Log.ForContext<Service>(), resolveStream (streamName id), maxAttempts=3)
     Service(resolve)
 
 module Cosmos =

--- a/equinox-shipping/Watchdog.Integration/PropulsionInfrastructure.fs
+++ b/equinox-shipping/Watchdog.Integration/PropulsionInfrastructure.fs
@@ -20,7 +20,7 @@ type MemoryStoreProjector<'F, 'B> private (log, inner : Propulsion.ProjectorPipe
     let mutable checkpointed = None
 
     let queue = new System.Collections.Concurrent.BlockingCollection<_>(1024)
-    member __.Pump = async {
+    member _.Pump = async {
         for epoch, checkpoint, events, markCompleted in queue.GetConsumingEnumerable() do
             let! _ = ingester.Submit(epoch, checkpoint, events, markCompleted) in ()
     }
@@ -32,7 +32,7 @@ type MemoryStoreProjector<'F, 'B> private (log, inner : Propulsion.ProjectorPipe
         instance
 
     /// Accepts an individual batch of events from a stream for submission into the <c>inner</c> projector
-    member __.Submit(stream, events : 'E seq) =
+    member _.Submit(stream, events : 'E seq) =
         let epoch = Interlocked.Increment &epoch
         log.Debug("Submitted! {stream} {epoch}", stream, epoch)
         let markCompleted () =
@@ -46,7 +46,7 @@ type MemoryStoreProjector<'F, 'B> private (log, inner : Propulsion.ProjectorPipe
         Observable.subscribe this.Submit source
 
     /// Waits until all <c>Submit</c>ted batches have been fed into the <c>inner</c> Projector
-    member __.AwaitCompletion
+    member _.AwaitCompletion
         (   /// sleep time while awaiting completion
             ?delay,
             /// interval at which to log progress of Projector loop
@@ -83,7 +83,7 @@ type TestOutputAdapter(testOutput : Xunit.Abstractions.ITestOutputHelper) =
         formatter.Format(logEvent, writer)
         writer |> string |> testOutput.WriteLine
         writer |> string |> System.Diagnostics.Debug.Write
-    interface Serilog.Core.ILogEventSink with member __.Emit logEvent = writeSerilogEvent logEvent
+    interface Serilog.Core.ILogEventSink with member _.Emit logEvent = writeSerilogEvent logEvent
 
 module TestOutputLogger =
 

--- a/equinox-shipping/Watchdog/Handler.fs
+++ b/equinox-shipping/Watchdog/Handler.fs
@@ -12,14 +12,14 @@ type Stats(log, statsInterval, stateInterval) =
     let mutable completed, deferred, failed, succeeded = 0, 0, 0, 0
     member val StatsInterval = statsInterval
 
-    override __.HandleOk res = res |> function
+    override _.HandleOk res = res |> function
         | Outcome.Completed -> completed <- completed + 1
         | Outcome.Deferred -> deferred <- deferred + 1
         | Outcome.Resolved successfully -> if successfully then succeeded <- succeeded + 1 else failed <- failed + 1
-    override __.HandleExn(log, exn) =
+    override _.HandleExn(log, exn) =
         log.Information(exn, "Unhandled")
 
-    override __.DumpStats() =
+    override _.DumpStats() =
         if completed <> 0 || deferred <> 0 || failed <> 0 || succeeded <> 0 then
             log.Information(" Completed {completed} Deferred {deferred} Failed {failed} Succeeded {succeeded}", completed, deferred, failed, succeeded)
             completed <- 0; deferred <- 0; failed <- 0; succeeded <- 0

--- a/equinox-shipping/Watchdog/Infrastructure.fs
+++ b/equinox-shipping/Watchdog/Infrastructure.fs
@@ -2,12 +2,16 @@
 module Shipping.Watchdog.Infrastructure
 
 open Serilog
-open System.Runtime.CompilerServices
+open System
 
-[<Extension>]
+module EnvVar =
+
+    let tryGet varName : string option = Environment.GetEnvironmentVariable varName |> Option.ofObj
+
+[<System.Runtime.CompilerServices.Extension>]
 type LoggerConfigurationExtensions() =
 
-    [<Extension>]
+    [<System.Runtime.CompilerServices.Extension>]
     static member inline ExcludeChangeFeedProcessorV2InternalDiagnostics(c : LoggerConfiguration) =
         let isCfp429a = Filters.Matching.FromSource("Microsoft.Azure.Documents.ChangeFeedProcessor.LeaseManagement.DocumentServiceLeaseUpdater").Invoke
         let isCfp429b = Filters.Matching.FromSource("Microsoft.Azure.Documents.ChangeFeedProcessor.PartitionManagement.LeaseRenewer").Invoke
@@ -16,17 +20,17 @@ type LoggerConfigurationExtensions() =
         let isCfp x = isCfp429a x || isCfp429b x || isCfp429c x || isCfp429d x
         c.Filter.ByExcluding(fun x -> isCfp x)
 
-    [<Extension>]
+    [<System.Runtime.CompilerServices.Extension>]
     static member inline ConfigureChangeFeedProcessorLogging(c : LoggerConfiguration, verbose : bool) =
         // LibLog writes to the global logger, so we need to control the emission
         let cfpl = if verbose then Serilog.Events.LogEventLevel.Debug else Serilog.Events.LogEventLevel.Warning
         c.MinimumLevel.Override("Microsoft.Azure.Documents.ChangeFeedProcessor", cfpl)
         |> fun c -> if verbose then c else c.ExcludeChangeFeedProcessorV2InternalDiagnostics()
 
-[<Extension>]
+[<System.Runtime.CompilerServices.Extension>]
 type Logging() =
 
-    [<Extension>]
+    [<System.Runtime.CompilerServices.Extension>]
     static member Configure(configuration : LoggerConfiguration, ?verbose, ?changeFeedProcessorVerbose) =
         configuration
             .Destructure.FSharpTypes()

--- a/equinox-shipping/Watchdog/Program.fs
+++ b/equinox-shipping/Watchdog/Program.fs
@@ -114,8 +114,9 @@ module Args =
             let Equinox.Cosmos.Discovery.UriAndKey (endpointUri, _) as discovery = x.Connection
             Log.Information("Source CosmosDb {mode} {endpointUri} Database {database} Container {container}",
                 x.Mode, endpointUri, x.Database, x.Container)
+            let ts (x : TimeSpan) = x.TotalSeconds
             Log.Information("Source CosmosDb timeout {timeout}s; Throttling retries {retries}, max wait {maxRetryWaitTime}s",
-                (let t = x.Timeout in t.TotalSeconds), x.Retries, (let t = x.MaxRetryWaitTime in t.TotalSeconds))
+                ts x.Timeout, x.Retries, ts x.MaxRetryWaitTime)
             let connector = Equinox.Cosmos.Connector(x.Timeout, x.Retries, x.MaxRetryWaitTime, Log.Logger, mode=x.Mode)
             connector, discovery, { database = x.Database; container = x.Container }
         member val Cosmos =

--- a/equinox-testbed/Infrastructure.fs
+++ b/equinox-testbed/Infrastructure.fs
@@ -4,6 +4,10 @@ module TestbedTemplate.Infrastructure
 open FSharp.UMX
 open System
 
+module EnvVar =
+
+    let tryGet varName : string option = Environment.GetEnvironmentVariable varName |> Option.ofObj
+
 type Exception with
     // https://github.com/fsharp/fslang-suggestions/issues/660
     member this.Reraise () =

--- a/equinox-testbed/Storage.fs
+++ b/equinox-testbed/Storage.fs
@@ -5,7 +5,7 @@ open System
 
 exception MissingArg of message : string with override this.Message = this.message
 
-type Configuration(tryGet) =
+type Configuration(tryGet : string -> string option) =
 
     let get key =
         match tryGet key with
@@ -87,9 +87,9 @@ module Cosmos =
         log.Information("CosmosDb timeout {timeout}s; Throttling retries {retries}, max wait {maxRetryWaitTime}s",
             (let t = a.Timeout in t.TotalSeconds), a.Retries, (let t = a.MaxRetryWaitTime in t.TotalSeconds))
         let connector = Connector(a.Timeout, a.Retries, a.MaxRetryWaitTime, storeLog, mode=a.Mode)
-        discovery, a.Database, a.Container, connector
+        connector, discovery, a.Database, a.Container
     let config (log: ILogger, storeLog) (cache, unfolds, batchSize) info =
-        let discovery, dbName, containerName, connector = context (log, storeLog) info
+        let connector, discovery, dbName, containerName = context (log, storeLog) info
         let conn = connector.Connect("TestbedTemplate", discovery) |> Async.RunSynchronously
         let cacheStrategy =
             if cache then

--- a/equinox-web/Domain/Aggregate.fs
+++ b/equinox-web/Domain/Aggregate.fs
@@ -38,17 +38,17 @@ type Service internal (resolve : string -> Equinox.Stream<Events.Event, Fold.Sta
 
     /// Read the present state
     // TOCONSIDER: you should probably be separating this out per CQRS and reading from a denormalized/cached set of projections
-    member __.Read clientId : Async<View> =
-        let stream = resolve clientId
-        stream.Query(fun s -> { sorted = s.happened })
+    member _.Read clientId : Async<View> =
+        let decider = resolve clientId
+        decider.Query(fun s -> { sorted = s.happened })
 
     /// Execute the specified command 
-    member __.Execute(clientId, command) : Async<unit> =
-        let stream = resolve clientId
-        stream.Transact(interpret command)
+    member _.Execute(clientId, command) : Async<unit> =
+        let decider = resolve clientId
+        decider.Transact(interpret command)
 
-let create resolve =
+let create resolveStream =
     let resolve id =
-        let stream = resolve (streamName id)
+        let stream = resolveStream (streamName id)
         Equinox.Stream(Serilog.Log.ForContext<Service>(), stream, maxAttempts=3)
     Service(resolve)

--- a/equinox-web/Web/Controllers/TodosController.fs
+++ b/equinox-web/Web/Controllers/TodosController.fs
@@ -26,38 +26,38 @@ type TodosController(service: Todo.Service) =
 
     let toProps (value : TodoView) : Todo.Props = { order = value.order; title = value.title; completed = value.completed }
 
-    member private __.WithUri(x : Todo.View) : TodoView =
-        let url = __.Url.RouteUrl("GetTodo", { id=x.id }, __.Request.Scheme) // Supplying scheme is secret sauce for making it absolute as required by client
+    member private this.WithUri(x : Todo.View) : TodoView =
+        let url = this.Url.RouteUrl("GetTodo", { id=x.id }, this.Request.Scheme) // Supplying scheme is secret sauce for making it absolute as required by client
         { id = x.id; url = url; order = x.order; title = x.title; completed = x.completed }
 
     [<HttpGet>]
-    member __.Get([<FromClientIdHeader>]clientId : ClientId) = async {
+    member this.Get([<FromClientIdHeader>]clientId : ClientId) = async {
         let! xs = service.List(clientId)
-        return seq { for x in xs -> __.WithUri(x) }
+        return seq { for x in xs -> this.WithUri(x) }
     }
 
     [<HttpGet("{id}", Name="GetTodo")>]
-    member __.Get([<FromClientIdHeader>]clientId : ClientId, id) : Async<IActionResult> = async {
+    member this.Get([<FromClientIdHeader>]clientId : ClientId, id) : Async<IActionResult> = async {
         let! x = service.TryGet(clientId, id)
-        return match x with None -> __.NotFound() :> _ | Some x -> ObjectResult(__.WithUri x) :> _
+        return match x with None -> this.NotFound() :> _ | Some x -> ObjectResult(this.WithUri x) :> _
     }
 
     [<HttpPost>]
-    member __.Post([<FromClientIdHeader>]clientId : ClientId, [<FromBody>]value : TodoView) : Async<TodoView> = async {
+    member this.Post([<FromClientIdHeader>]clientId : ClientId, [<FromBody>]value : TodoView) : Async<TodoView> = async {
         let! created = service.Create(clientId, toProps value)
-        return __.WithUri created
+        return this.WithUri created
     }
 
     [<HttpPatch "{id}">]
-    member __.Patch([<FromClientIdHeader>]clientId : ClientId, id, [<FromBody>]value : TodoView) : Async<TodoView> = async {
+    member this.Patch([<FromClientIdHeader>]clientId : ClientId, id, [<FromBody>]value : TodoView) : Async<TodoView> = async {
         let! updated = service.Patch(clientId, id, toProps value)
-        return __.WithUri updated
+        return this.WithUri updated
     }
 
     [<HttpDelete "{id}">]
-    member __.Delete([<FromClientIdHeader>]clientId : ClientId, id): Async<unit> =
+    member _.Delete([<FromClientIdHeader>]clientId : ClientId, id): Async<unit> =
         service.Execute(clientId, Todo.Delete id)
 
     [<HttpDelete>]
-    member __.DeleteAll([<FromClientIdHeader>]clientId : ClientId): Async<unit> =
+    member _.DeleteAll([<FromClientIdHeader>]clientId : ClientId): Async<unit> =
         service.Execute(clientId, Todo.Clear)

--- a/equinox-web/Web/Startup.fs
+++ b/equinox-web/Web/Startup.fs
@@ -95,11 +95,11 @@ module Storage =
 module Services =
     /// Builds a Stream Resolve function appropriate to the store being used
     type StreamResolver(storage : Storage.Instance) =
-        member __.Resolve
+        member _.Resolve
             (   codec : FsCodec.IEventCodec<'event, byte[], _>,
-                fold: ('state -> 'event seq -> 'state),
+                fold: 'state -> 'event seq -> 'state,
                 initial: 'state,
-                snapshot: (('event -> bool) * ('state -> 'event))) =
+                snapshot: ('event -> bool) * ('state -> 'event)) =
             match storage with
 //#if (memoryStore || (!cosmos && !eventStore))
             | Storage.MemoryStore store ->
@@ -121,20 +121,20 @@ module Services =
     /// Binds a storage independent Service's Handler's `resolve` function to a given Stream Policy using the StreamResolver
     type ServiceBuilder(resolver: StreamResolver) =
 //#if todos
-         member __.CreateTodosService() =
+         member _.CreateTodosService() =
             let fold, initial = Todo.Fold.fold, Todo.Fold.initial
             let snapshot = Todo.Fold.isOrigin, Todo.Fold.snapshot
             Todo.create (resolver.Resolve(Todo.Events.codec, fold, initial, snapshot))
 //#endif
 //#if aggregate
-         member __.CreateAggregateService() =
+         member _.CreateAggregateService() =
             let fold, initial = Aggregate.Fold.fold, Aggregate.Fold.initial
             let snapshot = Aggregate.Fold.isOrigin, Aggregate.Fold.snapshot
             Aggregate.create (resolver.Resolve(Aggregate.Events.codec, fold, initial, snapshot))
 //#endif
 //#if (!aggregate && !todos)
         // TODO implement Service builders, e.g. 
-        //member __.CreateThingService() =
+        //member _.CreateThingService() =
         //   let codec = genCodec<Thing.Events.Event>()
         //   let fold, initial = Thing.Fold.fold, Thing.Fold.initial
         //   let snapshot = Thing.Fold.isOrigin, Thing.Fold.compact
@@ -166,7 +166,7 @@ module Services =
 /// Defines the Hosting configuration, including registration of the store and backend services
 type Startup() =
     // This method gets called by the runtime. Use this method to add services to the container.
-    member __.ConfigureServices(services: IServiceCollection) : unit =
+    member _.ConfigureServices(services: IServiceCollection) : unit =
         services
             .AddMvc()
             .SetCompatibilityVersion(CompatibilityVersion.Latest)
@@ -228,7 +228,7 @@ type Startup() =
         Services.register(services, storeConfig)
 
     // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.
-    member __.Configure(app: IApplicationBuilder, env: IHostEnvironment) : unit =
+    member _.Configure(app: IApplicationBuilder, env: IHostEnvironment) : unit =
         if env.IsDevelopment() then app.UseDeveloperExceptionPage() |> ignore
         else app.UseHsts() |> ignore
 

--- a/propulsion-archiver/Handler.fs
+++ b/propulsion-archiver/Handler.fs
@@ -3,8 +3,8 @@ module ArchiverTemplate.Handler
 type Stats(log, statsInterval, stateInterval) =
     inherit Propulsion.Streams.Sync.Stats<unit>(log, statsInterval, stateInterval)
 
-    override __.HandleOk(()) = ()
-    override __.HandleExn(log, exn) =
+    override _.HandleOk(()) = ()
+    override _.HandleExn(log, exn) =
         log.Information(exn, "Unhandled")
 
 let (|Archivable|NotArchivable|) = function

--- a/propulsion-archiver/Infrastructure.fs
+++ b/propulsion-archiver/Infrastructure.fs
@@ -2,12 +2,16 @@
 module ArchiverTemplate.Infrastructure
 
 open Serilog
-open System.Runtime.CompilerServices
+open System
 
-[<Extension>]
+module EnvVar =
+
+    let tryGet varName : string option = Environment.GetEnvironmentVariable varName |> Option.ofObj
+
+[<System.Runtime.CompilerServices.Extension>]
 type LoggerConfigurationExtensions() =
 
-    [<Extension>]
+    [<System.Runtime.CompilerServices.Extension>]
     static member inline ExcludeChangeFeedProcessorV2InternalDiagnostics(c : LoggerConfiguration) =
         let isCfp429a = Filters.Matching.FromSource("Microsoft.Azure.Documents.ChangeFeedProcessor.LeaseManagement.DocumentServiceLeaseUpdater").Invoke
         let isCfp429b = Filters.Matching.FromSource("Microsoft.Azure.Documents.ChangeFeedProcessor.PartitionManagement.LeaseRenewer").Invoke
@@ -16,17 +20,17 @@ type LoggerConfigurationExtensions() =
         let isCfp x = isCfp429a x || isCfp429b x || isCfp429c x || isCfp429d x
         c.Filter.ByExcluding(fun x -> isCfp x)
 
-    [<Extension>]
+    [<System.Runtime.CompilerServices.Extension>]
     static member inline ConfigureChangeFeedProcessorLogging(c : LoggerConfiguration, verbose : bool) =
         // LibLog writes to the global logger, so we need to control the emission
         let cfpl = if verbose then Events.LogEventLevel.Debug else Events.LogEventLevel.Warning
         c.MinimumLevel.Override("Microsoft.Azure.Documents.ChangeFeedProcessor", cfpl)
         |> fun c -> if verbose then c else c.ExcludeChangeFeedProcessorV2InternalDiagnostics()
 
-[<Extension>]
+[<System.Runtime.CompilerServices.Extension>]
 type Logging() =
 
-    [<Extension>]
+    [<System.Runtime.CompilerServices.Extension>]
     static member Configure(configuration : LoggerConfiguration, verbose, (logSyncToConsole, minRu), cfpVerbose) =
         configuration
             .Destructure.FSharpTypes()

--- a/propulsion-archiver/Program.fs
+++ b/propulsion-archiver/Program.fs
@@ -5,42 +5,20 @@ open Propulsion.Cosmos
 open Serilog
 open System
 
-module EnvVar =
+exception MissingArg of message : string with override this.Message = this.message
 
-    let tryGet varName : string option = Environment.GetEnvironmentVariable varName |> Option.ofObj
-    let set varName value : unit = Environment.SetEnvironmentVariable(varName, value)
+type Configuration(tryGet) =
 
-// TODO remove this entire comment after reading https://github.com/jet/dotnet-templates#module-configuration
-// - this is where any custom retrieval of settings not arriving via commandline arguments or environment variables should go
-// - values should be propagated by setting environment variables and/or returning them from `initialize`
-module Configuration =
+    let get key =
+        match tryGet key with
+        | Some value -> value
+        | None -> raise (MissingArg (sprintf "Missing Argument/Environment Variable %s" key))
 
-    let private initEnvVar var key loadF =
-        if None = EnvVar.tryGet var then
-            printfn "Setting %s from %A" var key
-            EnvVar.set var (loadF key)
+    member _.CosmosConnection =             get "EQUINOX_COSMOS_CONNECTION"
+    member _.CosmosDatabase =               get "EQUINOX_COSMOS_DATABASE"
+    member _.CosmosContainer =              get "EQUINOX_COSMOS_CONTAINER"
 
-    let initialize () =
-        // e.g. initEnvVar     "EQUINOX_COSMOS_CONTAINER"    "CONSUL KEY" readFromConsul
-        () // TODO add any custom logic preprocessing commandline arguments and/or gathering custom defaults from external sources, etc
-
-// TODO remove this entire comment after reading https://github.com/jet/dotnet-templates#module-args
-// - this module is responsible solely for parsing/validating the commandline arguments (including falling back to values supplied via environment variables)
-// - It's expected that the properties on *Arguments types will summarize the active settings as a side effect of
-// TODO DONT invest time reorganizing or reformatting this - half the value is having a legible summary of all program parameters in a consistent value
-//      you may want to regenerate it at a different time and/or facilitate comparing it with the `module Args` of other programs
-// TODO NEVER hack temporary overrides in here; if you're going to do that, use commandline arguments that fall back to environment variables
-//      or (as a last resort) supply them via code in `module Configuration`
 module Args =
-
-    exception MissingArg of string
-    let private getEnvVarForArgumentOrThrow varName argName =
-        match EnvVar.tryGet varName with
-        | None -> raise (MissingArg(sprintf "Please provide a %s, either as an argument or via the %s environment variable" argName varName))
-        | Some x -> x
-    let private defaultWithEnvVar varName argName = function
-        | None -> getEnvVarForArgumentOrThrow varName argName
-        | Some x -> x
 
     open Argu
     [<NoEquality; NoComparison>]
@@ -67,27 +45,27 @@ module Args =
                 | CfpVerbose ->             "request Verbose Change Feed Processor Logging. Default: off"
 
                 | SrcCosmos _ ->            "Cosmos input parameters."
-    and Arguments(a : ParseResults<Parameters>) =
-        member __.ConsumerGroupName =       a.GetResult ConsumerGroupName
-        member __.MaxReadAhead =            a.GetResult(MaxReadAhead, 32)
-        member __.MaxWriters =              a.GetResult(MaxWriters, 4)
-        member __.Verbose =                 a.Contains Parameters.Verbose
-        member __.CfpVerbose =              a.Contains CfpVerbose
-        member __.SyncLogging =             a.Contains SyncVerbose, a.TryGetResult RuThreshold
-        member __.StatsInterval =           TimeSpan.FromMinutes 1.
-        member __.StateInterval =           TimeSpan.FromMinutes 5.
+    and Arguments(c : Configuration, a : ParseResults<Parameters>) =
+        member val ConsumerGroupName =      a.GetResult ConsumerGroupName
+        member val MaxReadAhead =           a.GetResult(MaxReadAhead, 32)
+        member val MaxWriters =             a.GetResult(MaxWriters, 4)
+        member val Verbose =                a.Contains Parameters.Verbose
+        member val CfpVerbose =             a.Contains CfpVerbose
+        member val SyncLogging =            a.Contains SyncVerbose, a.TryGetResult RuThreshold
+        member val StatsInterval =          TimeSpan.FromMinutes 1.
+        member val StateInterval =          TimeSpan.FromMinutes 5.
         member val private Source : CosmosSourceArguments =
             match a.TryGetSubCommand() with
-            | Some (SrcCosmos cosmos) -> (CosmosSourceArguments cosmos)
+            | Some (SrcCosmos cosmos) -> CosmosSourceArguments (c, cosmos)
             | _ -> raise (MissingArg "Must specify cosmos for Src")
         member x.SourceParams() =
             let srcC = x.Source
             let disco, db =
                 let dstC : CosmosSinkArguments = srcC.Sink
                 match srcC.LeaseContainer, dstC.LeaseContainer with
-                | None, None ->     srcC.Discovery, { database = srcC.Database; container = srcC.Container + "-aux" }
-                | Some sc, None ->  srcC.Discovery, { database = srcC.Database; container = sc }
-                | None, Some dc ->  dstC.Discovery, { database = dstC.Database; container = dc }
+                | None, None ->     srcC.Connection, { database = srcC.Database; container = srcC.Container + "-aux" }
+                | Some sc, None ->  srcC.Connection, { database = srcC.Database; container = sc }
+                | None, Some dc ->  dstC.Connection, { database = dstC.Database; container = dc }
                 | Some _, Some _ -> raise (MissingArg "LeaseContainerSource and LeaseContainerDestination are mutually exclusive - can only store in one database")
             Log.Information("Archiving... {dop} writers, max {maxReadAhead} batches read ahead", x.MaxWriters, x.MaxReadAhead)
             Log.Information("Monitoring Group {leaseId} in Database {db} Container {container} with maximum document count limited to {maxDocuments}",
@@ -126,25 +104,24 @@ module Args =
                 | RetriesWaitTime _ ->      "specify max wait-time for retry when being throttled by Cosmos in seconds. Default: 30."
 
                 | DstCosmos _ ->            "CosmosDb Sink parameters."
-    and CosmosSourceArguments(a : ParseResults<CosmosSourceParameters>) =
-        member __.FromTail =                a.Contains CosmosSourceParameters.FromTail
-        member __.MaxDocuments =            a.TryGetResult MaxDocuments
-        member __.LagFrequency =            a.TryGetResult LagFreqM |> Option.map TimeSpan.FromMinutes
-        member __.LeaseContainer =          a.TryGetResult CosmosSourceParameters.LeaseContainer
-        member __.Mode =                    a.GetResult(CosmosSourceParameters.ConnectionMode, Equinox.Cosmos.ConnectionMode.Direct)
-        member __.Discovery =               Discovery.FromConnectionString __.Connection
-        member __.Connection =              a.TryGetResult CosmosSourceParameters.Connection |> defaultWithEnvVar "EQUINOX_COSMOS_CONNECTION" "Connection"
-        member __.Database =                a.TryGetResult CosmosSourceParameters.Database   |> defaultWithEnvVar "EQUINOX_COSMOS_DATABASE"   "Database"
-        member __.Container =               a.GetResult CosmosSourceParameters.Container
-        member __.Timeout =                 a.GetResult(CosmosSourceParameters.Timeout, 5.) |> TimeSpan.FromSeconds
-        member __.Retries =                 a.GetResult(CosmosSourceParameters.Retries, 5)
-        member __.MaxRetryWaitTime =        a.GetResult(CosmosSourceParameters.RetriesWaitTime, 30.) |> TimeSpan.FromSeconds
+    and CosmosSourceArguments(c : Configuration, a : ParseResults<CosmosSourceParameters>) =
+        member val FromTail =               a.Contains CosmosSourceParameters.FromTail
+        member val MaxDocuments =           a.TryGetResult MaxDocuments
+        member val LagFrequency =           a.TryGetResult LagFreqM |> Option.map TimeSpan.FromMinutes
+        member val LeaseContainer =         a.TryGetResult CosmosSourceParameters.LeaseContainer
+        member val Mode =                   a.GetResult(CosmosSourceParameters.ConnectionMode, Equinox.Cosmos.ConnectionMode.Direct)
+        member val Connection =             a.TryGetResult CosmosSourceParameters.Connection |> Option.defaultWith (fun () -> c.CosmosConnection) |> Discovery.FromConnectionString
+        member val Database =               a.TryGetResult CosmosSourceParameters.Database   |> Option.defaultWith (fun () -> c.CosmosDatabase)
+        member val Container =              a.GetResult CosmosSourceParameters.Container
+        member val Timeout =                a.GetResult(CosmosSourceParameters.Timeout, 5.) |> TimeSpan.FromSeconds
+        member val Retries =                a.GetResult(CosmosSourceParameters.Retries, 5)
+        member val MaxRetryWaitTime =       a.GetResult(CosmosSourceParameters.RetriesWaitTime, 30.) |> TimeSpan.FromSeconds
         member val Sink =
             match a.TryGetSubCommand() with
-            | Some (DstCosmos cosmos) -> CosmosSinkArguments cosmos
+            | Some (DstCosmos cosmos) -> CosmosSinkArguments (c, cosmos)
             | _ -> raise (MissingArg "Must specify cosmos for Sink")
         member x.MonitoringParams() =
-            let (Discovery.UriAndKey (endpointUri, _)) as discovery = x.Discovery
+            let Discovery.UriAndKey (endpointUri, _) as discovery = x.Connection
             Log.Information("Source CosmosDb {mode} {endpointUri} Database {database} Container {container}",
                 x.Mode, endpointUri, x.Database, x.Container)
             Log.Information("Source CosmosDb timeout {timeout}s; Throttling retries {retries}, max wait {maxRetryWaitTime}s",
@@ -170,36 +147,35 @@ module Args =
                 | Timeout _ ->              "specify operation timeout in seconds. Default: 5."
                 | Retries _ ->              "specify operation retries. Default: 0."
                 | RetriesWaitTime _ ->      "specify max wait-time for retry when being throttled by Cosmos in seconds. Default: 5."
-    and CosmosSinkArguments(a : ParseResults<CosmosSinkParameters>) =
-        member __.Mode =                    a.GetResult(ConnectionMode, Equinox.Cosmos.ConnectionMode.Direct)
-        member __.Discovery =               Discovery.FromConnectionString __.Connection
-        member __.Connection =              a.TryGetResult Connection |> defaultWithEnvVar "EQUINOX_COSMOS_CONNECTION" "Connection"
-        member __.Database =                a.TryGetResult Database   |> defaultWithEnvVar "EQUINOX_COSMOS_DATABASE"   "Database"
-        member __.Container =               a.TryGetResult Container  |> defaultWithEnvVar "EQUINOX_COSMOS_CONTAINER"  "Container"
-        member __.LeaseContainer =          a.TryGetResult LeaseContainer
-        member __.Timeout =                 a.GetResult(CosmosSinkParameters.Timeout, 5.) |> TimeSpan.FromSeconds
-        member __.Retries =                 a.GetResult(CosmosSinkParameters.Retries, 0)
-        member __.MaxRetryWaitTime =        a.GetResult(RetriesWaitTime, 5.) |> TimeSpan.FromSeconds
+    and CosmosSinkArguments(c : Configuration, a : ParseResults<CosmosSinkParameters>) =
+        member val Mode =                   a.GetResult(ConnectionMode, Equinox.Cosmos.ConnectionMode.Direct)
+        member val Connection =             a.TryGetResult Connection |> Option.defaultWith (fun () -> c.CosmosConnection) |> Discovery.FromConnectionString
+        member val Database =               a.TryGetResult Database   |> Option.defaultWith (fun () -> c.CosmosDatabase)
+        member val Container =              a.TryGetResult Container  |> Option.defaultWith (fun () -> c.CosmosContainer)
+        member val LeaseContainer =         a.TryGetResult LeaseContainer
+        member val Timeout =                a.GetResult(CosmosSinkParameters.Timeout, 5.) |> TimeSpan.FromSeconds
+        member val Retries =                a.GetResult(CosmosSinkParameters.Retries, 0)
+        member val MaxRetryWaitTime =       a.GetResult(RetriesWaitTime, 5.) |> TimeSpan.FromSeconds
         /// Connect with the provided parameters and/or environment variables
         member x.Connect appName : Async<Equinox.Cosmos.Connection> =
-            let (Discovery.UriAndKey (endpointUri, _masterKey)) as discovery = x.Discovery
+            let Discovery.UriAndKey (endpointUri, _masterKey) as discovery = x.Connection
             Log.Information("Destination CosmosDb {mode} {endpointUri} Database {database} Container {container}",
                 x.Mode, endpointUri, x.Database, x.Container)
             Log.Information("Destination CosmosDb timeout {timeout}s; Throttling retries {retries}, max wait {maxRetryWaitTime}s",
                 (let t = x.Timeout in t.TotalSeconds), x.Retries, (let t = x.MaxRetryWaitTime in t.TotalSeconds))
-            let c = Equinox.Cosmos.Connector(x.Timeout, x.Retries, x.MaxRetryWaitTime, Log.Logger, mode=x.Mode)
+            let c = Connector(x.Timeout, x.Retries, x.MaxRetryWaitTime, Log.Logger, mode=x.Mode)
             c.Connect(appName, discovery)
 
     /// Parse the commandline; can throw exceptions in response to missing arguments and/or `-h`/`--help` args
-    let parse argv : Arguments =
+    let parse tryGetConfigValue argv : Arguments =
         let programName = System.Reflection.Assembly.GetEntryAssembly().GetName().Name
         let parser = ArgumentParser.Create<Parameters>(programName=programName)
-        parser.ParseCommandLine argv |> Arguments
+        Arguments(Configuration tryGetConfigValue, parser.ParseCommandLine argv)
 
 let [<Literal>] AppName = "ArchiverTemplate"
 
 let build (args : Args.Arguments, log, storeLog : ILogger) =
-    let (source, (auxDiscovery, aux, leaseId, startFromTail, maxDocuments, lagFrequency)) = args.SourceParams()
+    let source, (auxDiscovery, aux, leaseId, startFromTail, maxDocuments, lagFrequency) = args.SourceParams()
     let archiverSink =
         let target = source.Sink
         let containers = Containers(target.Database, target.Container)
@@ -224,13 +200,12 @@ let run args = async {
 
 [<EntryPoint>]
 let main argv =
-    try let args = Args.parse argv
+    try let args = Args.parse EnvVar.tryGet argv
         try Log.Logger <- LoggerConfiguration().Configure(args.Verbose, args.SyncLogging, args.CfpVerbose).CreateLogger()
-            try Configuration.initialize ()
-                run args |> Async.RunSynchronously
+            try run args |> Async.RunSynchronously
                 0
-            with e when not (e :? Args.MissingArg) -> Log.Fatal(e, "Exiting"); 2
+            with e when not (e :? MissingArg) -> Log.Fatal(e, "Exiting"); 2
         finally Log.CloseAndFlush()
-    with Args.MissingArg msg -> eprintfn "%s" msg; 1
+    with MissingArg msg -> eprintfn "%s" msg; 1
         | :? Argu.ArguParseException as e -> eprintfn "%s" e.Message; 1
         | e -> eprintf "Exception %s" e.Message; 1

--- a/propulsion-consumer/Infrastructure.fs
+++ b/propulsion-consumer/Infrastructure.fs
@@ -5,6 +5,10 @@ open Serilog
 open System
 open System.Threading.Tasks
 
+module EnvVar =
+
+    let tryGet varName : string option = Environment.GetEnvironmentVariable varName |> Option.ofObj
+
 type FSharp.Control.Async with
     static member AwaitTaskCorrect (task : Task<'T>) : Async<'T> =
         Async.FromContinuations <| fun (k, ek, _) ->

--- a/propulsion-projector/Handler.fs
+++ b/propulsion-projector/Handler.fs
@@ -63,10 +63,10 @@ type ProductionStats(log, statsInterval, stateInterval) =
     inherit Propulsion.Streams.Sync.Stats<unit>(log, statsInterval, stateInterval)
 
     // TODO consider whether it's warranted to log every time a message is produced given the stats will periodically emit counts
-    override __.HandleOk(()) =
+    override _.HandleOk(()) =
         log.Warning("Produced")
     // TODO consider whether to log cause of every individual produce failure in full (Failure counts are emitted periodically)
-    override __.HandleExn(log, exn) =
+    override _.HandleExn(log, exn) =
         log.Information(exn, "Unhandled")
 
 /// Responsible for wrapping a span of events for a specific stream into an envelope
@@ -92,13 +92,13 @@ type ProjectorStats(log, statsInterval, stateInterval) =
 
     // TODO consider best balance between logging or gathering summary information per handler invocation
     // here we don't log per invocation (such high level stats are already gathered and emitted) but accumulate for periodic emission
-    override __.HandleOk count =
+    override _.HandleOk count =
         totalCount <- totalCount + count
     // TODO consider whether to log cause of every individual failure in full (Failure counts are emitted periodically)
-    override __.HandleExn(log, exn) =
+    override _.HandleExn(log, exn) =
         log.Information(exn, "Unhandled")
 
-    override __.DumpStats() =
+    override _.DumpStats() =
         log.Information(" Total events processed {total}", totalCount)
         totalCount <- 0
 

--- a/propulsion-projector/Infrastructure.fs
+++ b/propulsion-projector/Infrastructure.fs
@@ -2,13 +2,17 @@
 module ProjectorTemplate.Infrastructure
 
 open Serilog
-open System.Runtime.CompilerServices
+open System
+
+module EnvVar =
+
+    let tryGet varName : string option = Environment.GetEnvironmentVariable varName |> Option.ofObj
 
 #if cosmos
-[<Extension>]
+[<System.Runtime.CompilerServices.Extension>]
 type LoggerConfigurationExtensions() =
 
-    [<Extension>]
+    [<System.Runtime.CompilerServices.Extension>]
     static member inline ExcludeChangeFeedProcessorV2InternalDiagnostics(c : LoggerConfiguration) =
         let isCfp429a = Filters.Matching.FromSource("Microsoft.Azure.Documents.ChangeFeedProcessor.LeaseManagement.DocumentServiceLeaseUpdater").Invoke
         let isCfp429b = Filters.Matching.FromSource("Microsoft.Azure.Documents.ChangeFeedProcessor.PartitionManagement.LeaseRenewer").Invoke
@@ -17,7 +21,7 @@ type LoggerConfigurationExtensions() =
         let isCfp x = isCfp429a x || isCfp429b x || isCfp429c x || isCfp429d x
         c.Filter.ByExcluding(fun x -> isCfp x)
 
-    [<Extension>]
+    [<System.Runtime.CompilerServices.Extension>]
     static member inline ConfigureChangeFeedProcessorLogging(c : LoggerConfiguration, verbose : bool) =
         // LibLog writes to the global logger, so we need to control the emission
         let cfpl = if verbose then Serilog.Events.LogEventLevel.Debug else Serilog.Events.LogEventLevel.Warning
@@ -25,10 +29,10 @@ type LoggerConfigurationExtensions() =
         |> fun c -> if verbose then c else c.ExcludeChangeFeedProcessorV2InternalDiagnostics()
 
 #endif
-[<Extension>]
+[<System.Runtime.CompilerServices.Extension>]
 type Logging() =
 
-    [<Extension>]
+    [<System.Runtime.CompilerServices.Extension>]
 #if cosmos
     static member Configure(configuration : LoggerConfiguration, ?verbose, ?changeFeedProcessorVerbose) =
 #else

--- a/propulsion-projector/Program.fs
+++ b/propulsion-projector/Program.fs
@@ -99,7 +99,7 @@ module Args =
             Log.Information("CosmosDb timeout {timeout}s; Throttling retries {retries}, max wait {maxRetryWaitTime}s",
                 TimeSpan.FromSeconds x.Timeout, x.Retries, TimeSpan.FromSeconds x.MaxRetryWaitTime)
             let connector = Connector(x.Timeout, x.Retries, x.MaxRetryWaitTime, Log.Logger, mode=x.Mode)
-            discovery, { database = x.Database; container = x.Container }, connector
+            connector, discovery, { database = x.Database; container = x.Container }
 #endif
 #if esdb
     open Equinox.EventStore
@@ -413,7 +413,7 @@ let build (args : Args.Arguments) =
     let sink = Propulsion.Streams.StreamsProjector.Start(Log.Logger, maxReadAhead, maxConcurrentStreams, Handler.handle, stats, args.StatsInterval)
 #endif // cosmos && !kafka
     let pipeline =
-        let monitoredDiscovery, monitored, monitoredConnector = args.Cosmos.MonitoringParams()
+        let monitoredConnector, monitoredDiscovery, monitored = args.Cosmos.MonitoringParams()
         let aux, leaseId, startFromTail, maxDocuments, lagFrequency = args.BuildChangeFeedParams()
         let createObserver () = CosmosSource.CreateObserver(Log.ForContext<CosmosSource>(), sink.StartIngester, Handler.mapToStreamItems)
         CosmosSource.Run(

--- a/propulsion-projector/Program.fs
+++ b/propulsion-projector/Program.fs
@@ -17,7 +17,7 @@ type Configuration(tryGet) =
 #if esdb
     let isTrue varName = tryGet varName |> Option.exists (fun s -> String.Equals(s, bool.TrueString, StringComparison.OrdinalIgnoreCase))
 #endif
-#if cosmos || esdb
+#if (cosmos || esdb)
     member _.CosmosConnection =             get "EQUINOX_COSMOS_CONNECTION"
     member _.CosmosDatabase =               get "EQUINOX_COSMOS_DATABASE"
     member _.CosmosContainer =              get "EQUINOX_COSMOS_CONTAINER"

--- a/propulsion-projector/Program.fs
+++ b/propulsion-projector/Program.fs
@@ -193,7 +193,7 @@ module Args =
         member val CheckpointInterval =     TimeSpan.FromHours 1.
         member val Cosmos : CosmosArguments =
             match a.TryGetSubCommand() with
-            | Some (EsSourceParameters.Cosmos cosmos) -> CosmosArguments cosmos
+            | Some (EsSourceParameters.Cosmos cosmos) -> CosmosArguments (c, cosmos)
             | _ -> raise (MissingArg "Must specify `cosmos` checkpoint store when source is `es`")
     and [<NoEquality; NoComparison>] CosmosParameters =
         | [<AltCommandLine "-s">]           Connection of string

--- a/propulsion-projector/Program.fs
+++ b/propulsion-projector/Program.fs
@@ -325,7 +325,7 @@ module Args =
             Log.Information("Projecting... {dop} writers, max {maxReadAhead} batches read ahead", x.MaxConcurrentProcessors, x.MaxReadAhead)
             (x.MaxReadAhead, x.MaxConcurrentProcessors)
 #if cosmos
-        member val Cosmos =                 CosmosArguments(a.GetResult Cosmos)
+        member val Cosmos =                 CosmosArguments (c, a.GetResult Cosmos)
         member x.BuildChangeFeedParams() =
             let c = x.Cosmos
             match c.MaxDocuments with

--- a/propulsion-projector/Program.fs
+++ b/propulsion-projector/Program.fs
@@ -6,47 +6,43 @@ open Propulsion.Cosmos
 open Serilog
 open System
 
-module EnvVar =
+exception MissingArg of message : string with override this.Message = this.message
 
-    let tryGet varName : string option = Environment.GetEnvironmentVariable varName |> Option.ofObj
-    let set varName value : unit = Environment.SetEnvironmentVariable(varName, value)
+type Configuration(tryGet) =
 
-// TODO remove this entire comment after reading https://github.com/jet/dotnet-templates#module-configuration
-// - this is where any custom retrieval of settings not arriving via commandline arguments or environment variables should go
-// - values should be propagated by setting environment variables and/or returning them from `initialize`
-module Configuration =
+    let get key =
+        match tryGet key with
+        | Some value -> value
+        | None -> raise (MissingArg (sprintf "Missing Argument/Environment Variable %s" key))
+#if esdb
+    let isTrue varName = tryGet varName |> Option.exists (fun s -> String.Equals(s, bool.TrueString, StringComparison.OrdinalIgnoreCase))
+#endif
+#if cosmos
+    member _.CosmosConnection =             get "EQUINOX_COSMOS_CONNECTION"
+    member _.CosmosDatabase =               get "EQUINOX_COSMOS_DATABASE"
+    member _.CosmosContainer =              get "EQUINOX_COSMOS_CONTAINER"
+#endif
+//#if sss
+    member _.SqlStreamStoreConnection =     get "SQLSTREAMSTORE_CONNECTION"
+    member _.SqlStreamStoreCredentials =    tryGet "SQLSTREAMSTORE_CREDENTIALS"
+    member _.SqlStreamStoreCredentialsCheckpoints = tryGet "SQLSTREAMSTORE_CREDENTIALS_CHECKPOINTS"
+    member _.SqlStreamStoreDatabase =       get "SQLSTREAMSTORE_DATABASE"
+    member _.SqlStreamStoreContainer =      get "SQLSTREAMSTORE_CONTAINER"
+//#endif
+#if esdb
+    member _.EventStoreHost =               get "EQUINOX_ES_HOST"
+    member _.EventStoreTcp =                isTrue "EQUINOX_ES_TCP"
+    member _.EventStorePort =               tryGet "EQUINOX_ES_PORT" |> Option.map int
+    member _.EventStoreUsername =           get "EQUINOX_ES_USERNAME"
+    member _.EventStorePassword =           get "EQUINOX_ES_PASSWORD"
+#endif
+//#if kafka
+    member _.Broker =                       get "PROPULSION_KAFKA_BROKER"
+    member _.Topic =                        get "PROPULSION_KAFKA_TOPIC"
+//#endif
 
-    let private initEnvVar var key loadF =
-        if None = EnvVar.tryGet var then
-            printfn "Setting %s from %A" var key
-            EnvVar.set var (loadF key)
-
-    let initialize () =
-        // e.g. initEnvVar     "EQUINOX_COSMOS_CONTAINER"    "CONSUL KEY" readFromConsul
-        () // TODO add any custom logic preprocessing commandline arguments and/or gathering custom defaults from external sources, etc
-
-// TODO remove this entire comment after reading https://github.com/jet/dotnet-templates#module-args
-// - this module is responsible solely for parsing/validating the commandline arguments (including falling back to values supplied via environment variables)
-// - It's expected that the properties on *Arguments types will summarize the active settings as a side effect of
-// TODO DONT invest time reorganizing or reformatting this - half the value is having a legible summary of all program parameters in a consistent value
-//      you may want to regenerate it at a different time and/or facilitate comparing it with the `module Args` of other programs
-// TODO NEVER hack temporary overrides in here; if you're going to do that, use commandline arguments that fall back to environment variables
-//      or (as a last resort) supply them via code in `module Configuration`
 module Args =
 
-    exception MissingArg of string
-    let private getEnvVarForArgumentOrThrow varName argName =
-        match EnvVar.tryGet varName with
-        | None -> raise (MissingArg(sprintf "Please provide a %s, either as an argument or via the %s environment variable" argName varName))
-        | Some x -> x
-    let private defaultWithEnvVar varName argName = function
-        | None -> getEnvVarForArgumentOrThrow varName argName
-        | Some x -> x
-#if esdb
-    let private isEnvVarTrue varName =
-         EnvVar.tryGet varName |> Option.exists (fun s -> String.Equals(s, bool.TrueString, StringComparison.OrdinalIgnoreCase))
-#endif
-    let private seconds (x : TimeSpan) = x.TotalSeconds
     open Argu
 #if cosmos
     type [<NoEquality; NoComparison>] CosmosParameters =
@@ -80,28 +76,28 @@ module Args =
                 | Retries _ ->          "specify operation retries. Default: 1."
                 | RetriesWaitTime _ ->  "specify max wait-time for retry when being throttled by Cosmos in seconds. Default: 5."
     open Equinox.Cosmos
-    type CosmosArguments(a : ParseResults<CosmosParameters>) =
-        member __.CfpVerbose =          a.Contains CfpVerbose
-        member private __.Suffix =      a.GetResult(LeaseContainerSuffix, "-aux")
-        member __.AuxContainerName =    __.Container + __.Suffix
-        member __.FromTail =            a.Contains FromTail
-        member __.MaxDocuments =        a.TryGetResult MaxDocuments
-        member __.LagFrequency =        a.TryGetResult LagFreqM |> Option.map TimeSpan.FromMinutes
+    type CosmosArguments(c : Configuration, a : ParseResults<CosmosParameters>) =
+        member val CfpVerbose =         a.Contains CfpVerbose
+        member val private Suffix =  a.GetResult(LeaseContainerSuffix, "-aux")
+        member val AuxContainerName =   Container + Suffix
+        member val FromTail =           a.Contains FromTail
+        member val MaxDocuments =       a.TryGetResult MaxDocuments
+        member val LagFrequency =       a.TryGetResult LagFreqM |> Option.map TimeSpan.FromMinutes
 
-        member __.Mode =                a.GetResult(ConnectionMode, Equinox.Cosmos.ConnectionMode.Direct)
-        member __.Connection =          a.TryGetResult CosmosParameters.Connection |> defaultWithEnvVar "EQUINOX_COSMOS_CONNECTION" "Connection"
-        member __.Database =            a.TryGetResult Database |> defaultWithEnvVar "EQUINOX_COSMOS_DATABASE"   "Database"
-        member __.Container =           a.TryGetResult Container |> defaultWithEnvVar "EQUINOX_COSMOS_CONTAINER"  "Container"
-        member __.Timeout =             a.GetResult(Timeout, 5.) |> TimeSpan.FromSeconds
-        member __.Retries =             a.GetResult(Retries, 1)
-        member __.MaxRetryWaitTime =    a.GetResult(RetriesWaitTime, 5.) |> TimeSpan.FromSeconds
+        member val Mode =               a.GetResult(ConnectionMode, Equinox.Cosmos.ConnectionMode.Direct)
+        member val Connection =         a.TryGetResult CosmosParameters.Connection |> Option.defaultWith (fun () -> c.CosmosConnection) |> Discovery.FromConnectionString
+        member val Database =           a.TryGetResult Database |> Option.defaultWith (fun () -> c.CosmosDatabase)
+        member val Container =          a.TryGetResult Container |> Option.defaultWith (fun () -> c.CosmosContainer)
+        member val Timeout =            a.GetResult(Timeout, 5.) |> TimeSpan.FromSeconds
+        member val Retries =            a.GetResult(Retries, 1)
+        member val MaxRetryWaitTime =   a.GetResult(RetriesWaitTime, 5.) |> TimeSpan.FromSeconds
 
         member x.MonitoringParams() =
-            let (Discovery.UriAndKey (endpointUri, _) as discovery) = Discovery.FromConnectionString x.Connection
+            let Discovery.UriAndKey (endpointUri, _) as discovery = x.Connection
             Log.Information("CosmosDb {mode} {endpointUri} Database {database} Container {container}",
                 x.Mode, endpointUri, x.Database, x.Container)
             Log.Information("CosmosDb timeout {timeout}s; Throttling retries {retries}, max wait {maxRetryWaitTime}s",
-                seconds x.Timeout, x.Retries, seconds x.MaxRetryWaitTime)
+                TimeSpan.FromSeconds x.Timeout, x.Retries, TimeSpan.FromSeconds x.MaxRetryWaitTime)
             let connector = Connector(x.Timeout, x.Retries, x.MaxRetryWaitTime, Log.Logger, mode=x.Mode)
             discovery, { database = x.Database; container = x.Container }, connector
 #endif
@@ -153,45 +149,45 @@ module Args =
                 | HeartbeatTimeout _ ->     "specify heartbeat timeout in seconds. Default: 1.5."
 
                 | Cosmos _ ->               "CosmosDB (Checkpoint) Store parameters."
-    and EsSourceArguments(a : ParseResults<EsSourceParameters>) =
+    and EsSourceArguments(c : Configuration, a : ParseResults<EsSourceParameters>) =
         let discovery (host, port, tcp) =
             match tcp, port with
             | false, None ->   Discovery.GossipDns            host
             | false, Some p -> Discovery.GossipDnsCustomPort (host, p)
             | true, None ->    Discovery.Uri                 (UriBuilder("tcp", host, 1113).Uri)
             | true, Some p ->  Discovery.Uri                 (UriBuilder("tcp", host, p).Uri)
-        member __.Gorge =                   a.TryGetResult Gorge
-        member __.TailInterval =            a.GetResult(Tail, 1.) |> TimeSpan.FromSeconds
-        member __.ForceRestart =            a.Contains ForceRestart
-        member __.StartingBatchSize =       a.GetResult(BatchSize, 4096)
-        member __.MinBatchSize =            a.GetResult(MinBatchSize, 512)
-        member __.StartPos =
+        member val Gorge =                  a.TryGetResult Gorge
+        member val TailInterval =           a.GetResult(Tail, 1.) |> TimeSpan.FromSeconds
+        member val ForceRestart =           a.Contains ForceRestart
+        member val StartingBatchSize =      a.GetResult(BatchSize, 4096)
+        member val MinBatchSize =           a.GetResult(MinBatchSize, 512)
+        member val StartPos =
             match a.TryGetResult Position, a.TryGetResult Chunk, a.TryGetResult Percent, a.Contains EsSourceParameters.FromTail with
             | Some p, _, _, _ ->            Absolute p
             | _, Some c, _, _ ->            StartPos.Chunk c
             | _, _, Some p, _ ->            Percentage p
             | None, None, None, true ->     StartPos.TailOrCheckpoint
             | None, None, None, _ ->        StartPos.StartOrCheckpoint
-        member __.Tcp =                     a.Contains Tcp || isEnvVarTrue "EQUINOX_ES_TCP"
-        member __.Port =                    match a.TryGetResult Port with Some x -> Some x | None -> EnvVar.tryGet "EQUINOX_ES_PORT" |> Option.map int
-        member __.Host =                    a.TryGetResult Host     |> defaultWithEnvVar "EQUINOX_ES_HOST"     "Host"
-        member __.User =                    a.TryGetResult Username |> defaultWithEnvVar "EQUINOX_ES_USERNAME" "Username"
-        member __.Password =                a.TryGetResult Password |> defaultWithEnvVar "EQUINOX_ES_PASSWORD" "Password"
-        member __.Retries =                 a.GetResult(EsSourceParameters.Retries, 3)
-        member __.Timeout =                 a.GetResult(EsSourceParameters.Timeout, 20.) |> TimeSpan.FromSeconds
-        member __.Heartbeat =               a.GetResult(HeartbeatTimeout, 1.5) |> TimeSpan.FromSeconds
+        member val Tcp =                    a.Contains Tcp || c.EventStoreTcp
+        member val Port =                   match a.TryGetResult Port with Some x -> Some x | None -> c.EventStorePort
+        member val Host =                   a.TryGetResult Host     |> Option.defaultWith (fun () -> c.EventStoreHost)
+        member val User =                   a.TryGetResult Username |> Option.defaultWith (fun () -> c.EventStoreUsername)
+        member val Password =               a.TryGetResult Password |> Option.defaultWith (fun () -> c.EventStorePassword)
+        member val Retries =                a.GetResult(EsSourceParameters.Retries, 3)
+        member val Timeout =                a.GetResult(EsSourceParameters.Timeout, 20.) |> TimeSpan.FromSeconds
+        member val Heartbeat =              a.GetResult(HeartbeatTimeout, 1.5) |> TimeSpan.FromSeconds
 
         member x.Connect(log: ILogger, storeLog: ILogger, appName, nodePreference) =
             let discovery = discovery (x.Host, x.Port, x.Tcp)
             log.ForContext("host", x.Host).ForContext("port", x.Port)
                 .Information("EventStore {discovery} heartbeat: {heartbeat}s Timeout: {timeout}s Retries {retries}",
-                    discovery, seconds x.Heartbeat, seconds x.Timeout, x.Retries)
+                    discovery, TimeSpan.FromSeconds x.Heartbeat, TimeSpan.FromSeconds x.Timeout, x.Retries)
             let log=if storeLog.IsEnabled Serilog.Events.LogEventLevel.Debug then Logger.SerilogVerbose storeLog else Logger.SerilogNormal storeLog
             let tags=["M", Environment.MachineName; "I", Guid.NewGuid() |> string]
             Connector(x.User, x.Password, x.Timeout, x.Retries, log=log, heartbeatTimeout=x.Heartbeat, tags=tags)
                 .Connect(appName, discovery, nodePreference) |> Async.RunSynchronously
 
-        member __.CheckpointInterval =  TimeSpan.FromHours 1.
+        member val CheckpointInterval =     TimeSpan.FromHours 1.
         member val Cosmos : CosmosArguments =
             match a.TryGetSubCommand() with
             | Some (EsSourceParameters.Cosmos cosmos) -> CosmosArguments cosmos
@@ -214,20 +210,20 @@ module Args =
                 | Timeout _ ->              "specify operation timeout in seconds. Default: 5."
                 | Retries _ ->              "specify operation retries. Default: 1."
                 | RetriesWaitTime _ ->      "specify max wait-time for retry when being throttled by Cosmos in seconds. Default: 5."
-    and CosmosArguments(a : ParseResults<CosmosParameters>) =
-        member __.Mode =                    a.GetResult(CosmosParameters.ConnectionMode, Equinox.Cosmos.ConnectionMode.Direct)
-        member __.Connection =              a.TryGetResult CosmosParameters.Connection |> defaultWithEnvVar "EQUINOX_COSMOS_CONNECTION" "Connection"
-        member __.Database =                a.TryGetResult CosmosParameters.Database   |> defaultWithEnvVar "EQUINOX_COSMOS_DATABASE"   "Database"
-        member __.Container =               a.TryGetResult CosmosParameters.Container  |> defaultWithEnvVar "EQUINOX_COSMOS_CONTAINER"  "Container"
-        member __.Timeout =                 a.GetResult(CosmosParameters.Timeout, 5.) |> TimeSpan.FromSeconds
-        member __.Retries =                 a.GetResult(CosmosParameters.Retries, 1)
-        member __.MaxRetryWaitTime =        a.GetResult(CosmosParameters.RetriesWaitTime, 5.) |> TimeSpan.FromSeconds
+    and CosmosArguments(c : Configuration, a : ParseResults<CosmosParameters>) =
+        member val Mode =                   a.GetResult(CosmosParameters.ConnectionMode, Equinox.Cosmos.ConnectionMode.Direct)
+        member val Connection =             a.TryGetResult CosmosSourceParameters.Connection |> Option.defaultWith (fun () -> c.CosmosConnection) |> Discovery.FromConnectionString
+        member val Database =               a.TryGetResult CosmosSourceParameters.Database   |> Option.defaultWith (fun () -> c.CosmosDatabase)
+        member val Container =              a.TryGetResult CosmosSourceParameters.Container  |> Option.defaultWith (fun () -> c.CosmosContainer)
+        member val Timeout =                a.GetResult(CosmosParameters.Timeout, 5.) |> TimeSpan.FromSeconds
+        member val Retries =                a.GetResult(CosmosParameters.Retries, 1)
+        member val MaxRetryWaitTime =       a.GetResult(CosmosParameters.RetriesWaitTime, 5.) |> TimeSpan.FromSeconds
         member x.BuildConnectionDetails() =
-            let (Equinox.Cosmos.Discovery.UriAndKey (endpointUri, _) as discovery) = Equinox.Cosmos.Discovery.FromConnectionString x.Connection
+            let Equinox.Cosmos.Discovery.UriAndKey (endpointUri, _) as discovery = x.Connection
             Log.Information("CosmosDb {mode} {endpointUri} Database {database} Container {container}",
                 x.Mode, endpointUri, x.Database, x.Container)
             Log.Information("CosmosDb timeout {timeout}s; Throttling retries {retries}, max wait {maxRetryWaitTime}s",
-                seconds x.Timeout, x.Retries, seconds x.MaxRetryWaitTime)
+                TimeSpan.FromSeconds x.Timeout, x.Retries, TimeSpan.FromSeconds x.MaxRetryWaitTime)
             let connector = Equinox.Cosmos.Connector(x.Timeout, x.Retries, x.MaxRetryWaitTime, Log.Logger, mode=x.Mode)
             discovery, x.Database, x.Container, connector
 #endif
@@ -250,12 +246,12 @@ module Args =
                 | Schema _ ->               "Database schema name"
                 | CheckpointsConnection _ ->"Connection string for Checkpoints sql db. Optional if SQLSTREAMSTORE_CONNECTION_CHECKPOINTS specified. Default: same as `Connection`"
                 | CheckpointsCredentials _ ->"Credentials string for Checkpoints sql db. (used as part of checkpoints connection string, but NOT logged). Default (when no `CheckpointsConnection`: use `Credentials. Default (when `CheckpointsConnection` specified): use SQLSTREAMSTORE_CREDENTIALS_CHECKPOINTS environment variable (or assume no credentials)"
-    and SqlStreamStoreSourceArguments(a : ParseResults<SqlStreamStoreSourceParameters>) =
-        member __.TailInterval =            a.GetResult(Tail, 1.) |> TimeSpan.FromSeconds
-        member __.MaxBatchSize =            a.GetResult(BatchSize, 512)
-        member private __.Connection =      a.TryGetResult Connection |> defaultWithEnvVar "SQLSTREAMSTORE_CONNECTION" "Connection"
-        member private __.Credentials =     a.TryGetResult Credentials |> Option.orElseWith (fun () -> EnvVar.tryGet "SQLSTREAMSTORE_CREDENTIALS") |> Option.toObj
-        member __.Schema =                  a.GetResult(Schema, null)
+    and SqlStreamStoreSourceArguments(c : Configuration, a : ParseResults<SqlStreamStoreSourceParameters>) =
+        member val TailInterval =           a.GetResult(Tail, 1.) |> TimeSpan.FromSeconds
+        member val MaxBatchSize =           a.GetResult(BatchSize, 512)
+        member val private Connection =     a.TryGetResult Connection |> Option.defaultWith (fun () -> c.SqlStreamStoreConnection)
+        member val private Credentials =    a.TryGetResult Credentials |> Option.orElseWith (fun () -> c.SqlStreamStoreCredentials) |> Option.toObj
+        member val Schema =                 a.GetResult(Schema, null)
 
         member x.BuildCheckpointsConnectionString() =
             let c, cs =
@@ -263,8 +259,8 @@ module Args =
                 | Some c, Some p -> c, String.Join(";", c, p)
                 | None, Some p ->   let c = x.Connection in c, String.Join(";", c, p)
                 | None, None ->     let c = x.Connection in c, String.Join(";", c, x.Credentials)
-                | Some c, None ->   let p = EnvVar.tryGet "SQLSTREAMSTORE_CREDENTIALS_CHECKPOINTS" |> Option.toObj
-                                    c, String.Join(";", c, p)
+                | Some cc, None ->  let p = c.SqlStreamStoreCredentialsCheckpoints |> Option.toObj
+                                    cc, String.Join(";", cc, p)
             Log.Information("Checkpoints MsSql Connection {connectionString}", c)
             cs
         member x.Connect() =
@@ -314,65 +310,65 @@ module Args =
 //#if sss
                 | SqlMs _ ->                "specify SqlStreamStore input parameters."
 //#endif
-    and Arguments(a : ParseResults<Parameters>) =
-        member __.Verbose =                 a.Contains Verbose
-        member __.ConsumerGroupName =       a.GetResult ConsumerGroupName
-        member __.MaxReadAhead =            a.GetResult(MaxReadAhead, 64)
-        member __.MaxConcurrentProcessors = a.GetResult(MaxWriters, 1024)
-        member __.StatsInterval =           TimeSpan.FromMinutes 1.
-        member __.StateInterval =           TimeSpan.FromMinutes 2.
+    and Arguments(c : Configuration, a : ParseResults<Parameters>) =
+        member val Verbose =                a.Contains Verbose
+        member val ConsumerGroupName =      a.GetResult ConsumerGroupName
+        member val MaxReadAhead =           a.GetResult(MaxReadAhead, 64)
+        member val MaxConcurrentProcessors =a.GetResult(MaxWriters, 1024)
+        member val StatsInterval =          TimeSpan.FromMinutes 1.
+        member val StateInterval =          TimeSpan.FromMinutes 2.
         member x.BuildProcessorParams() =
             Log.Information("Projecting... {dop} writers, max {maxReadAhead} batches read ahead", x.MaxConcurrentProcessors, x.MaxReadAhead)
             (x.MaxReadAhead, x.MaxConcurrentProcessors)
 #if cosmos
         member val Cosmos =                 CosmosArguments(a.GetResult Cosmos)
-        member __.BuildChangeFeedParams() =
-            let c = __.Cosmos
+        member x.BuildChangeFeedParams() =
+            let c = x.Cosmos
             match c.MaxDocuments with
-            | None -> Log.Information("Processing {leaseId} in {auxContainerName} without document count limit", __.ConsumerGroupName, c.AuxContainerName)
+            | None -> Log.Information("Processing {leaseId} in {auxContainerName} without document count limit", x.ConsumerGroupName, c.AuxContainerName)
             | Some lim ->
-                Log.Information("Processing {leaseId} in {auxContainerName} with max {changeFeedMaxDocuments} documents", __.ConsumerGroupName, c.AuxContainerName, lim)
+                Log.Information("Processing {leaseId} in {auxContainerName} with max {changeFeedMaxDocuments} documents", x.ConsumerGroupName, c.AuxContainerName, lim)
             if c.FromTail then Log.Warning("(If new projector group) Skipping projection of all existing events.")
             c.LagFrequency |> Option.iter (fun s -> Log.Information("Dumping lag stats at {lagS:n0}s intervals", s.TotalSeconds))
-            { database = c.Database; container = c.AuxContainerName }, __.ConsumerGroupName, c.FromTail, c.MaxDocuments, c.LagFrequency
+            { database = c.Database; container = c.AuxContainerName }, x.ConsumerGroupName, c.FromTail, c.MaxDocuments, c.LagFrequency
 #endif
 #if esdb
         member val Es =                     EsSourceArguments(a.GetResult Es)
-        member __.BuildEventStoreParams() =
-            let srcE = __.Es
+        member x.BuildEventStoreParams() =
+            let srcE = x.Es
             let startPos, cosmos = srcE.StartPos, srcE.Cosmos
             Log.Information("Processing Consumer Group {groupName} from {startPos} (force: {forceRestart}) in Database {db} Container {container}",
-                __.ConsumerGroupName, startPos, srcE.ForceRestart, cosmos.Database, cosmos.Container)
+                x.ConsumerGroupName, startPos, srcE.ForceRestart, cosmos.Database, cosmos.Container)
             Log.Information("Ingesting in batches of [{minBatchSize}..{batchSize}], reading up to {maxReadAhead} uncommitted batches ahead",
-                srcE.MinBatchSize, srcE.StartingBatchSize, __.MaxReadAhead)
+                srcE.MinBatchSize, srcE.StartingBatchSize, x.MaxReadAhead)
             srcE, cosmos,
-                {   groupName = __.ConsumerGroupName; start = startPos; checkpointInterval = srcE.CheckpointInterval; tailInterval = srcE.TailInterval
+                {   groupName = x.ConsumerGroupName; start = startPos; checkpointInterval = srcE.CheckpointInterval; tailInterval = srcE.TailInterval
                     forceRestart = srcE.ForceRestart
                     batchSize = srcE.StartingBatchSize; minBatchSize = srcE.MinBatchSize; gorge = srcE.Gorge; streamReaders = 0 }
 #endif
 //#if sss
-        member val SqlStreamStore =         SqlStreamStoreSourceArguments(a.GetResult SqlMs)
-        member __.BuildSqlStreamStoreParams() =
-            let src = __.SqlStreamStore
+        member val SqlStreamStore =         SqlStreamStoreSourceArguments(c, a.GetResult SqlMs)
+        member x.BuildSqlStreamStoreParams() =
+            let src = x.SqlStreamStore
             let spec : Propulsion.SqlStreamStore.ReaderSpec =
-                {    consumerGroup          = __.ConsumerGroupName
+                {    consumerGroup          = x.ConsumerGroupName
                      maxBatchSize           = src.MaxBatchSize
                      tailSleepInterval      = src.TailInterval }
             src, spec
 //#endif
 //#if kafka
-        member val Target =                 TargetInfo a
-    and TargetInfo(a : ParseResults<Parameters>) =
-        member __.Broker =                  a.TryGetResult Broker |> defaultWithEnvVar "PROPULSION_KAFKA_BROKER" "Broker"
-        member __.Topic =                   a.TryGetResult Topic  |> defaultWithEnvVar "PROPULSION_KAFKA_TOPIC"  "Topic"
+        member val Target =                 TargetInfo (c, a)
+    and TargetInfo(c : Configuration, a : ParseResults<Parameters>) =
+        member val Broker =                 a.TryGetResult Broker |> Option.defaultWith (fun () -> c.Broker)
+        member val Topic =                  a.TryGetResult Topic  |> Option.defaultWith (fun () -> c.Topic)
         member x.BuildTargetParams() =      x.Broker, x.Topic
 //#endif
 
     /// Parse the commandline; can throw exceptions in response to missing arguments and/or `-h`/`--help` args
-    let parse argv =
+    let parse tryGetConfigValue argv : Arguments =
         let programName = System.Reflection.Assembly.GetEntryAssembly().GetName().Name
         let parser = ArgumentParser.Create<Parameters>(programName=programName)
-        parser.ParseCommandLine argv |> Arguments
+        Arguments(Configuration tryGetConfigValue, parser.ParseCommandLine argv)
 
 //#if esdb
 
@@ -404,7 +400,7 @@ let build (args : Args.Arguments) =
     let maxReadAhead, maxConcurrentStreams = args.BuildProcessorParams()
 #if cosmos // cosmos
 #if     kafka // cosmos && kafka
-    let (broker, topic) = args.Target.BuildTargetParams()
+    let broker, topic = args.Target.BuildTargetParams()
     let producer = Propulsion.Kafka.Producer(Log.Logger, AppName, broker, topic)
 #if         parallelOnly // cosmos && kafka && parallelOnly
     let sink = Propulsion.Kafka.ParallelProducerSink.Start(maxReadAhead, maxConcurrentStreams, Handler.render, producer, args.StatsInterval)
@@ -426,10 +422,10 @@ let build (args : Args.Arguments) =
             ?maxDocuments=maxDocuments, ?lagReportFreq=lagFrequency)
 #endif // cosmos
 #if esdb
-    let (srcE, cosmos, spec) = args.BuildEventStoreParams()
+    let srcE, cosmos, spec = args.BuildEventStoreParams()
 
     let connectEs () = srcE.Connect(Log.Logger, Log.Logger, AppName, Equinox.EventStore.NodePreference.Master)
-    let (discovery, database, container, connector) = cosmos.BuildConnectionDetails()
+    let discovery, database, container, connector = cosmos.BuildConnectionDetails()
 
     let context = CosmosContext.create AppName connector discovery (database, container)
     let cache = Equinox.Cache(AppName, sizeMb=10)
@@ -437,7 +433,7 @@ let build (args : Args.Arguments) =
     let checkpoints = Checkpoints.Cosmos.create spec.groupName (context, cache)
 
 #if     kafka // esdb && kafka
-    let (broker, topic) = args.Target.BuildTargetParams()
+    let broker, topic = args.Target.BuildTargetParams()
     let producer = Propulsion.Kafka.Producer(Log.Logger, AppName, broker, topic)
     let stats = Handler.ProductionStats(Log.Logger, args.StatsInterval, args.StateInterval)
     let sink = Propulsion.Kafka.StreamsProducerSink.Start(Log.Logger, maxReadAhead, maxConcurrentStreams, Handler.render, producer, stats, args.StatsInterval)
@@ -452,7 +448,7 @@ let build (args : Args.Arguments) =
             args.MaxReadAhead, args.StatsInterval)
 #endif // esdb
 //#if sss
-    let (srcSql, spec) = args.BuildSqlStreamStoreParams()
+    let srcSql, spec = args.BuildSqlStreamStoreParams()
 
     let monitored = srcSql.Connect()
 
@@ -460,7 +456,7 @@ let build (args : Args.Arguments) =
     let checkpointer = Propulsion.SqlStreamStore.SqlCheckpointer(connectionString)
 
 #if     kafka // sss && kafka
-    let (broker, topic) = args.Target.BuildTargetParams()
+    let broker, topic = args.Target.BuildTargetParams()
     let producer = Propulsion.Kafka.Producer(Log.Logger, AppName, broker, topic)
     let stats = Handler.ProductionStats(Log.Logger, args.StatsInterval, args.StateInterval)
     let sink = Propulsion.Kafka.StreamsProducerSink.Start(Log.Logger, maxReadAhead, maxConcurrentStreams, Handler.render, producer, stats, args.StatsInterval)
@@ -480,17 +476,16 @@ let run args = async {
 
 [<EntryPoint>]
 let main argv =
-    try let args = Args.parse argv
+    try let args = Args.parse EnvVar.tryGet argv
 #if cosmos
         try Log.Logger <- LoggerConfiguration().Configure(verbose=args.Verbose, changeFeedProcessorVerbose=args.Cosmos.CfpVerbose).CreateLogger()
 #else
         try Log.Logger <- LoggerConfiguration().Configure(verbose=args.Verbose).CreateLogger()
 #endif
-            try Configuration.initialize ()
-                run args  |> Async.RunSynchronously
+            try run args  |> Async.RunSynchronously
                 0
-            with e when not (e :? Args.MissingArg) -> Log.Fatal(e, "Exiting"); 2
+            with e when not (e :? MissingArg) -> Log.Fatal(e, "Exiting"); 2
         finally Log.CloseAndFlush()
-    with Args.MissingArg msg -> eprintfn "%s" msg; 1
+    with MissingArg msg -> eprintfn "%s" msg; 1
         | :? Argu.ArguParseException as e -> eprintfn "%s" e.Message; 1
         | e -> eprintf "Exception %s" e.Message; 1

--- a/propulsion-pruner/Infrastructure.fs
+++ b/propulsion-pruner/Infrastructure.fs
@@ -2,12 +2,16 @@
 module PrunerTemplate.Infrastructure
 
 open Serilog
-open System.Runtime.CompilerServices
+open System
 
-[<Extension>]
+module EnvVar =
+
+    let tryGet varName : string option = Environment.GetEnvironmentVariable varName |> Option.ofObj
+
+[<System.Runtime.CompilerServices.Extension>]
 type LoggerConfigurationExtensions() =
 
-    [<Extension>]
+    [<System.Runtime.CompilerServices.Extension>]
     static member inline ExcludeChangeFeedProcessorV2InternalDiagnostics(c : LoggerConfiguration) =
         let isCfp429a = Filters.Matching.FromSource("Microsoft.Azure.Documents.ChangeFeedProcessor.LeaseManagement.DocumentServiceLeaseUpdater").Invoke
         let isCfp429b = Filters.Matching.FromSource("Microsoft.Azure.Documents.ChangeFeedProcessor.PartitionManagement.LeaseRenewer").Invoke
@@ -16,17 +20,17 @@ type LoggerConfigurationExtensions() =
         let isCfp x = isCfp429a x || isCfp429b x || isCfp429c x || isCfp429d x
         c.Filter.ByExcluding(fun x -> isCfp x)
 
-    [<Extension>]
+    [<System.Runtime.CompilerServices.Extension>]
     static member inline ConfigureChangeFeedProcessorLogging(c : LoggerConfiguration, verbose : bool) =
         // LibLog writes to the global logger, so we need to control the emission
         let cfpl = if verbose then Events.LogEventLevel.Debug else Events.LogEventLevel.Warning
         c.MinimumLevel.Override("Microsoft.Azure.Documents.ChangeFeedProcessor", cfpl)
         |> fun c -> if verbose then c else c.ExcludeChangeFeedProcessorV2InternalDiagnostics()
 
-[<Extension>]
+[<System.Runtime.CompilerServices.Extension>]
 type Logging() =
 
-    [<Extension>]
+    [<System.Runtime.CompilerServices.Extension>]
     static member Configure(configuration : LoggerConfiguration, ?verbose, ?changeFeedProcessorVerbose) =
         let verbose, cfpVerbose = defaultArg verbose false, defaultArg changeFeedProcessorVerbose false
         configuration

--- a/propulsion-pruner/Program.fs
+++ b/propulsion-pruner/Program.fs
@@ -5,42 +5,20 @@ open Propulsion.Cosmos
 open Serilog
 open System
 
-module EnvVar =
+exception MissingArg of message : string with override this.Message = this.message
 
-    let tryGet varName : string option = Environment.GetEnvironmentVariable varName |> Option.ofObj
-    let set varName value : unit = Environment.SetEnvironmentVariable(varName, value)
+type Configuration(tryGet) =
 
-// TODO remove this entire comment after reading https://github.com/jet/dotnet-templates#module-configuration
-// - this is where any custom retrieval of settings not arriving via commandline arguments or environment variables should go
-// - values should be propagated by setting environment variables and/or returning them from `initialize`
-module Configuration =
+    let get key =
+        match tryGet key with
+        | Some value -> value
+        | None -> raise (MissingArg (sprintf "Missing Argument/Environment Variable %s" key))
 
-    let private initEnvVar var key loadF =
-        if None = EnvVar.tryGet var then
-            printfn "Setting %s from %A" var key
-            EnvVar.set var (loadF key)
+    member _.CosmosConnection =             get "EQUINOX_COSMOS_CONNECTION"
+    member _.CosmosDatabase =               get "EQUINOX_COSMOS_DATABASE"
+    member _.CosmosContainer =              get "EQUINOX_COSMOS_CONTAINER"
 
-    let initialize () =
-        // e.g. initEnvVar     "EQUINOX_COSMOS_CONTAINER"    "CONSUL KEY" readFromConsul
-        () // TODO add any custom logic preprocessing commandline arguments and/or gathering custom defaults from external sources, etc
-
-// TODO remove this entire comment after reading https://github.com/jet/dotnet-templates#module-args
-// - this module is responsible solely for parsing/validating the commandline arguments (including falling back to values supplied via environment variables)
-// - It's expected that the properties on *Arguments types will summarize the active settings as a side effect of
-// TODO DONT invest time reorganizing or reformatting this - half the value is having a legible summary of all program parameters in a consistent value
-//      you may want to regenerate it at a different time and/or facilitate comparing it with the `module Args` of other programs
-// TODO NEVER hack temporary overrides in here; if you're going to do that, use commandline arguments that fall back to environment variables
-//      or (as a last resort) supply them via code in `module Configuration`
 module Args =
-
-    exception MissingArg of string
-    let private getEnvVarForArgumentOrThrow varName argName =
-        match EnvVar.tryGet varName with
-        | None -> raise (MissingArg(sprintf "Please provide a %s, either as an argument or via the %s environment variable" argName varName))
-        | Some x -> x
-    let private defaultWithEnvVar varName argName = function
-        | None -> getEnvVarForArgumentOrThrow varName argName
-        | Some x -> x
 
     open Argu
     [<NoEquality; NoComparison>]
@@ -63,26 +41,26 @@ module Args =
                 | CfpVerbose ->             "request Verbose Change Feed Processor Logging. Default: off"
 
                 | SrcCosmos _ ->            "Cosmos input parameters."
-    and Arguments(a : ParseResults<Parameters>) =
-        member __.ConsumerGroupName =       a.GetResult ConsumerGroupName
-        member __.MaxReadAhead =            a.GetResult(MaxReadAhead, 32)
-        member __.MaxWriters =              a.GetResult(MaxWriters, 4)
-        member __.Verbose =                 a.Contains Parameters.Verbose
-        member __.CfpVerbose =              a.Contains CfpVerbose
-        member __.StatsInterval =           TimeSpan.FromMinutes 1.
-        member __.StateInterval =           TimeSpan.FromMinutes 5.
+    and Arguments(c : Configuration, a : ParseResults<Parameters>) =
+        member val ConsumerGroupName =      a.GetResult ConsumerGroupName
+        member val MaxReadAhead =           a.GetResult(MaxReadAhead, 32)
+        member val MaxWriters =             a.GetResult(MaxWriters, 4)
+        member val Verbose =                a.Contains Parameters.Verbose
+        member val CfpVerbose =             a.Contains CfpVerbose
+        member val StatsInterval =          TimeSpan.FromMinutes 1.
+        member val StateInterval =          TimeSpan.FromMinutes 5.
         member val private Source : CosmosSourceArguments =
             match a.TryGetSubCommand() with
-            | Some (SrcCosmos cosmos) -> (CosmosSourceArguments cosmos)
+            | Some (SrcCosmos cosmos) -> (CosmosSourceArguments (c, cosmos))
             | _ -> raise (MissingArg "Must specify cosmos for Src")
         member x.SourceParams() =
             let srcC = x.Source
             let disco, db =
                 let dstC : CosmosSinkArguments = srcC.Sink
                 match srcC.LeaseContainer, dstC.LeaseContainer with
-                | None, None ->     srcC.Discovery, { database = srcC.Database; container = srcC.Container + "-aux" }
-                | Some sc, None ->  srcC.Discovery, { database = srcC.Database; container = sc }
-                | None, Some dc ->  dstC.Discovery, { database = dstC.Database; container = dc }
+                | None, None ->     srcC.Connection, { database = srcC.Database; container = srcC.Container + "-aux" }
+                | Some sc, None ->  srcC.Connection, { database = srcC.Database; container = sc }
+                | None, Some dc ->  dstC.Connection, { database = dstC.Database; container = dc }
                 | Some _, Some _ -> raise (MissingArg "LeaseContainerSource and LeaseContainerDestination are mutually exclusive - can only store in one database")
             Log.Information("Pruning... {dop} writers, max {maxReadAhead} batches read ahead", x.MaxWriters, x.MaxReadAhead)
             Log.Information("Monitoring Group {leaseId} in Database {db} Container {container} with maximum document count limited to {maxDocuments}",
@@ -121,30 +99,29 @@ module Args =
                 | RetriesWaitTime _ ->      "specify max wait-time for retry when being throttled by Cosmos in seconds. Default: 30."
 
                 | DstCosmos _ ->            "CosmosDb Sink parameters."
-    and CosmosSourceArguments(a : ParseResults<CosmosSourceParameters>) =
-        member __.FromTail =                a.Contains CosmosSourceParameters.FromTail
-        member __.MaxDocuments =            a.TryGetResult MaxDocuments
-        member __.LagFrequency =            a.TryGetResult LagFreqM |> Option.map TimeSpan.FromMinutes
-        member __.LeaseContainer =          a.TryGetResult CosmosSourceParameters.LeaseContainer
-        member __.Mode =                    a.GetResult(CosmosSourceParameters.ConnectionMode, Equinox.Cosmos.ConnectionMode.Direct)
-        member __.Discovery =               Discovery.FromConnectionString __.Connection
-        member __.Connection =              a.TryGetResult CosmosSourceParameters.Connection |> defaultWithEnvVar "EQUINOX_COSMOS_CONNECTION" "Connection"
-        member __.Database =                a.TryGetResult CosmosSourceParameters.Database   |> defaultWithEnvVar "EQUINOX_COSMOS_DATABASE"   "Database"
-        member __.Container =               a.GetResult CosmosSourceParameters.Container
-        member __.Timeout =                 a.GetResult(CosmosSourceParameters.Timeout, 5.) |> TimeSpan.FromSeconds
-        member __.Retries =                 a.GetResult(CosmosSourceParameters.Retries, 5)
-        member __.MaxRetryWaitTime =        a.GetResult(CosmosSourceParameters.RetriesWaitTime, 30.) |> TimeSpan.FromSeconds
+    and CosmosSourceArguments(c : Configuration, a : ParseResults<CosmosSourceParameters>) =
+        member val FromTail =               a.Contains CosmosSourceParameters.FromTail
+        member val MaxDocuments =           a.TryGetResult MaxDocuments
+        member val LagFrequency =           a.TryGetResult LagFreqM |> Option.map TimeSpan.FromMinutes
+        member val LeaseContainer =         a.TryGetResult CosmosSourceParameters.LeaseContainer
+        member val Mode =                   a.GetResult(CosmosSourceParameters.ConnectionMode, Equinox.Cosmos.ConnectionMode.Direct)
+        member val Connection =             a.TryGetResult CosmosSourceParameters.Connection |> Option.defaultWith (fun () -> c.CosmosConnection) |> Discovery.FromConnectionString
+        member val Database =               a.TryGetResult CosmosSourceParameters.Database   |> Option.defaultWith (fun () -> c.CosmosDatabase)
+        member val Container =              a.GetResult CosmosSourceParameters.Container
+        member val Timeout =                a.GetResult(CosmosSourceParameters.Timeout, 5.) |> TimeSpan.FromSeconds
+        member val Retries =                a.GetResult(CosmosSourceParameters.Retries, 5)
+        member val MaxRetryWaitTime =       a.GetResult(CosmosSourceParameters.RetriesWaitTime, 30.) |> TimeSpan.FromSeconds
         member val Sink =
             match a.TryGetSubCommand() with
-            | Some (DstCosmos cosmos) -> CosmosSinkArguments cosmos
+            | Some (DstCosmos cosmos) -> CosmosSinkArguments (c, cosmos)
             | _ -> raise (MissingArg "Must specify cosmos for Sink")
         member x.MonitoringParams() =
-            let (Discovery.UriAndKey (endpointUri, _)) as discovery = x.Discovery
+            let Discovery.UriAndKey (endpointUri, _) as discovery = x.Connection
             Log.Information("Reference Source CosmosDb {mode} {endpointUri} Database {database} Container {container}",
                 x.Mode, endpointUri, x.Database, x.Container)
             Log.Information("Reference Source CosmosDb timeout {timeout}s; Throttling retries {retries}, max wait {maxRetryWaitTime}s",
                 (let t = x.Timeout in t.TotalSeconds), x.Retries, (let t = x.MaxRetryWaitTime in t.TotalSeconds))
-            let c = Equinox.Cosmos.Connector(x.Timeout, x.Retries, x.MaxRetryWaitTime, Log.Logger, mode=x.Mode)
+            let c = Connector(x.Timeout, x.Retries, x.MaxRetryWaitTime, Log.Logger, mode=x.Mode)
             discovery, { database = x.Database; container = x.Container }, c
     and [<NoEquality; NoComparison>] CosmosSinkParameters =
         | [<AltCommandLine "-m">]           ConnectionMode of Equinox.Cosmos.ConnectionMode
@@ -165,19 +142,18 @@ module Args =
                 | Timeout _ ->              "specify operation timeout in seconds. Default: 5."
                 | Retries _ ->              "specify operation retries. Default: 0."
                 | RetriesWaitTime _ ->      "specify max wait-time for retry when being throttled by Cosmos in seconds. Default: 5."
-    and CosmosSinkArguments(a : ParseResults<CosmosSinkParameters>) =
-        member __.Mode =                    a.GetResult(ConnectionMode, Equinox.Cosmos.ConnectionMode.Direct)
-        member __.Discovery =               Discovery.FromConnectionString __.Connection
-        member __.Connection =              a.TryGetResult Connection |> defaultWithEnvVar "EQUINOX_COSMOS_CONNECTION" "Connection"
-        member __.Database =                a.TryGetResult Database   |> defaultWithEnvVar "EQUINOX_COSMOS_DATABASE"   "Database"
-        member __.Container =               a.TryGetResult Container  |> defaultWithEnvVar "EQUINOX_COSMOS_CONTAINER"  "Container"
-        member __.LeaseContainer =          a.TryGetResult LeaseContainer
-        member __.Timeout =                 a.GetResult(CosmosSinkParameters.Timeout, 5.) |> TimeSpan.FromSeconds
-        member __.Retries =                 a.GetResult(CosmosSinkParameters.Retries, 0)
-        member __.MaxRetryWaitTime =        a.GetResult(RetriesWaitTime, 5.) |> TimeSpan.FromSeconds
+    and CosmosSinkArguments(c : Configuration, a : ParseResults<CosmosSinkParameters>) =
+        member val Mode =                   a.GetResult(ConnectionMode, Equinox.Cosmos.ConnectionMode.Direct)
+        member val Connection =             a.TryGetResult Connection |> Option.defaultWith (fun () -> c.CosmosConnection) |> Discovery.FromConnectionString
+        member val Database =               a.TryGetResult Database   |> Option.defaultWith (fun () -> c.CosmosDatabase)
+        member val Container =              a.TryGetResult Container  |> Option.defaultWith (fun () -> c.CosmosContainer)
+        member val LeaseContainer =         a.TryGetResult LeaseContainer
+        member val Timeout =                a.GetResult(CosmosSinkParameters.Timeout, 5.) |> TimeSpan.FromSeconds
+        member val Retries =                a.GetResult(CosmosSinkParameters.Retries, 0)
+        member val MaxRetryWaitTime =       a.GetResult(RetriesWaitTime, 5.) |> TimeSpan.FromSeconds
         /// Connect with the provided parameters and/or environment variables
         member x.Connect appName : Async<Equinox.Cosmos.Connection> =
-            let (Discovery.UriAndKey (endpointUri, _masterKey)) as discovery = x.Discovery
+            let Discovery.UriAndKey (endpointUri, _masterKey) as discovery = x.Connection
             Log.Information("DELETION Target CosmosDb {mode} {endpointUri} Database {database} Container {container}",
                 x.Mode, endpointUri, x.Database, x.Container)
             Log.Information("DELETION Target CosmosDb timeout {timeout}s; Throttling retries {retries}, max wait {maxRetryWaitTime}s",
@@ -186,21 +162,21 @@ module Args =
             c.Connect(appName, discovery)
 
     /// Parse the commandline; can throw exceptions in response to missing arguments and/or `-h`/`--help` args
-    let parse argv : Arguments =
+    let parse tryGetConfigValue argv : Arguments =
         let programName = System.Reflection.Assembly.GetEntryAssembly().GetName().Name
         let parser = ArgumentParser.Create<Parameters>(programName=programName)
-        parser.ParseCommandLine argv |> Arguments
+        Arguments(Configuration tryGetConfigValue, parser.ParseCommandLine argv)
 
 let [<Literal>] AppName = "PrunerTemplate"
 
 let build (args : Args.Arguments, log : ILogger, storeLog : ILogger) =
-    let (source, (auxDiscovery, aux, leaseId, startFromTail, maxDocuments, lagFrequency)) = args.SourceParams()
+    let source, (auxDiscovery, aux, leaseId, startFromTail, maxDocuments, lagFrequency) = args.SourceParams()
 
     // NOTE - DANGEROUS - events submitted to this sink get DELETED from the supplied Context!
     let deletingEventsSink =
         let target = source.Sink
         if (target.Database, target.Container) = (source.Database, source.Container) then
-            raise (Args.MissingArg "Danger! Can not prune a target based on itself")
+            raise (MissingArg "Danger! Can not prune a target based on itself")
         let containers = Containers(target.Database, target.Container)
         let conn = target.Connect AppName |> Async.RunSynchronously
         let context = Equinox.Cosmos.Core.Context(conn, containers, storeLog)
@@ -223,13 +199,12 @@ let run args = async {
 
 [<EntryPoint>]
 let main argv =
-    try let args = Args.parse argv
+    try let args = Args.parse EnvVar.tryGet argv
         try Log.Logger <- LoggerConfiguration().Configure(args.Verbose, args.CfpVerbose).CreateLogger()
-            try Configuration.initialize ()
-                run args |> Async.RunSynchronously
+            try run args |> Async.RunSynchronously
                 0
-            with e when not (e :? Args.MissingArg) -> Log.Fatal(e, "Exiting"); 2
+            with e when not (e :? MissingArg) -> Log.Fatal(e, "Exiting"); 2
         finally Log.CloseAndFlush()
-    with Args.MissingArg msg -> eprintfn "%s" msg; 1
+    with MissingArg msg -> eprintfn "%s" msg; 1
         | :? Argu.ArguParseException as e -> eprintfn "%s" e.Message; 1
         | e -> eprintf "Exception %s" e.Message; 1

--- a/propulsion-reactor/Handler.fs
+++ b/propulsion-reactor/Handler.fs
@@ -35,18 +35,18 @@ type Stats(log, statsInterval, stateInterval, ?logExternalStats) =
 
     let mutable ok, skipped, na = 0, 0, 0
 
-    override __.HandleOk res = res |> function
+    override _.HandleOk res = res |> function
         | Outcome.Ok (used, unused) -> ok <- ok + used; skipped <- skipped + unused
         | Outcome.Skipped count -> skipped <- skipped + count
         | Outcome.NotApplicable count -> na <- na + count
 #if kafkaEventSpans
-    override __.HandleExn exn =
+    override _.HandleExn exn =
 #else
-    override __.HandleExn(log, exn) =
+    override _.HandleExn(log, exn) =
 #endif
         log.Information(exn, "Unhandled")
         
-    override __.DumpStats() =
+    override _.DumpStats() =
         if ok <> 0 || skipped <> 0 || na <> 0 then
             log.Information(" used {ok} skipped {skipped} n/a {na}", ok, skipped, na)
             ok <- 0; skipped <- 0; na <- 0

--- a/propulsion-reactor/Infrastructure.fs
+++ b/propulsion-reactor/Infrastructure.fs
@@ -6,11 +6,11 @@ open FSharp.UMX // see https://github.com/fsprojects/FSharp.UMX - % operator and
 open Serilog
 open System
 
-#if (kafka || !blank)
 module EnvVar =
 
     let tryGet varName : string option = Environment.GetEnvironmentVariable varName |> Option.ofObj
 
+#if (kafka || !blank)
 module EventCodec =
 
     /// Uses the supplied codec to decode the supplied event record `x` (iff at LogEventLevel.Debug, detail fails to `log` citing the `stream` and content)

--- a/propulsion-reactor/Ingester.fs
+++ b/propulsion-reactor/Ingester.fs
@@ -20,18 +20,18 @@ type Stats(log, statsInterval, stateInterval) =
 
     let mutable ok, skipped, na = 0, 0, 0
 
-    override __.HandleOk res = res |> function
+    override _.HandleOk res = res |> function
         | Outcome.Ok (used, unused) -> ok <- ok + used; skipped <- skipped + unused
         | Outcome.Skipped count -> skipped <- skipped + count
         | Outcome.NotApplicable count -> na <- na + count
 #if kafkaEventSpans
-    override __.HandleExn exn =
+    override _.HandleExn exn =
 #else
-    override __.HandleExn(log, exn) =
+    override _.HandleExn(log, exn) =
 #endif
         log.Information(exn, "Unhandled")
 
-    override __.DumpStats() =
+    override _.DumpStats() =
         if ok <> 0 || skipped <> 0 || na <> 0 then
             log.Information(" used {ok} skipped {skipped} n/a {na}", ok, skipped, na)
             ok <- 0; skipped <- 0; na <- 0

--- a/propulsion-reactor/Program.fs
+++ b/propulsion-reactor/Program.fs
@@ -259,7 +259,7 @@ module Args =
         member val LeaseContainer =         a.TryGetResult CosmosSourceParameters.LeaseContainer
 
         member val Mode =                   a.GetResult(CosmosSourceParameters.ConnectionMode, Equinox.Cosmos.ConnectionMode.Direct)
-        member val Connection =             a.TryGetResult CosmosSourceParameters.Connection |> Option.defaultWith (fun () -> c.CosmosConnection) |> Discovery.FromConnectionString
+        member val Connection =             a.TryGetResult CosmosSourceParameters.Connection |> Option.defaultWith (fun () -> c.CosmosConnection) |> Equinox.Cosmos.Discovery.FromConnectionString
         member val Database =               a.TryGetResult CosmosSourceParameters.Database   |> Option.defaultWith (fun () -> c.CosmosDatabase)
         member val Container =              a.GetResult CosmosSourceParameters.Container
         member val Timeout =                a.GetResult(CosmosSourceParameters.Timeout, 5.) |> TimeSpan.FromSeconds
@@ -441,7 +441,7 @@ module Args =
 //#endif
     and CosmosArguments(c : Configuration, a : ParseResults<CosmosParameters>) =
         member val Mode =                   a.GetResult(CosmosParameters.ConnectionMode, Equinox.Cosmos.ConnectionMode.Direct)
-        member val Connection =             a.TryGetResult CosmosParameters.Connection |> Option.defaultWith (fun () -> c.CosmosConnection) |> Discovery.FromConnectionString
+        member val Connection =             a.TryGetResult CosmosParameters.Connection |> Option.defaultWith (fun () -> c.CosmosConnection) |> Equinox.Cosmos.Discovery.FromConnectionString
         member val Database =               a.TryGetResult CosmosParameters.Database   |> Option.defaultWith (fun () -> c.CosmosDatabase)
         member val Container =              a.TryGetResult CosmosParameters.Container  |> Option.defaultWith (fun () -> c.CosmosContainer)
         member val Timeout =                a.GetResult(CosmosParameters.Timeout, 5.) |> TimeSpan.FromSeconds

--- a/propulsion-reactor/Program.fs
+++ b/propulsion-reactor/Program.fs
@@ -262,9 +262,9 @@ module Args =
         member val Connection =             a.TryGetResult CosmosSourceParameters.Connection |> Option.defaultWith (fun () -> c.CosmosConnection) |> Discovery.FromConnectionString
         member val Database =               a.TryGetResult CosmosSourceParameters.Database   |> Option.defaultWith (fun () -> c.CosmosDatabase)
         member val Container =              a.GetResult CosmosSourceParameters.Container
-        member val Timeout =                 a.GetResult(CosmosSourceParameters.Timeout, 5.) |> TimeSpan.FromSeconds
-        member val Retries =                 a.GetResult(CosmosSourceParameters.Retries, 1)
-        member val MaxRetryWaitTime =        a.GetResult(CosmosSourceParameters.RetriesWaitTime, 5.) |> TimeSpan.FromSeconds
+        member val Timeout =                a.GetResult(CosmosSourceParameters.Timeout, 5.) |> TimeSpan.FromSeconds
+        member val Retries =                a.GetResult(CosmosSourceParameters.Retries, 1)
+        member val MaxRetryWaitTime =       a.GetResult(CosmosSourceParameters.RetriesWaitTime, 5.) |> TimeSpan.FromSeconds
         member x.MonitoringParams() =
             let Equinox.Cosmos.Discovery.UriAndKey (endpointUri, _) as discovery = x.Connection
             Log.Information("Source CosmosDb {mode} {endpointUri} Database {database} Container {container}",

--- a/propulsion-reactor/TodoSummary.fs
+++ b/propulsion-reactor/TodoSummary.fs
@@ -47,17 +47,17 @@ let render : Fold.State -> Item[] = function
 type Service internal (resolve : ClientId -> Equinox.Stream<Events.Event, Fold.State>) =
 
     /// Returns false if the ingestion was rejected due to being an older version of the data than is presently being held
-    member __.TryIngest(clientId, version, value) : Async<bool> =
-        let stream = resolve clientId
-        stream.Transact(decide (Consume (version, value)))
+    member _.TryIngest(clientId, version, value) : Async<bool> =
+        let decider = resolve clientId
+        decider.Transact(decide (Consume (version, value)))
 
-    member __.Read clientId: Async<Item[]> =
-        let stream = resolve clientId
-        stream.Query render
+    member _.Read clientId: Async<Item[]> =
+        let decider = resolve clientId
+        decider.Query render
 
-let create resolve =
+let create resolveStream =
     let resolve clientId =
-        let stream = resolve (streamName clientId)
+        let stream = resolveStream (streamName clientId)
         Equinox.Stream(Serilog.Log.ForContext<Service>(), stream, maxAttempts=3)
     Service(resolve)
 

--- a/propulsion-summary-consumer/Infrastructure.fs
+++ b/propulsion-summary-consumer/Infrastructure.fs
@@ -4,19 +4,24 @@ open FSharp.UMX // see https://github.com/fsprojects/FSharp.UMX - % operator and
 open Serilog
 open System
 
+module EnvVar =
+
+    let tryGet varName : string option = Environment.GetEnvironmentVariable varName |> Option.ofObj
+
 module EventCodec =
 
     /// Uses the supplied codec to decode the supplied event record `x` (iff at LogEventLevel.Debug, detail fails to `log` citing the `stream` and content)
     let tryDecode (codec : FsCodec.IEventCodec<_, _, _>)streamName (x : FsCodec.ITimelineEvent<byte[]>) =
         match codec.TryDecode x with
         | None ->
-            if Serilog.Log.IsEnabled Serilog.Events.LogEventLevel.Debug then
-                Serilog.Log.ForContext("event", System.Text.Encoding.UTF8.GetString(x.Data), true)
+            if Log.IsEnabled Serilog.Events.LogEventLevel.Debug then
+                Log.ForContext("event", System.Text.Encoding.UTF8.GetString(x.Data), true)
                     .Debug("Codec {type} Could not decode {eventType} in {stream}", codec.GetType().FullName, x.EventType, streamName)
             None
         | x -> x
 
 module Guid =
+
     let inline toStringN (x : Guid) = x.ToString "N"
 
 /// ClientId strongly typed id; represented internally as a Guid; not used for storage so rendering is not significant

--- a/propulsion-summary-consumer/Ingester.fs
+++ b/propulsion-summary-consumer/Ingester.fs
@@ -46,14 +46,14 @@ type Stats(log, statsInterval, stateInterval) =
 
     let mutable ok, na, skipped = 0, 0, 0
 
-    override __.HandleOk res = res |> function
+    override _.HandleOk res = res |> function
         | Outcome.Ok (used, unused) -> ok <- ok + used; skipped <- skipped + unused
         | Outcome.Skipped count -> skipped <- skipped + count
         | Outcome.NotApplicable count -> na <- na + count
-    override __.HandleExn exn =
+    override _.HandleExn exn =
         log.Information(exn, "Unhandled")
 
-    override __.DumpStats() =
+    override _.DumpStats() =
         if ok <> 0 || skipped <> 0 || na <> 0 then
             log.Information(" Used {ok} Skipped {skipped} N/A {na}", ok, skipped, na)
             ok <- 0; skipped <- 0l; na <- 0

--- a/propulsion-summary-consumer/Program.fs
+++ b/propulsion-summary-consumer/Program.fs
@@ -42,6 +42,7 @@ module Args =
                 | Retries _ ->              "specify operation retries. Default: 1."
                 | RetriesWaitTime _ ->      "specify max wait-time for retry when being throttled by Cosmos in seconds. Default: 5."
     type CosmosArguments(c : Configuration, a : ParseResults<CosmosParameters>) =
+        let ts (x : TimeSpan) = x.TotalSeconds
         member val Mode =                   a.GetResult(ConnectionMode, ConnectionMode.Direct)
         member val Connection =             a.TryGetResult Connection |> Option.defaultWith (fun () -> c.CosmosConnection) |> Discovery.FromConnectionString
         member val Database =               a.TryGetResult Database   |> Option.defaultWith (fun () -> c.CosmosDatabase)
@@ -56,7 +57,7 @@ module Args =
             Log.Information("CosmosDb {mode} {endpointUri} Database {database} Container {container}.",
                 x.Mode, endpointUri, x.Database, x.Container)
             Log.Information("CosmosDb timeout {timeout}s; Throttling retries {retries}, max wait {maxRetryWaitTime}s",
-                (let t = x.Timeout in t.TotalSeconds), x.Retries, (let t = x.MaxRetryWaitTime in t.TotalSeconds))
+                ts x.Timeout, x.Retries, ts x.MaxRetryWaitTime)
             let! connection = Connector(x.Timeout, x.Retries, x.MaxRetryWaitTime, Log.Logger, mode=x.Mode).Connect(clientId, discovery)
             return Context(connection, x.Database, x.Container) }
 

--- a/propulsion-summary-consumer/Program.fs
+++ b/propulsion-summary-consumer/Program.fs
@@ -3,74 +3,56 @@
 open Serilog
 open System
 
-module EnvVar =
+exception MissingArg of message : string with override this.Message = this.message
 
-    let tryGet varName : string option = Environment.GetEnvironmentVariable varName |> Option.ofObj
-    let set varName value : unit = Environment.SetEnvironmentVariable(varName, value)
+type Configuration(tryGet) =
 
-// TODO remove this entire comment after reading https://github.com/jet/dotnet-templates#module-configuration
-// - this is where any custom retrieval of settings not arriving via commandline arguments or environment variables should go
-// - values should be propagated by setting environment variables and/or returning them from `initialize`
-module Configuration =
+    let get key =
+        match tryGet key with
+        | Some value -> value
+        | None -> raise (MissingArg (sprintf "Missing Argument/Environment Variable %s" key))
 
-    let private initEnvVar var key loadF =
-        if None = EnvVar.tryGet var then
-            printfn "Setting %s from %A" var key
-            EnvVar.set var (loadF key)
+    member _.CosmosConnection =             get "EQUINOX_COSMOS_CONNECTION"
+    member _.CosmosDatabase =               get "EQUINOX_COSMOS_DATABASE"
+    member _.CosmosContainer =              get "EQUINOX_COSMOS_CONTAINER"
+    member _.Broker =                       get "PROPULSION_KAFKA_BROKER"
+    member _.Topic =                        get "PROPULSION_KAFKA_TOPIC"
+    member _.Group =                        get "PROPULSION_KAFKA_GROUP"
 
-    let initialize () =
-        // e.g. initEnvVar     "EQUINOX_COSMOS_CONTAINER"    "CONSUL KEY" readFromConsul
-        () // TODO add any custom logic preprocessing commandline arguments and/or gathering custom defaults from external sources, etc
-
-// TODO remove this entire comment after reading https://github.com/jet/dotnet-templates#module-args
-// - this module is responsible solely for parsing/validating the commandline arguments (including falling back to values supplied via environment variables)
-// - It's expected that the properties on *Arguments types will summarize the active settings as a side effect of
-// TODO DONT invest time reorganizing or reformatting this - half the value is having a legible summary of all program parameters in a consistent value
-//      you may want to regenerate it at a different time and/or facilitate comparing it with the `module Args` of other programs
-// TODO NEVER hack temporary overrides in here; if you're going to do that, use commandline arguments that fall back to environment variables
-//      or (as a last resort) supply them via code in `module Configuration`
 module Args =
 
-    exception MissingArg of string
-    let private getEnvVarForArgumentOrThrow varName argName =
-        match EnvVar.tryGet varName with
-        | None -> raise (MissingArg(sprintf "Please provide a %s, either as an argument or via the %s environment variable" argName varName))
-        | Some x -> x
-    let private defaultWithEnvVar varName argName = function
-        | None -> getEnvVarForArgumentOrThrow varName argName
-        | Some x -> x
     open Argu
     open Equinox.Cosmos
     type [<NoEquality; NoComparison>] CosmosParameters =
-        | [<AltCommandLine "-m">]       ConnectionMode of ConnectionMode
-        | [<AltCommandLine "-s">]       Connection of string
-        | [<AltCommandLine "-d">]       Database of string
-        | [<AltCommandLine "-c">]       Container of string
-        | [<AltCommandLine "-o">]       Timeout of float
-        | [<AltCommandLine "-r">]       Retries of int
-        | [<AltCommandLine "-rt">]      RetriesWaitTime of float
+        | [<AltCommandLine "-m">]           ConnectionMode of ConnectionMode
+        | [<AltCommandLine "-s">]           Connection of string
+        | [<AltCommandLine "-d">]           Database of string
+        | [<AltCommandLine "-c">]           Container of string
+        | [<AltCommandLine "-o">]           Timeout of float
+        | [<AltCommandLine "-r">]           Retries of int
+        | [<AltCommandLine "-rt">]          RetriesWaitTime of float
         interface IArgParserTemplate with
             member a.Usage =
                 match a with
-                | ConnectionMode _ ->   "override the connection mode. Default: Direct."
-                | Connection _ ->       "specify a connection string for a Cosmos account. (optional if environment variable EQUINOX_COSMOS_CONNECTION specified)"
-                | Database _ ->         "specify a database name for Cosmos store. (optional if environment variable EQUINOX_COSMOS_DATABASE specified)"
-                | Container _ ->        "specify a container name for Cosmos store. (optional if environment variable EQUINOX_COSMOS_CONTAINER specified)"
-                | Timeout _ ->          "specify operation timeout in seconds. Default: 5."
-                | Retries _ ->          "specify operation retries. Default: 1."
-                | RetriesWaitTime _ ->  "specify max wait-time for retry when being throttled by Cosmos in seconds. Default: 5."
-    type CosmosArguments(a : ParseResults<CosmosParameters>) =
-        member __.Mode =                a.GetResult(ConnectionMode, ConnectionMode.Direct)
-        member __.Connection =          a.TryGetResult Connection |> defaultWithEnvVar "EQUINOX_COSMOS_CONNECTION" "Connection"
-        member __.Database =            a.TryGetResult Database   |> defaultWithEnvVar "EQUINOX_COSMOS_DATABASE"   "Database"
-        member __.Container =           a.TryGetResult Container  |> defaultWithEnvVar "EQUINOX_COSMOS_CONTAINER"  "Container"
+                | ConnectionMode _ ->       "override the connection mode. Default: Direct."
+                | Connection _ ->           "specify a connection string for a Cosmos account. (optional if environment variable EQUINOX_COSMOS_CONNECTION specified)"
+                | Database _ ->             "specify a database name for Cosmos store. (optional if environment variable EQUINOX_COSMOS_DATABASE specified)"
+                | Container _ ->            "specify a container name for Cosmos store. (optional if environment variable EQUINOX_COSMOS_CONTAINER specified)"
+                | Timeout _ ->              "specify operation timeout in seconds. Default: 5."
+                | Retries _ ->              "specify operation retries. Default: 1."
+                | RetriesWaitTime _ ->      "specify max wait-time for retry when being throttled by Cosmos in seconds. Default: 5."
+    type CosmosArguments(c : Configuration, a : ParseResults<CosmosParameters>) =
+        member val Mode =                   a.GetResult(ConnectionMode, ConnectionMode.Direct)
+        member val Connection =             a.TryGetResult Connection |> Option.defaultWith (fun () -> c.CosmosConnection) |> Discovery.FromConnectionString
+        member val Database =               a.TryGetResult Database   |> Option.defaultWith (fun () -> c.CosmosDatabase)
+        member val Container =              a.TryGetResult Container  |> Option.defaultWith (fun () -> c.CosmosContainer)
 
-        member __.Timeout =             a.GetResult(Timeout, 5.) |> TimeSpan.FromSeconds
-        member __.Retries =             a.GetResult(Retries, 1)
-        member __.MaxRetryWaitTime =    a.GetResult(RetriesWaitTime, 5.) |> TimeSpan.FromSeconds
+        member val Timeout =                a.GetResult(Timeout, 5.) |> TimeSpan.FromSeconds
+        member val Retries =                a.GetResult(Retries, 1)
+        member val MaxRetryWaitTime =       a.GetResult(RetriesWaitTime, 5.) |> TimeSpan.FromSeconds
 
         member x.Connect(clientId) = async {
-            let (Discovery.UriAndKey (endpointUri, _) as discovery) = Discovery.FromConnectionString x.Connection
+            let Discovery.UriAndKey (endpointUri, _) as discovery = x.Connection
             Log.Information("CosmosDb {mode} {endpointUri} Database {database} Container {container}.",
                 x.Mode, endpointUri, x.Database, x.Container)
             Log.Information("CosmosDb timeout {timeout}s; Throttling retries {retries}, max wait {maxRetryWaitTime}s",
@@ -102,25 +84,25 @@ module Args =
                 | Verbose _ ->              "request verbose logging."
                 | Cosmos _ ->               "specify CosmosDb input parameters"
 
-    type Arguments(a : ParseResults<Parameters>) =
-        member val Cosmos =                 CosmosArguments(a.GetResult Cosmos)
-        member __.Broker =                  a.TryGetResult Broker |> defaultWithEnvVar "PROPULSION_KAFKA_BROKER" "Broker"
-        member __.Topic =                   a.TryGetResult Topic  |> defaultWithEnvVar "PROPULSION_KAFKA_TOPIC"  "Topic"
-        member __.Group =                   a.TryGetResult Group  |> defaultWithEnvVar "PROPULSION_KAFKA_GROUP"  "Group"
-        member __.MaxInFlightBytes =        a.GetResult(MaxInflightMb, 10.) * 1024. * 1024. |> int64
-        member __.LagFrequency =            a.TryGetResult LagFreqM |> Option.map TimeSpan.FromMinutes
+    type Arguments(c : Configuration, a : ParseResults<Parameters>) =
+        member val Cosmos =                 CosmosArguments(c, a.GetResult Cosmos)
+        member val Broker =                 a.TryGetResult Broker |> Option.defaultWith (fun () -> c.Broker)
+        member val Topic =                  a.TryGetResult Topic  |> Option.defaultWith (fun () -> c.Topic)
+        member val Group =                  a.TryGetResult Group  |> Option.defaultWith (fun () -> c.Group)
+        member val MaxInFlightBytes =       a.GetResult(MaxInflightMb, 10.) * 1024. * 1024. |> int64
+        member val LagFrequency =           a.TryGetResult LagFreqM |> Option.map TimeSpan.FromMinutes
 
-        member __.MaxConcurrentStreams =    a.GetResult(MaxWriters, 8)
+        member val MaxConcurrentStreams =   a.GetResult(MaxWriters, 8)
 
-        member __.Verbose =                 a.Contains Verbose
-        member __.StatsInterval =           TimeSpan.FromMinutes 1.
-        member __.StateInterval =           TimeSpan.FromMinutes 5.
+        member val Verbose =                a.Contains Verbose
+        member val StatsInterval =          TimeSpan.FromMinutes 1.
+        member val StateInterval =          TimeSpan.FromMinutes 5.
 
     /// Parse the commandline; can throw exceptions in response to missing arguments and/or `-h`/`--help` args
-    let parse argv =
+    let parse tryGetConfigValue argv : Arguments =
         let programName = Reflection.Assembly.GetEntryAssembly().GetName().Name
         let parser = ArgumentParser.Create<Parameters>(programName=programName)
-        parser.ParseCommandLine argv |> Arguments
+        Arguments(Configuration tryGetConfigValue, parser.ParseCommandLine argv)
 
 let [<Literal>] AppName = "ConsumerTemplate"
 
@@ -146,13 +128,12 @@ let run args = async {
 
 [<EntryPoint>]
 let main argv =
-    try let args = Args.parse argv
+    try let args = Args.parse EnvVar.tryGet argv
         try Log.Logger <- LoggerConfiguration().Configure(verbose=args.Verbose).CreateLogger()
-            try Configuration.initialize ()
-                run args |> Async.RunSynchronously
+            try run args |> Async.RunSynchronously
                 0
-            with e when not (e :? Args.MissingArg) -> Log.Fatal(e, "Exiting"); 2
+            with e when not (e :? MissingArg) -> Log.Fatal(e, "Exiting"); 2
         finally Log.CloseAndFlush()
-    with Args.MissingArg msg -> eprintfn "%s" msg; 1
+    with MissingArg msg -> eprintfn "%s" msg; 1
         | :? Argu.ArguParseException as e -> eprintfn "%s" e.Message; 1
         | e -> eprintf "Exception %s" e.Message; 1

--- a/propulsion-summary-consumer/TodoSummary.fs
+++ b/propulsion-summary-consumer/TodoSummary.fs
@@ -46,17 +46,17 @@ let render : Fold.State -> Item[] = function
 /// Defines the operations that the Read side of a Controller and/or the Ingester can perform on the 'aggregate'
 type Service internal (resolve : ClientId -> Equinox.Stream<Events.Event, Fold.State>) =
 
-    member __.TryIngest(clientId, version, value) : Async<bool> =
-        let stream = resolve clientId
-        stream.Transact(decide (Consume (version, value)))
+    member _.TryIngest(clientId, version, value) : Async<bool> =
+        let decider = resolve clientId
+        decider.Transact(decide (Consume (version, value)))
 
-    member __.Read clientId: Async<Item[]> =
-        let stream = resolve clientId
-        stream.Query render
+    member _.Read clientId: Async<Item[]> =
+        let decider = resolve clientId
+        decider.Query render
 
-let create resolve =
+let create resolveStream =
     let resolve clientId =
-        let stream = resolve (streamName clientId)
+        let stream = resolveStream (streamName clientId)
         Equinox.Stream(Serilog.Log.ForContext<Service>(), stream, maxAttempts=3)
     Service(resolve)
 

--- a/propulsion-sync/Infrastructure.fs
+++ b/propulsion-sync/Infrastructure.fs
@@ -2,12 +2,16 @@ namespace SyncTemplate
 
 open Serilog
 open Serilog.Events
-open System.Runtime.CompilerServices
+open System
 
-[<Extension>]
+module EnvVar =
+
+    let tryGet varName : string option = Environment.GetEnvironmentVariable varName |> Option.ofObj
+
+[<System.Runtime.CompilerServices.Extension>]
 type LoggerConfigurationExtensions() =
 
-    [<Extension>]
+    [<System.Runtime.CompilerServices.Extension>]
     static member inline ExcludeChangeFeedProcessorV2InternalDiagnostics(c : LoggerConfiguration) =
         let isCfp429a = Filters.Matching.FromSource("Microsoft.Azure.Documents.ChangeFeedProcessor.LeaseManagement.DocumentServiceLeaseUpdater").Invoke
         let isCfp429b = Filters.Matching.FromSource("Microsoft.Azure.Documents.ChangeFeedProcessor.PartitionManagement.LeaseRenewer").Invoke
@@ -16,10 +20,10 @@ type LoggerConfigurationExtensions() =
         let isCfp x = isCfp429a x || isCfp429b x || isCfp429c x || isCfp429d x
         c.Filter.ByExcluding(fun x -> isCfp x)
 
-    [<Extension>]
+    [<System.Runtime.CompilerServices.Extension>]
     static member inline ConfigureChangeFeedProcessorLogging(c : LoggerConfiguration, verbose : bool) =
         // LibLog writes to the global logger, so we need to control the emission
-        let cfpl = if verbose then Serilog.Events.LogEventLevel.Debug else Serilog.Events.LogEventLevel.Warning
+        let cfpl = if verbose then LogEventLevel.Debug else LogEventLevel.Warning
         c.MinimumLevel.Override("Microsoft.Azure.Documents.ChangeFeedProcessor", cfpl)
         |> fun c -> if verbose then c else c.ExcludeChangeFeedProcessorV2InternalDiagnostics()
 

--- a/propulsion-sync/Program.fs
+++ b/propulsion-sync/Program.fs
@@ -350,7 +350,7 @@ module Args =
 #if kafka
         member val KafkaSink =
             match a.TryGetSubCommand() with
-            | Some (Kafka kafka) -> Some (KafkaSinkArguments kafka)
+            | Some (Kafka kafka) -> Some (KafkaSinkArguments (c, kafka))
             | _ -> None
 #endif
     and [<NoEquality; NoComparison>] EsSinkParameters =

--- a/propulsion-sync/Program.fs
+++ b/propulsion-sync/Program.fs
@@ -201,7 +201,7 @@ module Args =
             Log.Information("Source CosmosDb timeout {timeout}s; Throttling retries {retries}, max wait {maxRetryWaitTime}s",
                 (let t = x.Timeout in t.TotalSeconds), x.Retries, (let t = x.MaxRetryWaitTime in t.TotalSeconds))
             let c = Equinox.Cosmos.Connector(x.Timeout, x.Retries, x.MaxRetryWaitTime, Log.Logger, mode=x.Mode)
-            discovery, { database = x.Database; container = x.Container }, c
+            c, discovery, { database = x.Database; container = x.Container }
 
         member val Sink =
             match a.TryGetSubCommand() with
@@ -546,7 +546,7 @@ let build (args : Args.Arguments, log, storeLog : ILogger) =
             None, sink, args.CategoryFilterFunction()
     match args.SourceParams() with
     | Choice1Of2 (srcC, (auxDiscovery, aux, leaseId, startFromTail, maxDocuments, lagFrequency)) ->
-        let discovery, source, connector = srcC.MonitoringParams()
+        let connector, discovery, source = srcC.MonitoringParams()
 #if marveleqx
         let createObserver () = CosmosSource.CreateObserver(log, sink.StartIngester, Seq.collect (transformV0 streamFilter))
 #else

--- a/propulsion-sync/Program.fs
+++ b/propulsion-sync/Program.fs
@@ -10,42 +10,30 @@ open Propulsion.Kafka
 open Serilog
 open System
 
-module EnvVar =
+exception MissingArg of message : string with override this.Message = this.message
 
-    let tryGet varName : string option = Environment.GetEnvironmentVariable varName |> Option.ofObj
-    let set varName value : unit = Environment.SetEnvironmentVariable(varName, value)
+type Configuration(tryGet) =
 
-// TODO remove this entire comment after reading https://github.com/jet/dotnet-templates#module-configuration
-// - this is where any custom retrieval of settings not arriving via commandline arguments or environment variables should go
-// - values should be propagated by setting environment variables and/or returning them from `initialize`
-module Configuration =
+    let get key =
+        match tryGet key with
+        | Some value -> value
+        | None -> raise (MissingArg (sprintf "Missing Argument/Environment Variable %s" key))
+    let isTrue varName = tryGet varName |> Option.exists (fun s -> String.Equals(s, bool.TrueString, StringComparison.OrdinalIgnoreCase))
 
-    let private initEnvVar var key loadF =
-        if None = EnvVar.tryGet var then
-            printfn "Setting %s from %A" var key
-            EnvVar.set var (loadF key)
+    member _.CosmosConnection =             get "EQUINOX_COSMOS_CONNECTION"
+    member _.CosmosDatabase =               get "EQUINOX_COSMOS_DATABASE"
+    member _.CosmosContainer =              get "EQUINOX_COSMOS_CONTAINER"
+    member _.EventStoreHost =               get "EQUINOX_ES_HOST"
+    member _.EventStoreTcp =                isTrue "EQUINOX_ES_TCP"
+    member _.EventStorePort =               tryGet "EQUINOX_ES_PORT" |> Option.map int
+    member _.EventStoreUsername =           get "EQUINOX_ES_USERNAME"
+    member _.EventStorePassword =           get "EQUINOX_ES_PASSWORD"
+#if kafka
+    member _.Broker =                       get "PROPULSION_KAFKA_BROKER"
+    member _.Topic =                        get "PROPULSION_KAFKA_TOPIC"
+#endif
 
-    let initialize () =
-        // e.g. initEnvVar     "EQUINOX_COSMOS_CONTAINER"    "CONSUL KEY" readFromConsul
-        () // TODO add any custom logic preprocessing commandline arguments and/or gathering custom defaults from external sources, etc
-
-// TODO remove this entire comment after reading https://github.com/jet/dotnet-templates#module-args
-// - this module is responsible solely for parsing/validating the commandline arguments (including falling back to values supplied via environment variables)
-// - It's expected that the properties on *Arguments types will summarize the active settings as a side effect of
-// TODO DONT invest time reorganizing or reformatting this - half the value is having a legible summary of all program parameters in a consistent value
-//      you may want to regenerate it at a different time and/or facilitate comparing it with the `module Args` of other programs
-// TODO NEVER hack temporary overrides in here; if you're going to do that, use commandline arguments that fall back to environment variables
-//      or (as a last resort) supply them via code in `module Configuration`
 module Args =
-
-    exception MissingArg of string
-    let private getEnvVarForArgumentOrThrow varName argName =
-        match EnvVar.tryGet varName with
-        | None -> raise (MissingArg(sprintf "Please provide a %s, either as an argument or via the %s environment variable" argName varName))
-        | Some x -> x
-    let private defaultWithEnvVar varName argName = function
-        | None -> getEnvVarForArgumentOrThrow varName argName
-        | Some x -> x
 
     open Argu
     [<NoEquality; NoComparison>]
@@ -82,25 +70,25 @@ module Args =
 
                 | SrcCosmos _ ->            "Cosmos input parameters."
                 | SrcEs _ ->                "EventStore input parameters."
-    and Arguments(a : ParseResults<Parameters>) =
-        member __.ConsumerGroupName =       a.GetResult ConsumerGroupName
-        member __.MaxReadAhead =            a.GetResult(MaxReadAhead, 2048)
-        member __.MaxWriters =              a.GetResult(MaxWriters, 512)
-        member __.MaxConnections =          a.GetResult(MaxConnections, 1)
-        member __.MaybeSeqEndpoint =        if a.Contains LocalSeq then Some "http://localhost:5341" else None
-        member __.MaxSubmit =               a.GetResult(MaxSubmit, 8)
+    and Arguments(c : Configuration, a : ParseResults<Parameters>) =
+        member val ConsumerGroupName =      a.GetResult ConsumerGroupName
+        member val MaxReadAhead =           a.GetResult(MaxReadAhead, 2048)
+        member val MaxWriters =             a.GetResult(MaxWriters, 512)
+        member val MaxConnections =         a.GetResult(MaxConnections, 1)
+        member val MaybeSeqEndpoint =       if a.Contains LocalSeq then Some "http://localhost:5341" else None
+        member val MaxSubmit =              a.GetResult(MaxSubmit, 8)
 
-        member __.Verbose =                 a.Contains Parameters.Verbose
-        member __.CfpVerbose =              a.Contains CfpVerbose
+        member val Verbose =                a.Contains Parameters.Verbose
+        member val CfpVerbose =             a.Contains CfpVerbose
         member val Source : Choice<CosmosSourceArguments, EsSourceArguments> =
             match a.TryGetSubCommand() with
-            | Some (SrcCosmos cosmos) -> Choice1Of2 (CosmosSourceArguments cosmos)
-            | Some (SrcEs es) -> Choice2Of2 (EsSourceArguments es)
+            | Some (SrcCosmos cosmos) -> Choice1Of2 (CosmosSourceArguments (c, cosmos))
+            | Some (SrcEs es) -> Choice2Of2 (EsSourceArguments (c, es))
             | _ -> raise (MissingArg "Must specify one of cosmos or es for Src")
 
-        member __.StatsInterval =           TimeSpan.FromMinutes 1.
-        member __.StateInterval =           TimeSpan.FromMinutes 5.
-        member __.CategoryFilterFunction(?excludeLong, ?longOnly): string -> bool =
+        member val StatsInterval =          TimeSpan.FromMinutes 1.
+        member val StateInterval =          TimeSpan.FromMinutes 5.
+        member _.CategoryFilterFunction(?excludeLong, ?longOnly): string -> bool =
             let isLong (streamName : string) =
                 streamName.StartsWith "Inventory-" // Too long
                 || streamName.StartsWith "InventoryCount-" // No Longer used
@@ -126,8 +114,8 @@ module Args =
             | [], good ->   let white = Set.ofList good in Log.Warning("Only copying categories: {cats}", white); fun x -> white.Contains x
             | _, _ -> raise (MissingArg "BlackList and Whitelist are mutually exclusive; inclusions and exclusions cannot be mixed")
 
-        member __.Sink : Choice<CosmosSinkArguments, EsSinkArguments> =
-            match __.Source with
+        member x.Sink : Choice<CosmosSinkArguments, EsSinkArguments> =
+            match x.Source with
             | Choice1Of2 cosmos -> cosmos.Sink
             | Choice2Of2 es -> Choice1Of2 es.Sink
         member x.SourceParams() : Choice<_, _*ReaderSpec> =
@@ -137,13 +125,13 @@ module Args =
                     match srcC.Sink with
                     | Choice1Of2 dstC ->
                         match srcC.LeaseContainer, dstC.LeaseContainer with
-                        | None, None ->     srcC.Discovery, { database = srcC.Database; container = srcC.Container + "-aux" }
-                        | Some sc, None ->  srcC.Discovery, { database = srcC.Database; container = sc }
-                        | None, Some dc ->  dstC.Discovery, { database = dstC.Database; container = dc }
+                        | None, None ->     srcC.Connection, { database = srcC.Database; container = srcC.Container + "-aux" }
+                        | Some sc, None ->  srcC.Connection, { database = srcC.Database; container = sc }
+                        | None, Some dc ->  dstC.Connection, { database = dstC.Database; container = dc }
                         | Some _, Some _ -> raise (MissingArg "LeaseContainerSource and LeaseContainerDestination are mutually exclusive - can only store in one database")
                     | Choice2Of2 _dstE ->
                         let lc = match srcC.LeaseContainer with Some sc -> sc | None -> srcC.Container + "-aux"
-                        srcC.Discovery, { database = srcC.Database; container = lc }
+                        srcC.Connection, { database = srcC.Database; container = lc }
                 Log.Information("Syncing... {dop} writers, max {maxReadAhead} batches read ahead", x.MaxWriters, x.MaxReadAhead)
                 Log.Information("Monitoring Group {leaseId} in Database {db} Container {container} with maximum document count limited to {maxDocuments}",
                     x.ConsumerGroupName, db.database, db.container, srcC.MaxDocuments)
@@ -193,22 +181,21 @@ module Args =
 
                 | DstEs _ ->                "EventStore Sink parameters."
                 | DstCosmos _ ->            "CosmosDb Sink parameters."
-    and CosmosSourceArguments(a : ParseResults<CosmosSourceParameters>) =
-        member __.FromTail =                a.Contains CosmosSourceParameters.FromTail
-        member __.MaxDocuments =            a.TryGetResult MaxDocuments
-        member __.LagFrequency =            a.TryGetResult LagFreqM |> Option.map TimeSpan.FromMinutes
-        member __.LeaseContainer =          a.TryGetResult CosmosSourceParameters.LeaseContainer
+    and CosmosSourceArguments(c : Configuration, a : ParseResults<CosmosSourceParameters>) =
+        member val FromTail =               a.Contains CosmosSourceParameters.FromTail
+        member val MaxDocuments =           a.TryGetResult MaxDocuments
+        member val LagFrequency =           a.TryGetResult LagFreqM |> Option.map TimeSpan.FromMinutes
+        member val LeaseContainer =         a.TryGetResult CosmosSourceParameters.LeaseContainer
 
-        member __.Mode =                    a.GetResult(CosmosSourceParameters.ConnectionMode, Equinox.Cosmos.ConnectionMode.Direct)
-        member __.Discovery =               Discovery.FromConnectionString __.Connection
-        member __.Connection =              a.TryGetResult CosmosSourceParameters.Connection |> defaultWithEnvVar "EQUINOX_COSMOS_CONNECTION" "Connection"
-        member __.Database =                a.TryGetResult CosmosSourceParameters.Database   |> defaultWithEnvVar "EQUINOX_COSMOS_DATABASE"   "Database"
-        member __.Container =               a.GetResult CosmosSourceParameters.Container
-        member __.Timeout =                 a.GetResult(CosmosSourceParameters.Timeout, 5.) |> TimeSpan.FromSeconds
-        member __.Retries =                 a.GetResult(CosmosSourceParameters.Retries, 1)
-        member __.MaxRetryWaitTime =        a.GetResult(CosmosSourceParameters.RetriesWaitTime, 5.) |> TimeSpan.FromSeconds
+        member val Mode =                   a.GetResult(CosmosSourceParameters.ConnectionMode, Equinox.Cosmos.ConnectionMode.Direct)
+        member val Connection =             a.TryGetResult CosmosSourceParameters.Connection |> Option.defaultWith (fun () -> c.CosmosConnection) |> Discovery.FromConnectionString
+        member val Database =               a.TryGetResult CosmosSourceParameters.Database   |> Option.defaultWith (fun () -> c.CosmosDatabase)
+        member val Container =              a.GetResult CosmosSourceParameters.Container
+        member val Timeout =                a.GetResult(CosmosSourceParameters.Timeout, 5.) |> TimeSpan.FromSeconds
+        member val Retries =                a.GetResult(CosmosSourceParameters.Retries, 1)
+        member val MaxRetryWaitTime =       a.GetResult(CosmosSourceParameters.RetriesWaitTime, 5.) |> TimeSpan.FromSeconds
         member x.MonitoringParams() =
-            let (Discovery.UriAndKey (endpointUri, _)) as discovery = x.Discovery
+            let Discovery.UriAndKey (endpointUri, _) as discovery = x.Connection
             Log.Information("Source CosmosDb {mode} {endpointUri} Database {database} Container {container}",
                 x.Mode, endpointUri, x.Database, x.Container)
             Log.Information("Source CosmosDb timeout {timeout}s; Throttling retries {retries}, max wait {maxRetryWaitTime}s",
@@ -218,8 +205,8 @@ module Args =
 
         member val Sink =
             match a.TryGetSubCommand() with
-            | Some (DstCosmos cosmos) -> Choice1Of2 (CosmosSinkArguments cosmos)
-            | Some (DstEs es) -> Choice2Of2 (EsSinkArguments es)
+            | Some (DstCosmos cosmos) -> Choice1Of2 (CosmosSinkArguments (c, cosmos))
+            | Some (DstEs es) -> Choice2Of2 (EsSinkArguments (c, es))
             | _ -> raise (MissingArg "Must specify one of cosmos or es for Sink")
     and [<NoEquality; NoComparison>] EsSourceParameters =
         | [<AltCommandLine "-Z"; Unique>]   FromTail
@@ -270,14 +257,14 @@ module Args =
 
                 | Cosmos _ ->               "CosmosDb Sink parameters."
                 | Es _ ->                   "EventStore Sink parameters."
-    and EsSourceArguments(a : ParseResults<EsSourceParameters>) =
-        member __.Gorge =                   a.TryGetResult Gorge
-        member __.StreamReaders =           a.GetResult(StreamReaders, 1)
-        member __.TailInterval =            a.GetResult(Tail, 1.) |> TimeSpan.FromSeconds
-        member __.ForceRestart =            a.Contains ForceRestart
-        member __.StartingBatchSize =       a.GetResult(BatchSize, 4096)
-        member __.MinBatchSize =            a.GetResult(MinBatchSize, 512)
-        member __.StartPos =
+    and EsSourceArguments(c : Configuration, a : ParseResults<EsSourceParameters>) =
+        member val Gorge =                  a.TryGetResult Gorge
+        member val StreamReaders =          a.GetResult(StreamReaders, 1)
+        member val TailInterval =           a.GetResult(Tail, 1.) |> TimeSpan.FromSeconds
+        member val ForceRestart =           a.Contains ForceRestart
+        member val StartingBatchSize =      a.GetResult(BatchSize, 4096)
+        member val MinBatchSize =           a.GetResult(MinBatchSize, 512)
+        member val StartPos =
             match a.TryGetResult Position, a.TryGetResult Chunk, a.TryGetResult Percent, a.Contains FromTail with
             | Some p, _, _, _ ->            Absolute p
             | _, Some c, _, _ ->            StartPos.Chunk c
@@ -285,22 +272,20 @@ module Args =
             | None, None, None, true ->     StartPos.TailOrCheckpoint
             | None, None, None, _ ->        StartPos.StartOrCheckpoint
 
-        member __.Discovery =
-            match __.Tcp, __.Port with
-            | false, None ->   Discovery.GossipDns            __.Host
-            | false, Some p -> Discovery.GossipDnsCustomPort (__.Host, p)
-            | true, None ->    Discovery.Uri                 (UriBuilder("tcp", __.Host, 1113).Uri)
-            | true, Some p ->  Discovery.Uri                 (UriBuilder("tcp", __.Host, p).Uri)
-        member __.Tcp =
-            a.Contains EsSourceParameters.Tcp
-            || EnvVar.tryGet "EQUINOX_ES_TCP" |> Option.exists (fun s -> String.Equals(s, bool.TrueString, StringComparison.OrdinalIgnoreCase))
-        member __.Port =                    match a.TryGetResult EsSourceParameters.Port with Some x -> Some x | None -> EnvVar.tryGet "EQUINOX_ES_PORT" |> Option.map int
-        member __.Host =                    a.TryGetResult EsSourceParameters.Host     |> defaultWithEnvVar "EQUINOX_ES_HOST"     "Host"
-        member __.User =                    a.TryGetResult EsSourceParameters.Username |> defaultWithEnvVar "EQUINOX_ES_USERNAME" "Username"
-        member __.Password =                a.TryGetResult EsSourceParameters.Password |> defaultWithEnvVar "EQUINOX_ES_PASSWORD" "Password"
-        member __.Retries =                 a.GetResult(EsSourceParameters.Retries, 3)
-        member __.Timeout =                 a.GetResult(EsSourceParameters.Timeout, 20.) |> TimeSpan.FromSeconds
-        member __.Heartbeat =               a.GetResult(EsSourceParameters.HeartbeatTimeout, 1.5) |> TimeSpan.FromSeconds
+        member x.Discovery =
+            match x.Tcp, x.Port with
+            | false, None ->   Discovery.GossipDns            x.Host
+            | false, Some p -> Discovery.GossipDnsCustomPort (x.Host, p)
+            | true, None ->    Discovery.Uri                 (UriBuilder("tcp", x.Host, 1113).Uri)
+            | true, Some p ->  Discovery.Uri                 (UriBuilder("tcp", x.Host, p).Uri)
+        member val Tcp =                    a.Contains EsSourceParameters.Tcp || c.EventStoreTcp
+        member val Port =                   match a.TryGetResult EsSourceParameters.Port with Some x -> Some x | None -> c.EventStorePort
+        member val Host =                   a.TryGetResult EsSourceParameters.Host     |> Option.defaultWith (fun () -> c.EventStoreHost)
+        member val User =                   a.TryGetResult EsSourceParameters.Username |> Option.defaultWith (fun () -> c.EventStoreUsername)
+        member val Password =               a.TryGetResult EsSourceParameters.Password |> Option.defaultWith (fun () -> c.EventStorePassword)
+        member val Retries =                a.GetResult(EsSourceParameters.Retries, 3)
+        member val Timeout =                a.GetResult(EsSourceParameters.Timeout, 20.) |> TimeSpan.FromSeconds
+        member val Heartbeat =              a.GetResult(EsSourceParameters.HeartbeatTimeout, 1.5) |> TimeSpan.FromSeconds
         member x.Connect(log: ILogger, storeLog: ILogger, appName, connectionStrategy) =
             let discovery = x.Discovery
             let s (x : TimeSpan) = x.TotalSeconds
@@ -311,11 +296,11 @@ module Args =
             let tags=["M", Environment.MachineName; "I", Guid.NewGuid() |> string]
             Connector(x.User, x.Password, x.Timeout, x.Retries, log=log, heartbeatTimeout=x.Heartbeat, tags=tags)
                 .Establish(appName, discovery, connectionStrategy)
-        member __.CheckpointInterval =  TimeSpan.FromHours 1.
+        member _.CheckpointInterval =   TimeSpan.FromHours 1.
 
         member val Sink =
             match a.TryGetSubCommand() with
-            | Some (Cosmos cosmos) -> CosmosSinkArguments cosmos
+            | Some (Cosmos cosmos) -> CosmosSinkArguments (c, cosmos)
             | _ -> raise (MissingArg "Must specify cosmos for Sink if source is `es`")
     and [<NoEquality; NoComparison>] CosmosSinkParameters =
         | [<AltCommandLine "-m">]           ConnectionMode of Equinox.Cosmos.ConnectionMode
@@ -342,21 +327,20 @@ module Args =
 #if kafka
                 | Kafka _ ->                "specify Kafka target for non-Synced categories. Default: None."
 #endif
-    and CosmosSinkArguments(a : ParseResults<CosmosSinkParameters>) =
-        member __.Mode =                    a.GetResult(ConnectionMode, Equinox.Cosmos.ConnectionMode.Direct)
-        member __.Discovery =               Discovery.FromConnectionString __.Connection
-        member __.Connection =              a.TryGetResult Connection |> defaultWithEnvVar "EQUINOX_COSMOS_CONNECTION" "Connection"
-        member __.Database =                a.TryGetResult Database   |> defaultWithEnvVar "EQUINOX_COSMOS_DATABASE"   "Database"
-        member __.Container =               a.TryGetResult Container  |> defaultWithEnvVar "EQUINOX_COSMOS_CONTAINER"  "Container"
-        member __.LeaseContainer =          a.TryGetResult LeaseContainer
-        member __.Timeout =                 a.GetResult(CosmosSinkParameters.Timeout, 5.) |> TimeSpan.FromSeconds
-        member __.Retries =                 a.GetResult(CosmosSinkParameters.Retries, 0)
-        member __.MaxRetryWaitTime =        a.GetResult(RetriesWaitTime, 5.) |> TimeSpan.FromSeconds
+    and CosmosSinkArguments(c : Configuration, a : ParseResults<CosmosSinkParameters>) =
+        member val Mode =                   a.GetResult(ConnectionMode, Equinox.Cosmos.ConnectionMode.Direct)
+        member val Connection =             a.TryGetResult Connection |> Option.defaultWith (fun () -> c.CosmosConnection) |> Discovery.FromConnectionString
+        member val Database =               a.TryGetResult Database   |> Option.defaultWith (fun () -> c.CosmosDatabase)
+        member val Container =              a.TryGetResult Container  |> Option.defaultWith (fun () -> c.CosmosContainer)
+        member val LeaseContainer =         a.TryGetResult LeaseContainer
+        member val Timeout =                a.GetResult(CosmosSinkParameters.Timeout, 5.) |> TimeSpan.FromSeconds
+        member val Retries =                a.GetResult(CosmosSinkParameters.Retries, 0)
+        member val MaxRetryWaitTime =       a.GetResult(RetriesWaitTime, 5.) |> TimeSpan.FromSeconds
         /// Connect with the provided parameters and/or environment variables
         member x.Connect
             /// Connection/Client identifier for logging purposes
             appName connIndex : Async<Equinox.Cosmos.Connection> =
-            let (Discovery.UriAndKey (endpointUri, _masterKey)) as discovery = x.Discovery
+            let Discovery.UriAndKey (endpointUri, _masterKey) as discovery = x.Connection
             Log.Information("Destination CosmosDb {mode} {endpointUri} Database {database} Container {container}",
                 x.Mode, endpointUri, x.Database, x.Container)
             Log.Information("Destination CosmosDb timeout {timeout}s; Throttling retries {retries}, max wait {maxRetryWaitTime}s",
@@ -390,23 +374,21 @@ module Args =
                 | Timeout _ ->              "specify operation timeout in seconds. Default: 20."
                 | Retries _ ->              "specify operation retries. Default: 3."
                 | HeartbeatTimeout _ ->     "specify heartbeat timeout in seconds. Default: 1.5."
-    and EsSinkArguments(a : ParseResults<EsSinkParameters>) =
-        member __.Discovery =
-            match __.Tcp, __.Port with
-            | false, None ->   Discovery.GossipDns            __.Host
-            | false, Some p -> Discovery.GossipDnsCustomPort (__.Host, p)
-            | true, None ->    Discovery.Uri                 (UriBuilder("tcp", __.Host, 1113).Uri)
-            | true, Some p ->  Discovery.Uri                 (UriBuilder("tcp", __.Host, p).Uri)
-        member __.Tcp =
-            a.Contains EsSinkParameters.Tcp
-            || EnvVar.tryGet "EQUINOX_ES_TCP" |> Option.exists (fun s -> String.Equals(s, bool.TrueString, StringComparison.OrdinalIgnoreCase))
-        member __.Port =                    match a.TryGetResult Port with Some x -> Some x | None -> EnvVar.tryGet "EQUINOX_ES_PORT" |> Option.map int
-        member __.Host =                    a.TryGetResult Host     |> defaultWithEnvVar "EQUINOX_ES_HOST"     "Host"
-        member __.User =                    a.TryGetResult Username |> defaultWithEnvVar "EQUINOX_ES_USERNAME" "Username"
-        member __.Password =                a.TryGetResult Password |> defaultWithEnvVar "EQUINOX_ES_PASSWORD" "Password"
-        member __.Retries =                 a.GetResult(Retries, 3)
-        member __.Timeout =                 a.GetResult(Timeout, 20.) |> TimeSpan.FromSeconds
-        member __.Heartbeat =               a.GetResult(HeartbeatTimeout, 1.5) |> TimeSpan.FromSeconds
+    and EsSinkArguments(c : Configuration, a : ParseResults<EsSinkParameters>) =
+        member x.Discovery =
+            match x.Tcp, x.Port with
+            | false, None ->   Discovery.GossipDns            x.Host
+            | false, Some p -> Discovery.GossipDnsCustomPort (x.Host, p)
+            | true, None ->    Discovery.Uri                 (UriBuilder("tcp", x.Host, 1113).Uri)
+            | true, Some p ->  Discovery.Uri                 (UriBuilder("tcp", x.Host, p).Uri)
+        member val Tcp =                    a.Contains EsSinkParameters.Tcp || c.EventStoreTcp
+        member val Port =                   match a.TryGetResult Port with Some x -> Some x | None -> c.EventStorePort
+        member val Host =                   a.TryGetResult Host     |> Option.defaultWith (fun () -> c.EventStoreHost)
+        member val User =                   a.TryGetResult Username |> Option.defaultWith (fun () -> c.EventStoreUsername)
+        member val Password =               a.TryGetResult Password |> Option.defaultWith (fun () -> c.EventStorePassword)
+        member val Retries =                a.GetResult(Retries, 3)
+        member val Timeout =                a.GetResult(Timeout, 20.) |> TimeSpan.FromSeconds
+        member val Heartbeat =              a.GetResult(HeartbeatTimeout, 1.5) |> TimeSpan.FromSeconds
         member x.Connect(log: ILogger, storeLog: ILogger, connectionStrategy, appName, connIndex) =
             let discovery = x.Discovery
             let s (x : TimeSpan) = x.TotalSeconds
@@ -427,18 +409,18 @@ module Args =
                 | Broker _ ->               "specify Kafka Broker, in host:port format. (optional if environment variable PROPULSION_KAFKA_BROKER specified)"
                 | Topic _ ->                "specify Kafka Topic Id. (optional if environment variable PROPULSION_KAFKA_TOPIC specified)."
                 | Producers _ ->            "specify number of Kafka Producer instances to use. Default: 1."
-    and KafkaSinkArguments(a : ParseResults<KafkaSinkParameters>) =
-        member __.Broker =                  a.TryGetResult Broker |> defaultWithEnvVar "PROPULSION_KAFKA_BROKER" "Broker"
-        member __.Topic =                   a.TryGetResult Topic  |> defaultWithEnvVar "PROPULSION_KAFKA_TOPIC"  "Topic"
-        member __.Producers =               a.GetResult(Producers, 1)
+    and KafkaSinkArguments(c : Configuration, a : ParseResults<KafkaSinkParameters>) =
+        member val Broker =                 a.TryGetResult Broker |> Option.defaultWith (fun () -> c.Broker)
+        member val Topic =                  a.TryGetResult Topic  |> Option.defaultWith (fun () -> c.Topic)
+        member val Producers =              a.GetResult(Producers, 1)
         member x.BuildTargetParams() =      x.Broker, x.Topic, x.Producers
 #endif
 
     /// Parse the commandline; can throw exceptions in response to missing arguments and/or `-h`/`--help` args
-    let parse argv : Arguments =
+    let parse tryGetConfigValue argv : Arguments =
         let programName = System.Reflection.Assembly.GetEntryAssembly().GetName().Name
         let parser = ArgumentParser.Create<Parameters>(programName=programName)
-        parser.ParseCommandLine argv |> Arguments
+        Arguments(Configuration tryGetConfigValue, parser.ParseCommandLine argv)
 
  //#if marveleqx
 [<RequireQualifiedAccess>]
@@ -468,12 +450,12 @@ module EventV0Parser =
             member x.IsUnfold = false
             member x.EventType = x.t
             member x.Data = x.d
-            member __.Meta = null
-            member __.EventId = Guid.Empty
+            member _.Meta = null
+            member _.EventId = Guid.Empty
             member x.Timestamp = x.c
-            member __.CorrelationId = null
-            member __.CausationId = null
-            member __.Context = null
+            member _.CorrelationId = null
+            member _.CausationId = null
+            member _.Context = null
 
     type Microsoft.Azure.Documents.Document with
         member document.Cast<'T>() =
@@ -517,8 +499,8 @@ module Checkpoints =
 type Stats(log, statsInterval, stateInterval) =
     inherit Propulsion.Streams.Sync.Stats<unit>(log, statsInterval, stateInterval)
 
-    override __.HandleOk(()) = ()
-    override __.HandleExn(log, exn) =
+    override _.HandleOk(()) = ()
+    override _.HandleExn(log, exn) =
         log.Information(exn, "Unhandled")
 
 let build (args : Args.Arguments, log, storeLog : ILogger) =
@@ -537,7 +519,7 @@ let build (args : Args.Arguments, log, storeLog : ILogger) =
                 let maxEvents, maxBytes = 100_000, 900_000
                 match cosmos.KafkaSink with
                 | Some kafka ->
-                    let (broker, topic, producers) = kafka.BuildTargetParams()
+                    let broker, topic, producers = kafka.BuildTargetParams()
                     let render (stream: FsCodec.StreamName, span: Propulsion.Streams.StreamSpan<_>) = async {
                         let value =
                             span
@@ -614,13 +596,12 @@ let run args = async {
 
 [<EntryPoint>]
 let main argv =
-    try let args = Args.parse argv
+    try let args = Args.parse EnvVar.tryGet argv
         try Log.Logger <- LoggerConfiguration().Configure(args.Verbose, args.CfpVerbose, ?maybeSeqEndpoint = args.MaybeSeqEndpoint).CreateLogger()
-            try Configuration.initialize ()
-                run args |> Async.RunSynchronously
+            try run args |> Async.RunSynchronously
                 0
-            with e when not (e :? Args.MissingArg) -> Log.Fatal(e, "Exiting"); 2
+            with e when not (e :? MissingArg) -> Log.Fatal(e, "Exiting"); 2
         finally Log.CloseAndFlush()
-    with Args.MissingArg msg -> eprintfn "%s" msg; 1
+    with MissingArg msg -> eprintfn "%s" msg; 1
         | :? Argu.ArguParseException as e -> eprintfn "%s" e.Message; 1
         | e -> eprintf "Exception %s" e.Message; 1

--- a/propulsion-tracking-consumer/Infrastructure.fs
+++ b/propulsion-tracking-consumer/Infrastructure.fs
@@ -4,14 +4,18 @@ open FSharp.UMX // see https://github.com/fsprojects/FSharp.UMX - % operator and
 open Serilog
 open System.Runtime.CompilerServices
 
+module EnvVar =
+
+    let tryGet varName : string option = System.Environment.GetEnvironmentVariable varName |> Option.ofObj
+
 module EventCodec =
 
     /// Uses the supplied codec to decode the supplied event record `x` (iff at LogEventLevel.Debug, detail fails to `log` citing the `stream` and content)
-    let tryDecode (codec : FsCodec.IEventCodec<_, _, _>) (log : Serilog.ILogger) streamName (x : FsCodec.ITimelineEvent<byte[]>) =
+    let tryDecode (codec : FsCodec.IEventCodec<_, _, _>) streamName (x : FsCodec.ITimelineEvent<byte[]>) =
         match codec.TryDecode x with
         | None ->
-            if log.IsEnabled Serilog.Events.LogEventLevel.Debug then
-                log.ForContext("event", System.Text.Encoding.UTF8.GetString(x.Data), true)
+            if Log.IsEnabled Serilog.Events.LogEventLevel.Debug then
+                Log.ForContext("event", System.Text.Encoding.UTF8.GetString(x.Data), true)
                     .Debug("Codec {type} Could not decode {eventType} in {stream}", codec.GetType().FullName, x.EventType, streamName)
             None
         | x -> x

--- a/propulsion-tracking-consumer/Ingester.fs
+++ b/propulsion-tracking-consumer/Ingester.fs
@@ -25,12 +25,12 @@ type Stats(log, statsInterval, stateInterval) =
 
     let mutable ok, skipped = 0, 0
 
-    override __.HandleOk res = res |> function
+    override _.HandleOk res = res |> function
         | Completed (used, unused) -> ok <- ok + used; skipped <- skipped + unused
-    override __.HandleExn exn =
+    override _.HandleExn exn =
         log.Information(exn, "Unhandled")
 
-    override __.DumpStats() =
+    override _.DumpStats() =
         if ok <> 0 || skipped <> 0 then
             log.Information(" Used {ok} Skipped {skipped}", ok, skipped)
             ok <- 0; skipped <- 0

--- a/propulsion-tracking-consumer/Program.fs
+++ b/propulsion-tracking-consumer/Program.fs
@@ -3,74 +3,56 @@
 open Serilog
 open System
 
-module EnvVar =
+exception MissingArg of message : string with override this.Message = this.message
 
-    let tryGet varName : string option = Environment.GetEnvironmentVariable varName |> Option.ofObj
-    let set varName value : unit = Environment.SetEnvironmentVariable(varName, value)
+type Configuration(tryGet) =
 
-// TODO remove this entire comment after reading https://github.com/jet/dotnet-templates#module-configuration
-// - this is where any custom retrieval of settings not arriving via commandline arguments or environment variables should go
-// - values should be propagated by setting environment variables and/or returning them from `initialize`
-module Configuration =
+    let get key =
+        match tryGet key with
+        | Some value -> value
+        | None -> raise (MissingArg (sprintf "Missing Argument/Environment Variable %s" key))
 
-    let private initEnvVar var key loadF =
-        if None = EnvVar.tryGet var then
-            printfn "Setting %s from %A" var key
-            EnvVar.set var (loadF key)
+    member _.CosmosConnection =             get "EQUINOX_COSMOS_CONNECTION"
+    member _.CosmosDatabase =               get "EQUINOX_COSMOS_DATABASE"
+    member _.CosmosContainer =              get "EQUINOX_COSMOS_CONTAINER"
+    member _.Broker =                       get "PROPULSION_KAFKA_BROKER"
+    member _.Topic =                        get "PROPULSION_KAFKA_TOPIC"
+    member _.Group =                        get "PROPULSION_KAFKA_GROUP"
 
-    let initialize () =
-        // e.g. initEnvVar     "EQUINOX_COSMOS_CONTAINER"    "CONSUL KEY" readFromConsul
-        () // TODO add any custom logic preprocessing commandline arguments and/or gathering custom defaults from external sources, etc
-
-// TODO remove this entire comment after reading https://github.com/jet/dotnet-templates#module-args
-// - this module is responsible solely for parsing/validating the commandline arguments (including falling back to values supplied via environment variables)
-// - It's expected that the properties on *Arguments types will summarize the active settings as a side effect of
-// TODO DONT invest time reorganizing or reformatting this - half the value is having a legible summary of all program parameters in a consistent value
-//      you may want to regenerate it at a different time and/or facilitate comparing it with the `module Args` of other programs
-// TODO NEVER hack temporary overrides in here; if you're going to do that, use commandline arguments that fall back to environment variables
-//      or (as a last resort) supply them via code in `module Configuration`
 module Args =
 
-    exception MissingArg of string
-    let private getEnvVarForArgumentOrThrow varName argName =
-        match Environment.GetEnvironmentVariable varName with
-        | null -> raise (MissingArg(sprintf "Please provide a %s, either as an argument or via the %s environment variable" argName varName))
-        | x -> x
-    let private defaultWithEnvVar varName argName = function
-        | None -> getEnvVarForArgumentOrThrow varName argName
-        | Some x -> x
     open Argu
     open Equinox.Cosmos
     type [<NoEquality; NoComparison>] CosmosParameters =
-        | [<AltCommandLine "-m">]       ConnectionMode of ConnectionMode
-        | [<AltCommandLine "-s">]       Connection of string
-        | [<AltCommandLine "-d">]       Database of string
-        | [<AltCommandLine "-c">]       Container of string
-        | [<AltCommandLine "-o">]       Timeout of float
-        | [<AltCommandLine "-r">]       Retries of int
-        | [<AltCommandLine "-rt">]      RetriesWaitTime of float
+        | [<AltCommandLine "-m">]           ConnectionMode of ConnectionMode
+        | [<AltCommandLine "-s">]           Connection of string
+        | [<AltCommandLine "-d">]           Database of string
+        | [<AltCommandLine "-c">]           Container of string
+        | [<AltCommandLine "-o">]           Timeout of float
+        | [<AltCommandLine "-r">]           Retries of int
+        | [<AltCommandLine "-rt">]          RetriesWaitTime of float
         interface IArgParserTemplate with
             member a.Usage =
                 match a with
-                | ConnectionMode _ ->   "override the connection mode. Default: Direct."
-                | Connection _ ->       "specify a connection string for a Cosmos account. (optional if environment variable EQUINOX_COSMOS_CONNECTION specified)"
-                | Database _ ->         "specify a database name for Cosmos store. (optional if environment variable EQUINOX_COSMOS_DATABASE specified)"
-                | Container _ ->        "specify a container name for Cosmos store. (optional if environment variable EQUINOX_COSMOS_CONTAINER specified)"
-                | Timeout _ ->          "specify operation timeout in seconds (default: 5)."
-                | Retries _ ->          "specify operation retries (default: 1)."
-                | RetriesWaitTime _ ->  "specify max wait-time for retry when being throttled by Cosmos in seconds (default: 5)"
-    type CosmosArguments(a : ParseResults<CosmosParameters>) =
-        member __.Mode =                a.GetResult(ConnectionMode, ConnectionMode.Direct)
-        member __.Connection =          a.TryGetResult Connection |> defaultWithEnvVar "EQUINOX_COSMOS_CONNECTION" "Connection"
-        member __.Database =            a.TryGetResult Database   |> defaultWithEnvVar "EQUINOX_COSMOS_DATABASE"   "Database"
-        member __.Container =           a.TryGetResult Container  |> defaultWithEnvVar "EQUINOX_COSMOS_CONTAINER"  "Container"
+                | ConnectionMode _ ->       "override the connection mode. Default: Direct."
+                | Connection _ ->           "specify a connection string for a Cosmos account. (optional if environment variable EQUINOX_COSMOS_CONNECTION specified)"
+                | Database _ ->             "specify a database name for Cosmos store. (optional if environment variable EQUINOX_COSMOS_DATABASE specified)"
+                | Container _ ->            "specify a container name for Cosmos store. (optional if environment variable EQUINOX_COSMOS_CONTAINER specified)"
+                | Timeout _ ->              "specify operation timeout in seconds (default: 5)."
+                | Retries _ ->              "specify operation retries (default: 1)."
+                | RetriesWaitTime _ ->      "specify max wait-time for retry when being throttled by Cosmos in seconds (default: 5)"
+    type CosmosArguments(c : Configuration, a : ParseResults<CosmosParameters>) =
+        member val Mode =                   a.GetResult(ConnectionMode, ConnectionMode.Direct)
+        member val Connection =             a.TryGetResult Connection |> Option.defaultWith (fun () -> c.CosmosConnection) |> Discovery.FromConnectionString
+        member val Database =               a.TryGetResult Database   |> Option.defaultWith (fun () -> c.CosmosDatabase)
+        member val Container =              a.TryGetResult Container  |> Option.defaultWith (fun () -> c.CosmosContainer)
 
-        member __.Timeout =             a.GetResult(Timeout, 5.) |> TimeSpan.FromSeconds
-        member __.Retries =             a.GetResult(Retries, 1)
-        member __.MaxRetryWaitTime =    a.GetResult(RetriesWaitTime, 5.) |> TimeSpan.FromSeconds
+        member val Timeout =                a.GetResult(Timeout, 5.) |> TimeSpan.FromSeconds
+        member val Retries =                a.GetResult(Retries, 1)
+        member val MaxRetryWaitTime =       a.GetResult(RetriesWaitTime, 5.) |> TimeSpan.FromSeconds
 
         member x.Connect(clientId) = async {
-            let (Discovery.UriAndKey (endpointUri, _) as discovery) = Discovery.FromConnectionString x.Connection
+            let Discovery.UriAndKey (endpointUri, _) as discovery = x.Connection
             Log.Information("CosmosDb {mode} {endpointUri} Database {database} Container {container}.",
                 x.Mode, endpointUri, x.Database, x.Container)
             Log.Information("CosmosDb timeout {timeout}s; Throttling retries {retries}, max wait {maxRetryWaitTime}s",
@@ -102,25 +84,25 @@ module Args =
                 | Verbose _ ->              "request verbose logging."
                 | Cosmos _ ->               "specify CosmosDb input parameters"
 
-    type Arguments(a : ParseResults<Parameters>) =
-        member val Cosmos =                 CosmosArguments(a.GetResult Cosmos)
-        member __.Broker =                  a.TryGetResult Broker |> defaultWithEnvVar "PROPULSION_KAFKA_BROKER" "Broker"
-        member __.Topic =                   a.TryGetResult Topic  |> defaultWithEnvVar "PROPULSION_KAFKA_TOPIC"  "Topic"
-        member __.Group =                   a.TryGetResult Group  |> defaultWithEnvVar "PROPULSION_KAFKA_GROUP"  "Group"
-        member __.MaxInFlightBytes =        a.GetResult(MaxInflightMb, 10.) * 1024. * 1024. |> int64
-        member __.LagFrequency =            a.TryGetResult LagFreqM |> Option.map TimeSpan.FromMinutes
+    type Arguments(c : Configuration, a : ParseResults<Parameters>) =
+        member val Cosmos =                 CosmosArguments(c, a.GetResult Cosmos)
+        member val Broker =                 a.TryGetResult Broker |> Option.defaultWith (fun () -> c.Broker)
+        member val Topic =                  a.TryGetResult Topic  |> Option.defaultWith (fun () -> c.Topic)
+        member val Group =                  a.TryGetResult Group  |> Option.defaultWith (fun () -> c.Group)
+        member val MaxInFlightBytes =       a.GetResult(MaxInflightMb, 10.) * 1024. * 1024. |> int64
+        member val LagFrequency =           a.TryGetResult LagFreqM |> Option.map TimeSpan.FromMinutes
 
-        member __.MaxConcurrentStreams =    a.GetResult(MaxWriters, 8)
+        member val MaxConcurrentStreams =   a.GetResult(MaxWriters, 8)
 
-        member __.Verbose =                 a.Contains Verbose
-        member __.StatsInterval =           TimeSpan.FromMinutes 1.
-        member __.StateInterval =           TimeSpan.FromMinutes 5.
+        member val Verbose =                a.Contains Verbose
+        member val StatsInterval =          TimeSpan.FromMinutes 1.
+        member val StateInterval =          TimeSpan.FromMinutes 5.
 
     /// Parse the commandline; can throw exceptions in response to missing arguments and/or `-h`/`--help` args
-    let parse argv =
+    let parse tryGetConfigValue argv =
         let programName = Reflection.Assembly.GetEntryAssembly().GetName().Name
         let parser = ArgumentParser.Create<Parameters>(programName=programName)
-        parser.ParseCommandLine argv |> Arguments
+        Arguments(Configuration tryGetConfigValue, parser.ParseCommandLine argv)
 
 let [<Literal>] AppName = "ConsumerTemplate"
 
@@ -150,13 +132,12 @@ let run args = async {
 
 [<EntryPoint>]
 let main argv =
-    try let args = Args.parse argv
+    try let args = Args.parse EnvVar.tryGet argv
         try Log.Logger <- LoggerConfiguration().Configure(verbose=args.Verbose).CreateLogger()
-            try Configuration.initialize ()
-                run args |> Async.RunSynchronously
+            try run args |> Async.RunSynchronously
                 0
-            with e when not (e :? Args.MissingArg) -> Log.Fatal(e, "Exiting"); 2
+            with e when not (e :? MissingArg) -> Log.Fatal(e, "Exiting"); 2
         finally Log.CloseAndFlush()
-    with Args.MissingArg msg -> eprintfn "%s" msg; 1
+    with MissingArg msg -> eprintfn "%s" msg; 1
         | :? Argu.ArguParseException as e -> eprintfn "%s" e.Message; 1
         | e -> eprintf "Exception %s" e.Message; 1

--- a/propulsion-tracking-consumer/Program.fs
+++ b/propulsion-tracking-consumer/Program.fs
@@ -55,8 +55,9 @@ module Args =
             let Discovery.UriAndKey (endpointUri, _) as discovery = x.Connection
             Log.Information("CosmosDb {mode} {endpointUri} Database {database} Container {container}.",
                 x.Mode, endpointUri, x.Database, x.Container)
+            let ts (x : TimeSpan) = x.TotalSeconds
             Log.Information("CosmosDb timeout {timeout}s; Throttling retries {retries}, max wait {maxRetryWaitTime}s",
-                (let t = x.Timeout in t.TotalSeconds), x.Retries, (let t = x.MaxRetryWaitTime in t.TotalSeconds))
+                ts x.Timeout, x.Retries, ts x.MaxRetryWaitTime)
             let! connection = Connector(x.Timeout, x.Retries, x.MaxRetryWaitTime, Log.Logger, mode=x.Mode).Connect(clientId, discovery)
             return Context(connection, x.Database, x.Container) }
 

--- a/tests/Equinox.Templates.Tests/Infrastructure.fs
+++ b/tests/Equinox.Templates.Tests/Infrastructure.fs
@@ -63,5 +63,5 @@ type EquinoxTemplatesFixture() =
     member val PackagePath = packagePath
 
     interface IDisposable with
-        member __.Dispose() =
+        member _.Dispose() =
             Dotnet.uninstall PackageName


### PR DESCRIPTION
Applies configuration style changes used in production systems, pioneered by @enricosada:

- use `member val` instead of `member __.` - triggering eager evaluation to minimize deferred throwing of exceptions for invalid invocations
- use `type Configuration` to:
  - ensure referential transparency in implementation of `type Arguments` - no more `EnvVar.tryGet` global lookups
  - centralize and DRY keys for environment variables
  - allow easy transition to `Microsoft.Extensions.Configuration` (can use `IConfigurationRoot.Item >> Option.ofObj` instead of `EnvVar.tryGet` to avail of layered loading of Secrets from aggregated configurations)
 - Roll out some naming and style changes from Equinox
   - `Equinox.Stream` -> `Decider` 