### PR TITLE
Add proCosmosReactor for same Container Reactions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ The `Unreleased` section name is replaced by the expected version of next releas
 ## [Unreleased]
 
 ### Added
+
+- `proCosmosReactor`: Template for simplified, same-container Cosmos-based reactions [#93](https://github.com/jet/dotnet-templates/pull/93)
+
 ### Changed
 
 - Added defaulting of 1 min for lag reporting frequency to all Cosmos consumers [#95](https://github.com/jet/dotnet-templates/pull/95)

--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ The specific behaviors carried out in reaction to incoming events often use `Equ
 
     - Specific only to Cosmos
 
-    - For reactions using the same container for listening and writing to (i.e.: same source and destination)
+    - For applications where the reactions using the same Container, credentials etc as the one being Monitored by the change feed processor (simpler config wiring and less argument processing)
 
 <a name="eqxShipping"></a>
 - [`eqxShipping`](equinox-shipping/README.md) - Example demonstrating the implementation of a [Process Manager](https://www.enterpriseintegrationpatterns.com/patterns/messaging/ProcessManager.html) using [`Equinox`](https://github.com/jet/equinox) that manages the enlistment of a set of `Shipment` Aggregate items into a separated `Container` Aggregate as an atomic operation. :pray: [@Kimserey](https://github.com/Kimserey). _Still targets Equinox V2 atm._

--- a/README.md
+++ b/README.md
@@ -81,6 +81,12 @@ The specific behaviors carried out in reaction to incoming events often use `Equ
     
     - It is necessary to reset the CFP checkpoint (delete the checkpoint documents, or use a new Consumer Group Name) to trigger a re-traversal if events have expired since the lsat time a traversal took place.
 
+- [`proCosmosReactor`](propulsion-cosmos-reactor/README.md) - Stripped down derivative of Propulsion Reactor template that is
+
+    - Specific only to Cosmos
+
+    - For reactions using the same container for listening and writing to (i.e.: same source and destination)
+
 <a name="eqxShipping"></a>
 - [`eqxShipping`](equinox-shipping/README.md) - Example demonstrating the implementation of a [Process Manager](https://www.enterpriseintegrationpatterns.com/patterns/messaging/ProcessManager.html) using [`Equinox`](https://github.com/jet/equinox) that manages the enlistment of a set of `Shipment` Aggregate items into a separated `Container` Aggregate as an atomic operation. :pray: [@Kimserey](https://github.com/Kimserey). _Still targets Equinox V2 atm._
  
@@ -167,6 +173,10 @@ To use from the command line, the outline is:
     # ... to add a Shipping Domain example containing a Process Manager with a Watchdog Service
     md -p ../Shipping | Set-Location
     dotnet new eqxShipping
+
+    # ... to add a Reactor against a Cosmos container for both listening and writing
+    md -p ../CosmosReactor | Set-Location
+    dotnet new proCosmosReactor
 
 ## TESTING
 

--- a/propulsion-cosmos-reactor/.template.config/template.json
+++ b/propulsion-cosmos-reactor/.template.config/template.json
@@ -1,0 +1,21 @@
+{
+  "$schema": "http://json.schemastore.org/template",
+  "author": "@jet @ragiano215 @bartelink",
+  "classifications": [
+    "CosmosDb",
+    "ChangeFeed",
+    "ChangeFeedProcessor",
+    "Event Sourcing",
+    "Equinox",
+    "Propulsion",
+    "Reactor"
+  ],
+  "tags": {
+    "language": "F#"
+  },
+  "identity": "Propulsion.Template.CosmosReactor",
+  "name": "Propulsion Cosmos Reactor",
+  "shortName": "proCosmosReactor",
+  "sourceName": "ReactorTemplate",
+  "preferNameDirectory": true
+}

--- a/propulsion-cosmos-reactor/Contract.fs
+++ b/propulsion-cosmos-reactor/Contract.fs
@@ -1,0 +1,14 @@
+module ReactorTemplate.Contract
+
+/// A single Item in the list
+type ItemInfo = { id: int; order: int; title: string; completed: bool }
+
+type SummaryInfo = { items : ItemInfo[] }
+
+let render (item: Todo.Events.ItemData) : ItemInfo =
+    {   id = item.id
+        order = item.order
+        title = item.title
+        completed = item.completed }
+let ofState (state : Todo.Fold.State) : SummaryInfo =
+    { items = [| for x in state.items -> render x |]}

--- a/propulsion-cosmos-reactor/Infrastructure.fs
+++ b/propulsion-cosmos-reactor/Infrastructure.fs
@@ -1,0 +1,105 @@
+namespace ReactorTemplate
+
+open FSharp.UMX // see https://github.com/fsprojects/FSharp.UMX - % operator and ability to apply units of measure to Guids+strings
+open Serilog
+open System
+
+module EnvVar =
+
+    let tryGet varName : string option = Environment.GetEnvironmentVariable varName |> Option.ofObj
+
+module EventCodec =
+
+    /// Uses the supplied codec to decode the supplied event record `x` (iff at LogEventLevel.Debug, detail fails to `log` citing the `stream` and content)
+    let tryDecode (codec : FsCodec.IEventCodec<_, _, _>) streamName (x : FsCodec.ITimelineEvent<byte[]>) =
+        match codec.TryDecode x with
+        | None ->
+            if Log.IsEnabled Serilog.Events.LogEventLevel.Debug then
+                Log.ForContext("event", System.Text.Encoding.UTF8.GetString(x.Data), true)
+                    .Debug("Codec {type} Could not decode {eventType} in {stream}", codec.GetType().FullName, x.EventType, streamName)
+            None
+        | x -> x
+
+module Log =
+
+    let forMetrics () =
+        Serilog.Log.ForContext("isMetric", true)
+
+module Equinox =
+
+    let createDecider stream =
+        Equinox.Decider(Log.forMetrics (), stream, maxAttempts = 3)
+
+module Guid =
+
+    let inline toStringN (x : Guid) = x.ToString "N"
+
+/// ClientId strongly typed id; represented internally as a Guid; not used for storage so rendering is not significant
+type ClientId = Guid<clientId>
+and [<Measure>] clientId
+module ClientId =
+    let toString (value : ClientId) : string = Guid.toStringN %value
+    let parse (value : string) : ClientId = let raw = Guid.Parse value in % raw
+    let (|Parse|) = parse
+
+[<System.Runtime.CompilerServices.Extension>]
+type LoggerConfigurationExtensions() =
+
+    [<System.Runtime.CompilerServices.Extension>]
+    static member inline ConfigureChangeFeedProcessorLogging(c : LoggerConfiguration, verbose : bool) =
+        let cfpl = if verbose then Serilog.Events.LogEventLevel.Debug else Serilog.Events.LogEventLevel.Warning
+        // TODO figure out what CFP v3 requires
+        c.MinimumLevel.Override("Microsoft.Azure.Documents.ChangeFeedProcessor", cfpl)
+
+[<System.Runtime.CompilerServices.Extension>]
+type Logging() =
+
+    [<System.Runtime.CompilerServices.Extension>]
+    static member Configure(configuration : LoggerConfiguration, ?verbose, ?changeFeedProcessorVerbose) =
+        configuration
+            .Destructure.FSharpTypes()
+            .Enrich.FromLogContext()
+        |> fun c -> if verbose = Some true then c.MinimumLevel.Debug() else c
+        |> fun c -> c.ConfigureChangeFeedProcessorLogging((changeFeedProcessorVerbose = Some true))
+        |> fun c -> let t = "[{Timestamp:HH:mm:ss} {Level:u3}] {Message:lj} {NewLine}{Exception}"
+                    c.WriteTo.Console(theme=Sinks.SystemConsole.Themes.AnsiConsoleTheme.Code, outputTemplate=t)
+
+module CosmosStoreContext =
+
+    /// Create with default packing and querying policies. Search for other `module CosmosStoreContext` impls for custom variations
+    let create (storeClient : Equinox.CosmosStore.CosmosStoreClient) =
+        let maxEvents = 256 // default is 0
+        Equinox.CosmosStore.CosmosStoreContext(storeClient, tipMaxEvents=maxEvents)
+
+[<AutoOpen>]
+module ConnectorExtensions =
+
+    type Equinox.CosmosStore.CosmosStoreConnector with
+
+        member private x.LogConfiguration(connectionName, databaseId, containerId) =
+            let o = x.Options
+            let timeout, retries429, timeout429 = o.RequestTimeout, o.MaxRetryAttemptsOnRateLimitedRequests, o.MaxRetryWaitTimeOnRateLimitedRequests
+            Log.Information("CosmosDb {name} {mode} {endpointUri} timeout {timeout}s; Throttling retries {retries}, max wait {maxRetryWaitTime}s",
+                            connectionName, o.ConnectionMode, x.Endpoint, timeout.TotalSeconds, retries429, let t = timeout429.Value in t.TotalSeconds)
+            Log.Information("CosmosDb {name} Database {database} Container {container}",
+                            connectionName, databaseId, containerId)
+
+        /// Use sparingly; in general one wants to use CreateAndInitialize to avoid slow first requests
+        member x.CreateUninitialized(databaseId, containerId) =
+            x.CreateUninitialized().GetDatabase(databaseId).GetContainer(containerId)
+
+        /// Connect a CosmosStoreClient, including warming up
+        member x.ConnectStore(connectionName, databaseId, containerId) =
+            x.LogConfiguration(connectionName, databaseId, containerId)
+            Equinox.CosmosStore.CosmosStoreClient.Connect(x.CreateAndInitialize, databaseId, containerId)
+
+        /// Creates a CosmosClient suitable for running a CFP via CosmosStoreSource
+        member x.ConnectMonitored(databaseId, containerId, ?connectionName) =
+            x.LogConfiguration(defaultArg connectionName "Source", databaseId, containerId)
+            x.CreateUninitialized(databaseId, containerId)
+
+        /// Connects to a Store as both a ChangeFeedProcessor Monitored Container and a CosmosStoreClient
+        member x.ConnectStoreAndMonitored(databaseId, containerId) =
+            let monitored = x.ConnectMonitored(databaseId, containerId, "Main")
+            let storeClient = Equinox.CosmosStore.CosmosStoreClient(monitored.Database.Client, databaseId, containerId)
+            storeClient, monitored

--- a/propulsion-cosmos-reactor/Infrastructure.fs
+++ b/propulsion-cosmos-reactor/Infrastructure.fs
@@ -94,12 +94,5 @@ module ConnectorExtensions =
             Equinox.CosmosStore.CosmosStoreClient.Connect(x.CreateAndInitialize, databaseId, containerId)
 
         /// Creates a CosmosClient suitable for running a CFP via CosmosStoreSource
-        member x.ConnectMonitored(databaseId, containerId, ?connectionName) =
-            x.LogConfiguration(defaultArg connectionName "Source", databaseId, containerId)
+        member x.ConnectMonitored(databaseId, containerId) =
             x.CreateUninitialized(databaseId, containerId)
-
-        /// Connects to a Store as both a ChangeFeedProcessor Monitored Container and a CosmosStoreClient
-        member x.ConnectStoreAndMonitored(databaseId, containerId) =
-            let monitored = x.ConnectMonitored(databaseId, containerId, "Main")
-            let storeClient = Equinox.CosmosStore.CosmosStoreClient(monitored.Database.Client, databaseId, containerId)
-            storeClient, monitored

--- a/propulsion-cosmos-reactor/Program.fs
+++ b/propulsion-cosmos-reactor/Program.fs
@@ -1,0 +1,187 @@
+module ReactorTemplate.Program
+
+open Serilog
+open System
+
+exception MissingArg of message : string with override this.Message = this.message
+
+type Configuration(tryGet) =
+
+    let get key =
+        match tryGet key with
+        | Some value -> value
+        | None -> raise (MissingArg (sprintf "Missing Argument/Environment Variable %s" key))
+
+    member _.CosmosConnection =             get "EQUINOX_COSMOS_CONNECTION"
+    member _.CosmosDatabase =               get "EQUINOX_COSMOS_DATABASE"
+    member _.CosmosContainer =              get "EQUINOX_COSMOS_CONTAINER"
+
+module Args =
+
+    open Argu
+    [<NoEquality; NoComparison>]
+    type Parameters =
+        | [<AltCommandLine "-g"; Mandatory>] ConsumerGroupName of string
+        | [<AltCommandLine "-r"; Unique>]   MaxReadAhead of int
+        | [<AltCommandLine "-w"; Unique>]   MaxWriters of int
+        | [<AltCommandLine "-V"; Unique>]   Verbose
+        | [<AltCommandLine "-C"; Unique>]   CfpVerbose
+        | [<CliPrefix(CliPrefix.None); Unique(*ExactlyOnce is not supported*); Last>] Cosmos of ParseResults<CosmosSourceParameters>
+        interface IArgParserTemplate with
+            member a.Usage = a |> function
+                | ConsumerGroupName _ ->    "Projector consumer group name."
+                | MaxReadAhead _ ->         "maximum number of batches to let processing get ahead of completion. Default: 16."
+                | MaxWriters _ ->           "maximum number of concurrent streams on which to process at any time. Default: 8."
+                | Verbose ->                "request Verbose Logging. Default: off."
+                | CfpVerbose ->             "request Verbose Change Feed Processor Logging. Default: off."
+                | Cosmos _ ->               "specify CosmosDB input parameters."
+    and Arguments(c : Configuration, a : ParseResults<Parameters>) =
+        member val ConsumerGroupName =      a.GetResult ConsumerGroupName
+        member val CfpVerbose =             a.Contains CfpVerbose
+        member val MaxReadAhead =           a.GetResult(MaxReadAhead, 16)
+        member val MaxConcurrentStreams =   a.GetResult(MaxWriters, 8)
+        member val Verbose =                a.Contains Parameters.Verbose
+        member val StatsInterval =          TimeSpan.FromMinutes 1.
+        member val StateInterval =          TimeSpan.FromMinutes 5.
+        member val Source : CosmosSourceArguments =
+            match a.TryGetSubCommand() with
+            | Some (Parameters.Cosmos cosmos) -> CosmosSourceArguments (c, cosmos)
+            | _ -> raise (MissingArg "Must specify cosmos for Src")
+        member x.SourceParams() =
+                let srcC = x.Source
+                let leases = srcC.ConnectLeases()
+                Log.Information("Reacting... {dop} writers, max {maxReadAhead} batches read ahead", x.MaxConcurrentStreams, x.MaxReadAhead)
+                Log.Information("Monitoring Group {processorName} in Database {db} Container {container} with maximum document count limited to {maxDocuments}",
+                    x.ConsumerGroupName, srcC.DatabaseId, srcC.ContainerId, Option.toNullable srcC.MaxDocuments)
+                if srcC.FromTail then Log.Warning("(If new projector group) Skipping projection of all existing events.")
+                srcC.LagFrequency |> Option.iter<TimeSpan> (fun i -> Log.Information("ChangeFeed Lag stats interval {lagS:n0}s", i.TotalSeconds))
+                let storeClient, monitored = srcC.ConnectStoreAndMonitored()
+                let context = CosmosStoreContext.create storeClient
+                (srcC, context, monitored, leases, x.ConsumerGroupName, srcC.FromTail, srcC.MaxDocuments, srcC.LagFrequency)
+    and [<NoEquality; NoComparison>] CosmosSourceParameters =
+        | [<AltCommandLine "-Z"; Unique>]   FromTail
+        | [<AltCommandLine "-md"; Unique>]  MaxDocuments of int
+        | [<AltCommandLine "-l"; Unique>]   LagFreqM of float
+        | [<AltCommandLine "-a"; Unique>]   LeaseContainer of string
+
+        | [<AltCommandLine "-m">]           ConnectionMode of Microsoft.Azure.Cosmos.ConnectionMode
+        | [<AltCommandLine "-s">]           Connection of string
+        | [<AltCommandLine "-d">]           Database of string
+        | [<AltCommandLine "-c"; Unique>]   Container of string // Actually Mandatory, but stating that is not supported
+        | [<AltCommandLine "-o">]           Timeout of float
+        | [<AltCommandLine "-r">]           Retries of int
+        | [<AltCommandLine "-rt">]          RetriesWaitTime of float
+
+        | [<CliPrefix(CliPrefix.None); Unique(*ExactlyOnce is not supported*); Last>] Cosmos of ParseResults<CosmosParameters>
+        interface IArgParserTemplate with
+            member a.Usage = a |> function
+                | FromTail ->               "(iff the Consumer Name is fresh) - force skip to present Position. Default: Never skip an event."
+                | MaxDocuments _ ->         "maximum item count to request from feed. Default: unlimited"
+                | LagFreqM _ ->             "frequency (in minutes) to dump lag stats. Default: off"
+                | LeaseContainer _ ->       "specify Container Name for Leases container. Default: `sourceContainer` + `-aux`."
+
+                | ConnectionMode _ ->       "override the connection mode. Default: Direct."
+                | Connection _ ->           "specify a connection string for a Cosmos account. (optional if environment variable EQUINOX_COSMOS_CONNECTION specified)"
+                | Database _ ->             "specify a database name for Cosmos account. (optional if environment variable EQUINOX_COSMOS_DATABASE specified)"
+                | Container _ ->            "specify a container name within `Database`"
+                | Timeout _ ->              "specify operation timeout in seconds. Default: 5."
+                | Retries _ ->              "specify operation retries. Default: 1."
+                | RetriesWaitTime _ ->      "specify max wait-time for retry when being throttled by Cosmos in seconds. Default: 5."
+
+                | Cosmos _ ->               "CosmosDb Sink parameters."
+    and CosmosSourceArguments(c : Configuration, a : ParseResults<CosmosSourceParameters>) =
+        let discovery =                     a.TryGetResult CosmosSourceParameters.Connection |> Option.defaultWith (fun () -> c.CosmosConnection) |> Equinox.CosmosStore.Discovery.ConnectionString
+        let mode =                          a.TryGetResult CosmosSourceParameters.ConnectionMode
+        let timeout =                       a.GetResult(CosmosSourceParameters.Timeout, 5.) |> TimeSpan.FromSeconds
+        let retries =                       a.GetResult(CosmosSourceParameters.Retries, 1)
+        let maxRetryWaitTime =              a.GetResult(CosmosSourceParameters.RetriesWaitTime, 5.) |> TimeSpan.FromSeconds
+        let connector =                     Equinox.CosmosStore.CosmosStoreConnector(discovery, timeout, retries, maxRetryWaitTime, ?mode = mode)
+        member val DatabaseId =             a.TryGetResult CosmosSourceParameters.Database |> Option.defaultWith (fun () -> c.CosmosDatabase)
+        member val ContainerId =            a.GetResult CosmosSourceParameters.Container
+
+        member val FromTail =               a.Contains CosmosSourceParameters.FromTail
+        member val MaxDocuments =           a.TryGetResult MaxDocuments
+        member val LagFrequency =           a.TryGetResult LagFreqM |> Option.map TimeSpan.FromMinutes
+        member val private LeaseContainerId = a.TryGetResult CosmosSourceParameters.LeaseContainer
+        member private x.ConnectLeases containerId = connector.CreateUninitialized(x.DatabaseId, containerId)
+        member x.ConnectLeases() =          match x.LeaseContainerId with
+                                            | None ->    x.ConnectLeases(x.ContainerId + "-aux")
+                                            | Some sc -> x.ConnectLeases(sc)
+        member x.ConnectStoreAndMonitored() = connector.ConnectStoreAndMonitored(x.DatabaseId, x.ContainerId)
+        member val Cosmos =
+            match a.TryGetSubCommand() with
+            | Some (CosmosSourceParameters.Cosmos cosmos) -> CosmosArguments (c, cosmos)
+            | _ -> raise (MissingArg "Must specify cosmos details")
+    and [<NoEquality; NoComparison>] CosmosParameters =
+        | [<AltCommandLine "-s">]           Connection of string
+        | [<AltCommandLine "-m">]           ConnectionMode of Microsoft.Azure.Cosmos.ConnectionMode
+        | [<AltCommandLine "-d">]           Database of string
+        | [<AltCommandLine "-c">]           Container of string
+        | [<AltCommandLine "-o">]           Timeout of float
+        | [<AltCommandLine "-r">]           Retries of int
+        | [<AltCommandLine "-rt">]          RetriesWaitTime of float
+        interface IArgParserTemplate with
+            member a.Usage = a |> function
+                | ConnectionMode _ ->       "override the connection mode. Default: Direct."
+                | Connection _ ->           "specify a connection string for a Cosmos account. (optional if environment variable EQUINOX_COSMOS_CONNECTION specified)"
+                | Database _ ->             "specify a database name for Cosmos store. (optional if environment variable EQUINOX_COSMOS_DATABASE specified)"
+                | Container _ ->            "specify a container name for Cosmos store. (optional if environment variable EQUINOX_COSMOS_CONTAINER specified)"
+                | Timeout _ ->              "specify operation timeout in seconds. Default: 5."
+                | Retries _ ->              "specify operation retries. Default: 1."
+                | RetriesWaitTime _ ->      "specify max wait-time for retry when being throttled by Cosmos in seconds. Default: 5."
+    and CosmosArguments(c : Configuration, a : ParseResults<CosmosParameters>) =
+        let discovery =                     a.TryGetResult Connection |> Option.defaultWith (fun () -> c.CosmosConnection) |> Equinox.CosmosStore.Discovery.ConnectionString
+        let mode =                          a.TryGetResult ConnectionMode
+        let timeout =                       a.GetResult(Timeout, 30.) |> TimeSpan.FromSeconds
+        let retries =                       a.GetResult(Retries, 9)
+        let maxRetryWaitTime =              a.GetResult(RetriesWaitTime, 30.) |> TimeSpan.FromSeconds
+        let connector =                     Equinox.CosmosStore.CosmosStoreConnector(discovery, timeout, retries, maxRetryWaitTime, ?mode=mode)
+        member val DatabaseId =             a.TryGetResult Database |> Option.defaultWith (fun () -> c.CosmosDatabase)
+        member val ContainerId =            a.TryGetResult Container |> Option.defaultWith (fun () -> c.CosmosContainer)
+        member x.Connect() =                connector.ConnectStore("Main", x.DatabaseId, x.ContainerId)
+
+    /// Parse the commandline; can throw exceptions in response to missing arguments and/or `-h`/`--help` args
+    let parse tryGetConfigValue argv : Arguments =
+        let programName = System.Reflection.Assembly.GetEntryAssembly().GetName().Name
+        let parser = ArgumentParser.Create<Parameters>(programName=programName)
+        Arguments(Configuration tryGetConfigValue, parser.ParseCommandLine argv)
+
+let [<Literal>] AppName = "ReactorTemplate"
+
+let build (args : Args.Arguments) =
+    let source, context, monitored, leases, processorName, startFromTail, maxDocuments, lagFrequency = args.SourceParams()
+
+    let context = source.Cosmos.Connect() |> Async.RunSynchronously |> CosmosStoreContext.create
+    let cache = Equinox.Cache(AppName, sizeMb=10)
+    let srcService = Todo.Cosmos.create (context, cache)
+    let dstService = TodoSummary.Cosmos.create (context, cache)
+    let handle = Reactor.handle srcService dstService
+    let stats = Reactor.Stats(Log.Logger, args.StatsInterval, args.StateInterval)
+    let sink = Propulsion.Streams.StreamsProjector.Start(Log.Logger, args.MaxReadAhead, args.MaxConcurrentStreams, handle, stats, args.StatsInterval)
+
+    let mapToStreamItems docs : Propulsion.Streams.StreamEvent<_> seq =
+        // TODO: customize parsing to events if source is not an Equinox Container
+        docs
+        |> Seq.collect Propulsion.CosmosStore.EquinoxNewtonsoftParser.enumStreamEvents
+    let pipeline =
+        use observer = Propulsion.CosmosStore.CosmosStoreSource.CreateObserver(Log.Logger, sink.StartIngester, mapToStreamItems)
+        Propulsion.CosmosStore.CosmosStoreSource.Run(Log.Logger, monitored, leases, processorName, observer, startFromTail, ?maxDocuments=maxDocuments, ?lagReportFreq=lagFrequency)
+    sink, pipeline
+
+let run args = async {
+    let sink, pipeline = build args
+    pipeline |> Async.Start
+    return! sink.AwaitCompletion()
+}
+
+[<EntryPoint>]
+let main argv =
+    try let args = Args.parse EnvVar.tryGet argv
+        try Log.Logger <- LoggerConfiguration().Configure(verbose=args.Verbose, changeFeedProcessorVerbose=args.CfpVerbose).CreateLogger()
+            try run args |> Async.RunSynchronously
+                0
+            with e when not (e :? MissingArg) -> Log.Fatal(e, "Exiting"); 2
+        finally Log.CloseAndFlush()
+    with MissingArg msg -> eprintfn "%s" msg; 1
+        | :? Argu.ArguParseException as e -> eprintfn "%s" e.Message; 1
+        | e -> eprintf "Exception %s" e.Message; 1

--- a/propulsion-cosmos-reactor/Program.fs
+++ b/propulsion-cosmos-reactor/Program.fs
@@ -21,92 +21,88 @@ module Args =
     open Argu
     [<NoEquality; NoComparison>]
     type Parameters =
+        | [<AltCommandLine "-V"; Unique>]       Verbose
         | [<AltCommandLine "-g"; Mandatory>]    ConsumerGroupName of string
         | [<AltCommandLine "-r"; Unique>]       MaxReadAhead of int
         | [<AltCommandLine "-w"; Unique>]       MaxWriters of int
-        | [<AltCommandLine "-V"; Unique>]       Verbose
-        | [<AltCommandLine "-C"; Unique>]       CfpVerbose
-        | [<CliPrefix(CliPrefix.None); Unique(*ExactlyOnce is not supported*); Last>] Cosmos of ParseResults<CosmosSourceParameters>
+        | [<CliPrefix(CliPrefix.None); Last>]   Cosmos of ParseResults<CosmosParameters>
         interface IArgParserTemplate with
             member a.Usage = a |> function
-                | ConsumerGroupName _ ->        "Projector consumer group name."
-                | MaxReadAhead _ ->             "maximum number of batches to let processing get ahead of completion. Default: 16."
-                | MaxWriters _ ->               "maximum number of concurrent streams on which to process at any time. Default: 8."
                 | Verbose ->                    "request Verbose Logging. Default: off."
-                | CfpVerbose ->                 "request Verbose Change Feed Processor Logging. Default: off."
+                | ConsumerGroupName _ ->        "Projector consumer group name."
+                | MaxReadAhead _ ->             "maximum number of batches to let processing get ahead of completion. Default: 2."
+                | MaxWriters _ ->               "maximum number of concurrent streams on which to process at any time. Default: 8."
                 | Cosmos _ ->                   "specify CosmosDB input parameters."
     and Arguments(c : Configuration, a : ParseResults<Parameters>) =
+        let maxReadAhead =                      a.GetResult(MaxReadAhead, 2)
+        let maxConcurrentProcessors =           a.GetResult(MaxWriters, 8)
+        member val Verbose =                    a.Contains Verbose
         member val ConsumerGroupName =          a.GetResult ConsumerGroupName
-        member val CfpVerbose =                 a.Contains CfpVerbose
-        member val MaxReadAhead =               a.GetResult(MaxReadAhead, 16)
-        member val MaxConcurrentStreams =       a.GetResult(MaxWriters, 8)
-        member val Verbose =                    a.Contains Parameters.Verbose
+        member x.ProcessorParams() =
+            Log.Information("Projecting... {processorName}, reading {maxReadAhead} ahead, {dop} writers",
+                            x.ConsumerGroupName, maxReadAhead, maxConcurrentProcessors)
+            (x.ConsumerGroupName, maxReadAhead, maxConcurrentProcessors)
         member val StatsInterval =              TimeSpan.FromMinutes 1.
-        member val StateInterval =              TimeSpan.FromMinutes 5.
-        member val Source : CosmosSourceArguments =
-            match a.TryGetSubCommand() with
-            | Some (Parameters.Cosmos cosmos) -> CosmosSourceArguments (c, cosmos)
-            | _ -> raise (MissingArg "Must specify cosmos for Src")
-        member x.SourceParams() =
-            let srcC = x.Source
-            let leases = srcC.ConnectLeases()
-            Log.Information("Reacting... {dop} writers, max {maxReadAhead} batches read ahead", x.MaxConcurrentStreams, x.MaxReadAhead)
-            Log.Information("Monitoring Group {processorName} in Database {database} Container {container} with maximum document count limited to {maxDocuments}",
-                x.ConsumerGroupName, srcC.DatabaseId, srcC.ContainerId, Option.toNullable srcC.MaxDocuments)
-            if srcC.FromTail then Log.Warning("(If new projector group) Skipping projection of all existing events.")
-            Log.Information("ChangeFeed Lag stats interval {lagS:n0}s", let f = srcC.LagFrequency in f.TotalSeconds)
-            let monitored = srcC.ConnectMonitored()
-            (srcC, monitored, leases, x.ConsumerGroupName, srcC.FromTail, srcC.MaxDocuments, srcC.LagFrequency)
-    and [<NoEquality; NoComparison>] CosmosSourceParameters =
-        | [<AltCommandLine "-Z"; Unique>]       FromTail
-        | [<AltCommandLine "-md"; Unique>]      MaxDocuments of int
-        | [<AltCommandLine "-l"; Unique>]       LagFreqM of float
-        | [<AltCommandLine "-a"; Unique>]       LeaseContainer of string
-
+        member val StateInterval =              TimeSpan.FromMinutes 2.
+        member val Cosmos =                     CosmosArguments (c, a.GetResult Cosmos)
+    and [<NoEquality; NoComparison>] CosmosParameters =
         | [<AltCommandLine "-m">]               ConnectionMode of Microsoft.Azure.Cosmos.ConnectionMode
         | [<AltCommandLine "-s">]               Connection of string
         | [<AltCommandLine "-d">]               Database of string
-        | [<AltCommandLine "-c"; Unique>]       Container of string // Actually Mandatory, but stating that is not supported
+        | [<AltCommandLine "-c">]               Container of string
         | [<AltCommandLine "-o">]               Timeout of float
         | [<AltCommandLine "-r">]               Retries of int
         | [<AltCommandLine "-rt">]              RetriesWaitTime of float
+
+        | [<AltCommandLine "-C"; Unique>]       CfpVerbose
+        | [<AltCommandLine "-a"; Unique>]       LeaseContainer of string
+        | [<AltCommandLine "-Z"; Unique>]       FromTail
+        | [<AltCommandLine "-md"; Unique>]      MaxDocuments of int
+        | [<AltCommandLine "-l"; Unique>]       LagFreqM of float
         interface IArgParserTemplate with
             member a.Usage = a |> function
-                | FromTail ->                   "(iff the Consumer Name is fresh) - force skip to present Position. Default: Never skip an event."
-                | MaxDocuments _ ->             "maximum item count to request from feed. Default: unlimited"
-                | LagFreqM _ ->                 "frequency (in minutes) to dump lag stats. Default: 1"
-                | LeaseContainer _ ->           "specify Container Name for Leases container. Default: `sourceContainer` + `-aux`."
-
                 | ConnectionMode _ ->           "override the connection mode. Default: Direct."
                 | Connection _ ->               "specify a connection string for a Cosmos account. (optional if environment variable EQUINOX_COSMOS_CONNECTION specified)"
-                | Database _ ->                 "specify a database name for Cosmos account. (optional if environment variable EQUINOX_COSMOS_DATABASE specified)"
-                | Container _ ->                "specify a container name within `Database`"
+                | Database _ ->                 "specify a database name for store. (optional if environment variable EQUINOX_COSMOS_DATABASE specified)"
+                | Container _ ->                "specify a container name for store. (optional if environment variable EQUINOX_COSMOS_CONTAINER specified)"
                 | Timeout _ ->                  "specify operation timeout in seconds. Default: 5."
                 | Retries _ ->                  "specify operation retries. Default: 1."
                 | RetriesWaitTime _ ->          "specify max wait-time for retry when being throttled by Cosmos in seconds. Default: 5."
-    and CosmosSourceArguments(c : Configuration, a : ParseResults<CosmosSourceParameters>) =
-        let discovery =                         a.TryGetResult CosmosSourceParameters.Connection
+
+                | CfpVerbose ->                 "request Verbose Logging from ChangeFeedProcessor. Default: off"
+                | LeaseContainer _ ->           "specify Container Name (in this [target] Database) for Leases container. Default: `SourceContainer` + `-aux`."
+                | FromTail _ ->                 "(iff the Consumer Name is fresh) - force skip to present Position. Default: Never skip an event."
+                | MaxDocuments _ ->             "maximum document count to supply for the Change Feed query. Default: use response size limit"
+                | LagFreqM _ ->                 "specify frequency (minutes) to dump lag stats. Default: 1"
+    and CosmosArguments(c : Configuration, a : ParseResults<CosmosParameters>) =
+        let discovery =                         a.TryGetResult CosmosParameters.Connection
                                                 |> Option.defaultWith (fun () -> c.CosmosConnection)
                                                 |> Equinox.CosmosStore.Discovery.ConnectionString
-        let mode =                              a.TryGetResult CosmosSourceParameters.ConnectionMode
-        let timeout =                           a.GetResult(CosmosSourceParameters.Timeout, 5.) |> TimeSpan.FromSeconds
-        let retries =                           a.GetResult(CosmosSourceParameters.Retries, 1)
-        let maxRetryWaitTime =                  a.GetResult(CosmosSourceParameters.RetriesWaitTime, 5.) |> TimeSpan.FromSeconds
+        let mode =                              a.TryGetResult ConnectionMode
+        let timeout =                           a.GetResult(Timeout, 5.) |> TimeSpan.FromSeconds
+        let retries =                           a.GetResult(Retries, 1)
+        let maxRetryWaitTime =                  a.GetResult(RetriesWaitTime, 5.) |> TimeSpan.FromSeconds
         let connector =                         Equinox.CosmosStore.CosmosStoreConnector(discovery, timeout, retries, maxRetryWaitTime, ?mode = mode)
-        member val DatabaseId =                 a.TryGetResult CosmosSourceParameters.Database |> Option.defaultWith (fun () -> c.CosmosDatabase)
-        member val ContainerId =                a.GetResult CosmosSourceParameters.Container
+        let database =                          a.TryGetResult Database |> Option.defaultWith (fun () -> c.CosmosDatabase)
+        let containerId =                       a.GetResult Container
 
-        member val FromTail =                   a.Contains CosmosSourceParameters.FromTail
-        member val MaxDocuments =               a.TryGetResult MaxDocuments
-        member val LagFrequency : TimeSpan =    a.GetResult(LagFreqM, 1.) |> TimeSpan.FromMinutes
-        member val private LeaseContainerId =   a.TryGetResult CosmosSourceParameters.LeaseContainer
-
-        member private x.ConnectLeases containerId = connector.CreateUninitialized(x.DatabaseId, containerId)
-        member x.ConnectLeases() =              match x.LeaseContainerId with
-                                                | None ->    x.ConnectLeases(x.ContainerId + "-aux")
+        let leaseContainerId =                  a.TryGetResult LeaseContainer
+        let fromTail =                          a.Contains FromTail
+        let maxDocuments =                      a.TryGetResult MaxDocuments
+        let lagFrequency =                      a.GetResult(LagFreqM, 1.) |> TimeSpan.FromMinutes
+        member _.CfpVerbose =                   a.Contains CfpVerbose
+        member _.ConnectLeases containerId =    connector.CreateUninitialized(database, containerId)
+        member private x.ConnectLeases() =      match leaseContainerId with
+                                                | None ->    x.ConnectLeases(containerId + "-aux")
                                                 | Some sc -> x.ConnectLeases(sc)
-        member x.ConnectMonitored() =           connector.ConnectMonitored(x.DatabaseId, x.ContainerId)
-        member x.Connect() =                    connector.ConnectStore("Main", x.DatabaseId, x.ContainerId)
+        member x.MonitoringParams() =
+            let leases : Microsoft.Azure.Cosmos.Container = x.ConnectLeases()
+            Log.Information("Monitoring Database {database} Container {container} with maximum document count limited to {maxDocuments}",
+                leases.Database.Id, leases.Id, Option.toNullable maxDocuments)
+            if fromTail then Log.Warning("(If new projector group) Skipping projection of all existing events.")
+            let lagFreq = lagFrequency in Log.Information("ChangeFeed Lag stats interval {lagS:n0}s", lagFreq.TotalSeconds)
+            (leases, fromTail, maxDocuments, lagFreq)
+        member x.ConnectStoreAndMonitored() =   connector.ConnectStoreAndMonitored(database, containerId)
 
     /// Parse the commandline; can throw exceptions in response to missing arguments and/or `-h`/`--help` args
     let parse tryGetConfigValue argv : Arguments =
@@ -117,22 +113,23 @@ module Args =
 let [<Literal>] AppName = "ReactorTemplate"
 
 let build (args : Args.Arguments) =
-    let source, monitored, leases, processorName, startFromTail, maxDocuments, lagFrequency = args.SourceParams()
+    let consumerGroupName, maxReadAhead, maxConcurrentStreams = args.ProcessorParams()
+    let client, monitored = args.Cosmos.ConnectStoreAndMonitored()
+    let sink =
+        let handle =
+            let context = client |> CosmosStoreContext.create
+            let cache = Equinox.Cache(AppName, sizeMb=10)
+            let srcService = Todo.Cosmos.create (context, cache)
+            let dstService = TodoSummary.Cosmos.create (context, cache)
+            Reactor.handle srcService dstService
+        let stats = Reactor.Stats(Log.Logger, args.StatsInterval, args.StateInterval)
+        Propulsion.Streams.StreamsProjector.Start(Log.Logger, maxReadAhead, maxConcurrentStreams, handle, stats, args.StatsInterval)
 
-    let context = source.Connect() |> Async.RunSynchronously |> CosmosStoreContext.create
-    let cache = Equinox.Cache(AppName, sizeMb=10)
-    let srcService = Todo.Cosmos.create (context, cache)
-    let dstService = TodoSummary.Cosmos.create (context, cache)
-    let handle = Reactor.handle srcService dstService
-    let stats = Reactor.Stats(Log.Logger, args.StatsInterval, args.StateInterval)
-    let sink = Propulsion.Streams.StreamsProjector.Start(Log.Logger, args.MaxReadAhead, args.MaxConcurrentStreams, handle, stats, args.StatsInterval)
-
-    let mapToStreamItems docs : Propulsion.Streams.StreamEvent<_> seq =
-        docs
-        |> Seq.collect Propulsion.CosmosStore.EquinoxNewtonsoftParser.enumStreamEvents
     let pipeline =
-        use observer = Propulsion.CosmosStore.CosmosStoreSource.CreateObserver(Log.Logger, sink.StartIngester, mapToStreamItems)
-        Propulsion.CosmosStore.CosmosStoreSource.Run(Log.Logger, monitored, leases, processorName, observer, startFromTail, ?maxDocuments=maxDocuments, lagReportFreq=lagFrequency)
+        let parseFeedDoc : _ -> Propulsion.Streams.StreamEvent<_> seq = Seq.collect Propulsion.CosmosStore.EquinoxNewtonsoftParser.enumStreamEvents
+        use observer = Propulsion.CosmosStore.CosmosStoreSource.CreateObserver(Log.Logger, sink.StartIngester, parseFeedDoc)
+        let leases, startFromTail, maxDocuments, lagFrequency = args.Cosmos.MonitoringParams()
+        Propulsion.CosmosStore.CosmosStoreSource.Run(Log.Logger, monitored, leases, consumerGroupName, observer, startFromTail, ?maxDocuments=maxDocuments, lagReportFreq=lagFrequency)
     sink, pipeline
 
 let run args = async {
@@ -144,11 +141,10 @@ let run args = async {
 [<EntryPoint>]
 let main argv =
     try let args = Args.parse EnvVar.tryGet argv
-        try Log.Logger <- LoggerConfiguration().Configure(verbose=args.Verbose, changeFeedProcessorVerbose=args.CfpVerbose).CreateLogger()
-            try run args |> Async.RunSynchronously
-                0
+        try Log.Logger <- LoggerConfiguration().Configure(args.Verbose).AsChangeFeedProcessor(AppName, args.ConsumerGroupName, args.Cosmos.CfpVerbose).Default()
+            try run args |> Async.RunSynchronously; 0
             with e when not (e :? MissingArg) -> Log.Fatal(e, "Exiting"); 2
         finally Log.CloseAndFlush()
     with MissingArg msg -> eprintfn "%s" msg; 1
         | :? Argu.ArguParseException as e -> eprintfn "%s" e.Message; 1
-        | e -> eprintf "Exception %s" e.Message; 1
+        | e -> eprintfn "Exception %s" e.Message; 1

--- a/propulsion-cosmos-reactor/Program.fs
+++ b/propulsion-cosmos-reactor/Program.fs
@@ -132,9 +132,9 @@ module Args =
     and CosmosArguments(c : Configuration, a : ParseResults<CosmosParameters>) =
         let discovery =                     a.TryGetResult Connection |> Option.defaultWith (fun () -> c.CosmosConnection) |> Equinox.CosmosStore.Discovery.ConnectionString
         let mode =                          a.TryGetResult ConnectionMode
-        let timeout =                       a.GetResult(Timeout, 30.) |> TimeSpan.FromSeconds
-        let retries =                       a.GetResult(Retries, 9)
-        let maxRetryWaitTime =              a.GetResult(RetriesWaitTime, 30.) |> TimeSpan.FromSeconds
+        let timeout =                       a.GetResult(Timeout, 5.) |> TimeSpan.FromSeconds
+        let retries =                       a.GetResult(Retries, 1)
+        let maxRetryWaitTime =              a.GetResult(RetriesWaitTime, 5.) |> TimeSpan.FromSeconds
         let connector =                     Equinox.CosmosStore.CosmosStoreConnector(discovery, timeout, retries, maxRetryWaitTime, ?mode=mode)
         member val DatabaseId =             a.TryGetResult Database |> Option.defaultWith (fun () -> c.CosmosDatabase)
         member val ContainerId =            a.TryGetResult Container |> Option.defaultWith (fun () -> c.CosmosContainer)

--- a/propulsion-cosmos-reactor/Program.fs
+++ b/propulsion-cosmos-reactor/Program.fs
@@ -48,16 +48,16 @@ module Args =
             | Some (Parameters.Cosmos cosmos) -> CosmosSourceArguments (c, cosmos)
             | _ -> raise (MissingArg "Must specify cosmos for Src")
         member x.SourceParams() =
-                let srcC = x.Source
-                let leases = srcC.ConnectLeases()
-                Log.Information("Reacting... {dop} writers, max {maxReadAhead} batches read ahead", x.MaxConcurrentStreams, x.MaxReadAhead)
-                Log.Information("Monitoring Group {processorName} in Database {db} Container {container} with maximum document count limited to {maxDocuments}",
-                    x.ConsumerGroupName, srcC.DatabaseId, srcC.ContainerId, Option.toNullable srcC.MaxDocuments)
-                if srcC.FromTail then Log.Warning("(If new projector group) Skipping projection of all existing events.")
-                srcC.LagFrequency |> Option.iter<TimeSpan> (fun i -> Log.Information("ChangeFeed Lag stats interval {lagS:n0}s", i.TotalSeconds))
-                let storeClient, monitored = srcC.ConnectStoreAndMonitored()
-                let context = CosmosStoreContext.create storeClient
-                (srcC, context, monitored, leases, x.ConsumerGroupName, srcC.FromTail, srcC.MaxDocuments, srcC.LagFrequency)
+            let srcC = x.Source
+            let leases = srcC.ConnectLeases()
+            Log.Information("Reacting... {dop} writers, max {maxReadAhead} batches read ahead", x.MaxConcurrentStreams, x.MaxReadAhead)
+            Log.Information("Monitoring Group {processorName} in Database {db} Container {container} with maximum document count limited to {maxDocuments}",
+                x.ConsumerGroupName, srcC.DatabaseId, srcC.ContainerId, Option.toNullable srcC.MaxDocuments)
+            if srcC.FromTail then Log.Warning("(If new projector group) Skipping projection of all existing events.")
+            srcC.LagFrequency |> Option.iter<TimeSpan> (fun i -> Log.Information("ChangeFeed Lag stats interval {lagS:n0}s", i.TotalSeconds))
+            let storeClient, monitored = srcC.ConnectStoreAndMonitored()
+            let context = CosmosStoreContext.create storeClient
+            (srcC, context, monitored, leases, x.ConsumerGroupName, srcC.FromTail, srcC.MaxDocuments, srcC.LagFrequency)
     and [<NoEquality; NoComparison>] CosmosSourceParameters =
         | [<AltCommandLine "-Z"; Unique>]       FromTail
         | [<AltCommandLine "-md"; Unique>]      MaxDocuments of int

--- a/propulsion-cosmos-reactor/Program.fs
+++ b/propulsion-cosmos-reactor/Program.fs
@@ -51,7 +51,7 @@ module Args =
             let srcC = x.Source
             let leases = srcC.ConnectLeases()
             Log.Information("Reacting... {dop} writers, max {maxReadAhead} batches read ahead", x.MaxConcurrentStreams, x.MaxReadAhead)
-            Log.Information("Monitoring Group {processorName} in Database {db} Container {container} with maximum document count limited to {maxDocuments}",
+            Log.Information("Monitoring Group {processorName} in Database {database} Container {container} with maximum document count limited to {maxDocuments}",
                 x.ConsumerGroupName, srcC.DatabaseId, srcC.ContainerId, Option.toNullable srcC.MaxDocuments)
             if srcC.FromTail then Log.Warning("(If new projector group) Skipping projection of all existing events.")
             srcC.LagFrequency |> Option.iter<TimeSpan> (fun i -> Log.Information("ChangeFeed Lag stats interval {lagS:n0}s", i.TotalSeconds))

--- a/propulsion-cosmos-reactor/Program.fs
+++ b/propulsion-cosmos-reactor/Program.fs
@@ -54,7 +54,7 @@ module Args =
             Log.Information("Monitoring Group {processorName} in Database {database} Container {container} with maximum document count limited to {maxDocuments}",
                 x.ConsumerGroupName, srcC.DatabaseId, srcC.ContainerId, Option.toNullable srcC.MaxDocuments)
             if srcC.FromTail then Log.Warning("(If new projector group) Skipping projection of all existing events.")
-            srcC.LagFrequency |> Option.iter<TimeSpan> (fun i -> Log.Information("ChangeFeed Lag stats interval {lagS:n0}s", i.TotalSeconds))
+            Log.Information("ChangeFeed Lag stats interval {lagS:n0}s", let f = srcC.LagFrequency in f.TotalSeconds)
             let monitored = srcC.ConnectMonitored()
             (srcC, monitored, leases, x.ConsumerGroupName, srcC.FromTail, srcC.MaxDocuments, srcC.LagFrequency)
     and [<NoEquality; NoComparison>] CosmosSourceParameters =
@@ -74,7 +74,7 @@ module Args =
             member a.Usage = a |> function
                 | FromTail ->                   "(iff the Consumer Name is fresh) - force skip to present Position. Default: Never skip an event."
                 | MaxDocuments _ ->             "maximum item count to request from feed. Default: unlimited"
-                | LagFreqM _ ->                 "frequency (in minutes) to dump lag stats. Default: off"
+                | LagFreqM _ ->                 "frequency (in minutes) to dump lag stats. Default: 1"
                 | LeaseContainer _ ->           "specify Container Name for Leases container. Default: `sourceContainer` + `-aux`."
 
                 | ConnectionMode _ ->           "override the connection mode. Default: Direct."
@@ -98,7 +98,7 @@ module Args =
 
         member val FromTail =                   a.Contains CosmosSourceParameters.FromTail
         member val MaxDocuments =               a.TryGetResult MaxDocuments
-        member val LagFrequency =               a.TryGetResult LagFreqM |> Option.map TimeSpan.FromMinutes
+        member val LagFrequency : TimeSpan =    a.GetResult(LagFreqM, 1.) |> TimeSpan.FromMinutes
         member val private LeaseContainerId =   a.TryGetResult CosmosSourceParameters.LeaseContainer
 
         member private x.ConnectLeases containerId = connector.CreateUninitialized(x.DatabaseId, containerId)
@@ -132,7 +132,7 @@ let build (args : Args.Arguments) =
         |> Seq.collect Propulsion.CosmosStore.EquinoxNewtonsoftParser.enumStreamEvents
     let pipeline =
         use observer = Propulsion.CosmosStore.CosmosStoreSource.CreateObserver(Log.Logger, sink.StartIngester, mapToStreamItems)
-        Propulsion.CosmosStore.CosmosStoreSource.Run(Log.Logger, monitored, leases, processorName, observer, startFromTail, ?maxDocuments=maxDocuments, ?lagReportFreq=lagFrequency)
+        Propulsion.CosmosStore.CosmosStoreSource.Run(Log.Logger, monitored, leases, processorName, observer, startFromTail, ?maxDocuments=maxDocuments, lagReportFreq=lagFrequency)
     sink, pipeline
 
 let run args = async {

--- a/propulsion-cosmos-reactor/Program.fs
+++ b/propulsion-cosmos-reactor/Program.fs
@@ -12,37 +12,37 @@ type Configuration(tryGet) =
         | Some value -> value
         | None -> raise (MissingArg (sprintf "Missing Argument/Environment Variable %s" key))
 
-    member _.CosmosConnection =             get "EQUINOX_COSMOS_CONNECTION"
-    member _.CosmosDatabase =               get "EQUINOX_COSMOS_DATABASE"
-    member _.CosmosContainer =              get "EQUINOX_COSMOS_CONTAINER"
+    member _.CosmosConnection =                 get "EQUINOX_COSMOS_CONNECTION"
+    member _.CosmosDatabase =                   get "EQUINOX_COSMOS_DATABASE"
+    member _.CosmosContainer =                  get "EQUINOX_COSMOS_CONTAINER"
 
 module Args =
 
     open Argu
     [<NoEquality; NoComparison>]
     type Parameters =
-        | [<AltCommandLine "-g"; Mandatory>] ConsumerGroupName of string
-        | [<AltCommandLine "-r"; Unique>]   MaxReadAhead of int
-        | [<AltCommandLine "-w"; Unique>]   MaxWriters of int
-        | [<AltCommandLine "-V"; Unique>]   Verbose
-        | [<AltCommandLine "-C"; Unique>]   CfpVerbose
+        | [<AltCommandLine "-g"; Mandatory>]    ConsumerGroupName of string
+        | [<AltCommandLine "-r"; Unique>]       MaxReadAhead of int
+        | [<AltCommandLine "-w"; Unique>]       MaxWriters of int
+        | [<AltCommandLine "-V"; Unique>]       Verbose
+        | [<AltCommandLine "-C"; Unique>]       CfpVerbose
         | [<CliPrefix(CliPrefix.None); Unique(*ExactlyOnce is not supported*); Last>] Cosmos of ParseResults<CosmosSourceParameters>
         interface IArgParserTemplate with
             member a.Usage = a |> function
-                | ConsumerGroupName _ ->    "Projector consumer group name."
-                | MaxReadAhead _ ->         "maximum number of batches to let processing get ahead of completion. Default: 16."
-                | MaxWriters _ ->           "maximum number of concurrent streams on which to process at any time. Default: 8."
-                | Verbose ->                "request Verbose Logging. Default: off."
-                | CfpVerbose ->             "request Verbose Change Feed Processor Logging. Default: off."
-                | Cosmos _ ->               "specify CosmosDB input parameters."
+                | ConsumerGroupName _ ->        "Projector consumer group name."
+                | MaxReadAhead _ ->             "maximum number of batches to let processing get ahead of completion. Default: 16."
+                | MaxWriters _ ->               "maximum number of concurrent streams on which to process at any time. Default: 8."
+                | Verbose ->                    "request Verbose Logging. Default: off."
+                | CfpVerbose ->                 "request Verbose Change Feed Processor Logging. Default: off."
+                | Cosmos _ ->                   "specify CosmosDB input parameters."
     and Arguments(c : Configuration, a : ParseResults<Parameters>) =
-        member val ConsumerGroupName =      a.GetResult ConsumerGroupName
-        member val CfpVerbose =             a.Contains CfpVerbose
-        member val MaxReadAhead =           a.GetResult(MaxReadAhead, 16)
-        member val MaxConcurrentStreams =   a.GetResult(MaxWriters, 8)
-        member val Verbose =                a.Contains Parameters.Verbose
-        member val StatsInterval =          TimeSpan.FromMinutes 1.
-        member val StateInterval =          TimeSpan.FromMinutes 5.
+        member val ConsumerGroupName =          a.GetResult ConsumerGroupName
+        member val CfpVerbose =                 a.Contains CfpVerbose
+        member val MaxReadAhead =               a.GetResult(MaxReadAhead, 16)
+        member val MaxConcurrentStreams =       a.GetResult(MaxWriters, 8)
+        member val Verbose =                    a.Contains Parameters.Verbose
+        member val StatsInterval =              TimeSpan.FromMinutes 1.
+        member val StateInterval =              TimeSpan.FromMinutes 5.
         member val Source : CosmosSourceArguments =
             match a.TryGetSubCommand() with
             | Some (Parameters.Cosmos cosmos) -> CosmosSourceArguments (c, cosmos)
@@ -59,86 +59,86 @@ module Args =
                 let context = CosmosStoreContext.create storeClient
                 (srcC, context, monitored, leases, x.ConsumerGroupName, srcC.FromTail, srcC.MaxDocuments, srcC.LagFrequency)
     and [<NoEquality; NoComparison>] CosmosSourceParameters =
-        | [<AltCommandLine "-Z"; Unique>]   FromTail
-        | [<AltCommandLine "-md"; Unique>]  MaxDocuments of int
-        | [<AltCommandLine "-l"; Unique>]   LagFreqM of float
-        | [<AltCommandLine "-a"; Unique>]   LeaseContainer of string
+        | [<AltCommandLine "-Z"; Unique>]       FromTail
+        | [<AltCommandLine "-md"; Unique>]      MaxDocuments of int
+        | [<AltCommandLine "-l"; Unique>]       LagFreqM of float
+        | [<AltCommandLine "-a"; Unique>]       LeaseContainer of string
 
-        | [<AltCommandLine "-m">]           ConnectionMode of Microsoft.Azure.Cosmos.ConnectionMode
-        | [<AltCommandLine "-s">]           Connection of string
-        | [<AltCommandLine "-d">]           Database of string
-        | [<AltCommandLine "-c"; Unique>]   Container of string // Actually Mandatory, but stating that is not supported
-        | [<AltCommandLine "-o">]           Timeout of float
-        | [<AltCommandLine "-r">]           Retries of int
-        | [<AltCommandLine "-rt">]          RetriesWaitTime of float
+        | [<AltCommandLine "-m">]               ConnectionMode of Microsoft.Azure.Cosmos.ConnectionMode
+        | [<AltCommandLine "-s">]               Connection of string
+        | [<AltCommandLine "-d">]               Database of string
+        | [<AltCommandLine "-c"; Unique>]       Container of string // Actually Mandatory, but stating that is not supported
+        | [<AltCommandLine "-o">]               Timeout of float
+        | [<AltCommandLine "-r">]               Retries of int
+        | [<AltCommandLine "-rt">]              RetriesWaitTime of float
 
         | [<CliPrefix(CliPrefix.None); Unique(*ExactlyOnce is not supported*); Last>] Cosmos of ParseResults<CosmosParameters>
         interface IArgParserTemplate with
             member a.Usage = a |> function
-                | FromTail ->               "(iff the Consumer Name is fresh) - force skip to present Position. Default: Never skip an event."
-                | MaxDocuments _ ->         "maximum item count to request from feed. Default: unlimited"
-                | LagFreqM _ ->             "frequency (in minutes) to dump lag stats. Default: off"
-                | LeaseContainer _ ->       "specify Container Name for Leases container. Default: `sourceContainer` + `-aux`."
+                | FromTail ->                   "(iff the Consumer Name is fresh) - force skip to present Position. Default: Never skip an event."
+                | MaxDocuments _ ->             "maximum item count to request from feed. Default: unlimited"
+                | LagFreqM _ ->                 "frequency (in minutes) to dump lag stats. Default: off"
+                | LeaseContainer _ ->           "specify Container Name for Leases container. Default: `sourceContainer` + `-aux`."
 
-                | ConnectionMode _ ->       "override the connection mode. Default: Direct."
-                | Connection _ ->           "specify a connection string for a Cosmos account. (optional if environment variable EQUINOX_COSMOS_CONNECTION specified)"
-                | Database _ ->             "specify a database name for Cosmos account. (optional if environment variable EQUINOX_COSMOS_DATABASE specified)"
-                | Container _ ->            "specify a container name within `Database`"
-                | Timeout _ ->              "specify operation timeout in seconds. Default: 5."
-                | Retries _ ->              "specify operation retries. Default: 1."
-                | RetriesWaitTime _ ->      "specify max wait-time for retry when being throttled by Cosmos in seconds. Default: 5."
+                | ConnectionMode _ ->           "override the connection mode. Default: Direct."
+                | Connection _ ->               "specify a connection string for a Cosmos account. (optional if environment variable EQUINOX_COSMOS_CONNECTION specified)"
+                | Database _ ->                 "specify a database name for Cosmos account. (optional if environment variable EQUINOX_COSMOS_DATABASE specified)"
+                | Container _ ->                "specify a container name within `Database`"
+                | Timeout _ ->                  "specify operation timeout in seconds. Default: 5."
+                | Retries _ ->                  "specify operation retries. Default: 1."
+                | RetriesWaitTime _ ->          "specify max wait-time for retry when being throttled by Cosmos in seconds. Default: 5."
 
-                | Cosmos _ ->               "CosmosDb Sink parameters."
+                | Cosmos _ ->                   "CosmosDb Sink parameters."
     and CosmosSourceArguments(c : Configuration, a : ParseResults<CosmosSourceParameters>) =
-        let discovery =                     a.TryGetResult CosmosSourceParameters.Connection |> Option.defaultWith (fun () -> c.CosmosConnection) |> Equinox.CosmosStore.Discovery.ConnectionString
-        let mode =                          a.TryGetResult CosmosSourceParameters.ConnectionMode
-        let timeout =                       a.GetResult(CosmosSourceParameters.Timeout, 5.) |> TimeSpan.FromSeconds
-        let retries =                       a.GetResult(CosmosSourceParameters.Retries, 1)
-        let maxRetryWaitTime =              a.GetResult(CosmosSourceParameters.RetriesWaitTime, 5.) |> TimeSpan.FromSeconds
-        let connector =                     Equinox.CosmosStore.CosmosStoreConnector(discovery, timeout, retries, maxRetryWaitTime, ?mode = mode)
-        member val DatabaseId =             a.TryGetResult CosmosSourceParameters.Database |> Option.defaultWith (fun () -> c.CosmosDatabase)
-        member val ContainerId =            a.GetResult CosmosSourceParameters.Container
+        let discovery =                         a.TryGetResult CosmosSourceParameters.Connection |> Option.defaultWith (fun () -> c.CosmosConnection) |> Equinox.CosmosStore.Discovery.ConnectionString
+        let mode =                              a.TryGetResult CosmosSourceParameters.ConnectionMode
+        let timeout =                           a.GetResult(CosmosSourceParameters.Timeout, 5.) |> TimeSpan.FromSeconds
+        let retries =                           a.GetResult(CosmosSourceParameters.Retries, 1)
+        let maxRetryWaitTime =                  a.GetResult(CosmosSourceParameters.RetriesWaitTime, 5.) |> TimeSpan.FromSeconds
+        let connector =                         Equinox.CosmosStore.CosmosStoreConnector(discovery, timeout, retries, maxRetryWaitTime, ?mode = mode)
+        member val DatabaseId =                 a.TryGetResult CosmosSourceParameters.Database |> Option.defaultWith (fun () -> c.CosmosDatabase)
+        member val ContainerId =                a.GetResult CosmosSourceParameters.Container
 
-        member val FromTail =               a.Contains CosmosSourceParameters.FromTail
-        member val MaxDocuments =           a.TryGetResult MaxDocuments
-        member val LagFrequency =           a.TryGetResult LagFreqM |> Option.map TimeSpan.FromMinutes
-        member val private LeaseContainerId = a.TryGetResult CosmosSourceParameters.LeaseContainer
+        member val FromTail =                   a.Contains CosmosSourceParameters.FromTail
+        member val MaxDocuments =               a.TryGetResult MaxDocuments
+        member val LagFrequency =               a.TryGetResult LagFreqM |> Option.map TimeSpan.FromMinutes
+        member val private LeaseContainerId =   a.TryGetResult CosmosSourceParameters.LeaseContainer
         member private x.ConnectLeases containerId = connector.CreateUninitialized(x.DatabaseId, containerId)
-        member x.ConnectLeases() =          match x.LeaseContainerId with
-                                            | None ->    x.ConnectLeases(x.ContainerId + "-aux")
-                                            | Some sc -> x.ConnectLeases(sc)
-        member x.ConnectStoreAndMonitored() = connector.ConnectStoreAndMonitored(x.DatabaseId, x.ContainerId)
+        member x.ConnectLeases() =              match x.LeaseContainerId with
+                                                | None ->    x.ConnectLeases(x.ContainerId + "-aux")
+                                                | Some sc -> x.ConnectLeases(sc)
+        member x.ConnectStoreAndMonitored() =   connector.ConnectStoreAndMonitored(x.DatabaseId, x.ContainerId)
         member val Cosmos =
             match a.TryGetSubCommand() with
             | Some (CosmosSourceParameters.Cosmos cosmos) -> CosmosArguments (c, cosmos)
             | _ -> raise (MissingArg "Must specify cosmos details")
     and [<NoEquality; NoComparison>] CosmosParameters =
-        | [<AltCommandLine "-s">]           Connection of string
-        | [<AltCommandLine "-m">]           ConnectionMode of Microsoft.Azure.Cosmos.ConnectionMode
-        | [<AltCommandLine "-d">]           Database of string
-        | [<AltCommandLine "-c">]           Container of string
-        | [<AltCommandLine "-o">]           Timeout of float
-        | [<AltCommandLine "-r">]           Retries of int
-        | [<AltCommandLine "-rt">]          RetriesWaitTime of float
+        | [<AltCommandLine "-s">]               Connection of string
+        | [<AltCommandLine "-m">]               ConnectionMode of Microsoft.Azure.Cosmos.ConnectionMode
+        | [<AltCommandLine "-d">]               Database of string
+        | [<AltCommandLine "-c">]               Container of string
+        | [<AltCommandLine "-o">]               Timeout of float
+        | [<AltCommandLine "-r">]               Retries of int
+        | [<AltCommandLine "-rt">]              RetriesWaitTime of float
         interface IArgParserTemplate with
             member a.Usage = a |> function
-                | ConnectionMode _ ->       "override the connection mode. Default: Direct."
-                | Connection _ ->           "specify a connection string for a Cosmos account. (optional if environment variable EQUINOX_COSMOS_CONNECTION specified)"
-                | Database _ ->             "specify a database name for Cosmos store. (optional if environment variable EQUINOX_COSMOS_DATABASE specified)"
-                | Container _ ->            "specify a container name for Cosmos store. (optional if environment variable EQUINOX_COSMOS_CONTAINER specified)"
-                | Timeout _ ->              "specify operation timeout in seconds. Default: 5."
-                | Retries _ ->              "specify operation retries. Default: 1."
-                | RetriesWaitTime _ ->      "specify max wait-time for retry when being throttled by Cosmos in seconds. Default: 5."
+                | ConnectionMode _ ->           "override the connection mode. Default: Direct."
+                | Connection _ ->               "specify a connection string for a Cosmos account. (optional if environment variable EQUINOX_COSMOS_CONNECTION specified)"
+                | Database _ ->                 "specify a database name for Cosmos store. (optional if environment variable EQUINOX_COSMOS_DATABASE specified)"
+                | Container _ ->                "specify a container name for Cosmos store. (optional if environment variable EQUINOX_COSMOS_CONTAINER specified)"
+                | Timeout _ ->                  "specify operation timeout in seconds. Default: 5."
+                | Retries _ ->                  "specify operation retries. Default: 1."
+                | RetriesWaitTime _ ->          "specify max wait-time for retry when being throttled by Cosmos in seconds. Default: 5."
     and CosmosArguments(c : Configuration, a : ParseResults<CosmosParameters>) =
-        let discovery =                     a.TryGetResult Connection |> Option.defaultWith (fun () -> c.CosmosConnection) |> Equinox.CosmosStore.Discovery.ConnectionString
-        let mode =                          a.TryGetResult ConnectionMode
-        let timeout =                       a.GetResult(Timeout, 5.) |> TimeSpan.FromSeconds
-        let retries =                       a.GetResult(Retries, 1)
-        let maxRetryWaitTime =              a.GetResult(RetriesWaitTime, 5.) |> TimeSpan.FromSeconds
-        let connector =                     Equinox.CosmosStore.CosmosStoreConnector(discovery, timeout, retries, maxRetryWaitTime, ?mode=mode)
-        member val DatabaseId =             a.TryGetResult Database |> Option.defaultWith (fun () -> c.CosmosDatabase)
-        member val ContainerId =            a.TryGetResult Container |> Option.defaultWith (fun () -> c.CosmosContainer)
-        member x.Connect() =                connector.ConnectStore("Main", x.DatabaseId, x.ContainerId)
+        let discovery =                         a.TryGetResult Connection |> Option.defaultWith (fun () -> c.CosmosConnection) |> Equinox.CosmosStore.Discovery.ConnectionString
+        let mode =                              a.TryGetResult ConnectionMode
+        let timeout =                           a.GetResult(Timeout, 5.) |> TimeSpan.FromSeconds
+        let retries =                           a.GetResult(Retries, 1)
+        let maxRetryWaitTime =                  a.GetResult(RetriesWaitTime, 5.) |> TimeSpan.FromSeconds
+        let connector =                         Equinox.CosmosStore.CosmosStoreConnector(discovery, timeout, retries, maxRetryWaitTime, ?mode=mode)
+        member val DatabaseId =                 a.TryGetResult Database |> Option.defaultWith (fun () -> c.CosmosDatabase)
+        member val ContainerId =                a.TryGetResult Container |> Option.defaultWith (fun () -> c.CosmosContainer)
+        member x.Connect() =                    connector.ConnectStore("Main", x.DatabaseId, x.ContainerId)
 
     /// Parse the commandline; can throw exceptions in response to missing arguments and/or `-h`/`--help` args
     let parse tryGetConfigValue argv : Arguments =

--- a/propulsion-cosmos-reactor/Program.fs
+++ b/propulsion-cosmos-reactor/Program.fs
@@ -90,7 +90,9 @@ module Args =
 
                 | Cosmos _ ->                   "CosmosDb Sink parameters."
     and CosmosSourceArguments(c : Configuration, a : ParseResults<CosmosSourceParameters>) =
-        let discovery =                         a.TryGetResult CosmosSourceParameters.Connection |> Option.defaultWith (fun () -> c.CosmosConnection) |> Equinox.CosmosStore.Discovery.ConnectionString
+        let discovery =                         a.TryGetResult CosmosSourceParameters.Connection
+                                                |> Option.defaultWith (fun () -> c.CosmosConnection)
+                                                |> Equinox.CosmosStore.Discovery.ConnectionString
         let mode =                              a.TryGetResult CosmosSourceParameters.ConnectionMode
         let timeout =                           a.GetResult(CosmosSourceParameters.Timeout, 5.) |> TimeSpan.FromSeconds
         let retries =                           a.GetResult(CosmosSourceParameters.Retries, 1)

--- a/propulsion-cosmos-reactor/Program.fs
+++ b/propulsion-cosmos-reactor/Program.fs
@@ -160,7 +160,6 @@ let build (args : Args.Arguments) =
     let sink = Propulsion.Streams.StreamsProjector.Start(Log.Logger, args.MaxReadAhead, args.MaxConcurrentStreams, handle, stats, args.StatsInterval)
 
     let mapToStreamItems docs : Propulsion.Streams.StreamEvent<_> seq =
-        // TODO: customize parsing to events if source is not an Equinox Container
         docs
         |> Seq.collect Propulsion.CosmosStore.EquinoxNewtonsoftParser.enumStreamEvents
     let pipeline =

--- a/propulsion-cosmos-reactor/README.md
+++ b/propulsion-cosmos-reactor/README.md
@@ -27,11 +27,11 @@ This project was generated using:
         # default name is "($EQUINOX_COSMOS_CONTAINER)-aux"
         propulsion init -ru 400 cosmos
 
-3. To run an instance of the Projector from a CosmosDb ChangeFeed
+3. To run an instance of the Reactor from a CosmosDb ChangeFeed
 
-        # `-g default` defines the Projector Group identity - each id has separated state in the checkpoints store (`Sync-default` in the cited `cosmos` store)
-        # `-c $env:EQUINOX_COSMOS_CONTAINER ` specifies the source (if you have specified EQUINOX_COSMOS_* environment vars, no connection/database arguments are needed, but the monitored (source) container must be specified explicitly)
-        # `cosmos` specifies the target store for the reactions (if you have specified 3x EQUINOX_COSMOS_* environment vars, no arguments are needed)
-        dotnet run -- -g default cosmos -c $env:EQUINOX_COSMOS_CONTAINER  cosmos
-
-4. To create a Consumer, use `dotnet new proConsumer` (see README therein for details)
+        # `-g default` defines the `processorName` - each processor group name has separated state in the leases store
+        # `-c MyContainer` specifies the source Container to monitor (if you have specified EQUINOX_COSMOS_* environment
+        #   vars, no connection/database/container arguments are needed.)
+        # For this template, this same container is also used to wire up the Connection used for the Reactions processing.
+        # See the `proReactor` template for a more complex variant that lets you specify them separately.
+        dotnet run -- -g default cosmos -c MyContainer

--- a/propulsion-cosmos-reactor/README.md
+++ b/propulsion-cosmos-reactor/README.md
@@ -1,0 +1,37 @@
+# Propulsion CosmosDb ChangeFeedProcessor Reactor
+
+This project was generated using:
+
+    dotnet new -i Equinox.Templates # just once, to install/update in the local templates store
+    dotnet new proCosmosReactor # use --help to see options
+
+## Usage instructions
+
+0. establish connection strings etc. per https://github.com/jet/equinox README
+
+        $env:EQUINOX_COSMOS_CONNECTION="AccountEndpoint=https://....;AccountKey=....=;" # or use -s
+        $env:EQUINOX_COSMOS_DATABASE="equinox-test" # or use -d
+        $env:EQUINOX_COSMOS_CONTAINER="equinox-test" # or use -c
+
+1. Use the `eqx` tool to initialize a CosmosDb container
+
+        dotnet tool install -g Equinox.Tool # only needed once
+
+        # (either add environment variables as per step 0 or use -s/-d/-c to specify them)
+        # generate a cosmos container to store events in
+        eqx init -ru 400 cosmos
+
+2. We'll be operating a ChangeFeedProcessor, so use `propulsion init` to make a `-aux` container (unless there already is one)
+
+        # (either add environment variables as per step 0 or use -s/-d/-c to specify them)
+        # default name is "($EQUINOX_COSMOS_CONTAINER)-aux"
+        propulsion init -ru 400 cosmos
+
+3. To run an instance of the Projector from a CosmosDb ChangeFeed
+
+        # `-g default` defines the Projector Group identity - each id has separated state in the checkpoints store (`Sync-default` in the cited `cosmos` store)
+        # `-c $env:EQUINOX_COSMOS_CONTAINER ` specifies the source (if you have specified EQUINOX_COSMOS_* environment vars, no connection/database arguments are needed, but the monitored (source) container must be specified explicitly)
+        # `cosmos` specifies the target store for the reactions (if you have specified 3x EQUINOX_COSMOS_* environment vars, no arguments are needed)
+        dotnet run -- -g default cosmos -c $env:EQUINOX_COSMOS_CONTAINER  cosmos
+
+4. To create a Consumer, use `dotnet new proConsumer` (see README therein for details)

--- a/propulsion-cosmos-reactor/Reactor.fs
+++ b/propulsion-cosmos-reactor/Reactor.fs
@@ -1,0 +1,47 @@
+module ReactorTemplate.Reactor
+
+[<RequireQualifiedAccess>]
+type Outcome =
+    /// Handler processed the span, with counts of used vs unused known event types
+    | Ok of used : int * unused : int
+    /// Handler processed the span, but idempotency checks resulted in no writes being applied; includes count of decoded events
+    | Skipped of count : int
+    /// Handler determined the events were not relevant to its duties and performed no actions
+    /// e.g. wrong category, events that dont imply a state change
+    | NotApplicable of count : int
+
+/// Gathers stats based on the outcome of each Span processed for emission, at intervals controlled by `StreamsConsumer`
+type Stats(log, statsInterval, stateInterval) =
+    inherit Propulsion.Streams.Stats<Outcome>(log, statsInterval, stateInterval)
+
+    let mutable ok, skipped, na = 0, 0, 0
+
+    override _.HandleOk res = res |> function
+        | Outcome.Ok (used, unused) -> ok <- ok + used; skipped <- skipped + unused
+        | Outcome.Skipped count -> skipped <- skipped + count
+        | Outcome.NotApplicable count -> na <- na + count
+    override _.HandleExn(log, exn) =
+        log.Information(exn, "Unhandled")
+
+    override _.DumpStats() =
+        if ok <> 0 || skipped <> 0 || na <> 0 then
+            log.Information(" used {ok} skipped {skipped} n/a {na}", ok, skipped, na)
+            ok <- 0; skipped <- 0; na <- 0
+
+// map from external contract to internal contract defined by the aggregate
+let toSummaryEventData ( x : Contract.SummaryInfo) : TodoSummary.Events.SummaryData =
+    { items =
+        [| for x in x.items ->
+            { id = x.id; order = x.order; title = x.title; completed = x.completed } |] }
+
+let handle
+        (sourceService : Todo.Service)
+        (summaryService : TodoSummary.Service)
+        (stream, span : Propulsion.Streams.StreamSpan<_>) = async {
+    match stream, span with
+    | Todo.Events.Match (clientId, events) when events |> Seq.exists Todo.Fold.impliesStateChange ->
+        let! version', summary = sourceService.QueryWithVersion(clientId, Contract.ofState)
+        match! summaryService.TryIngest(clientId, version', toSummaryEventData summary) with
+        | true -> return Propulsion.Streams.SpanResult.OverrideWritePosition version', Outcome.Ok (1, span.events.Length - 1)
+        | false -> return Propulsion.Streams.SpanResult.OverrideWritePosition version', Outcome.Skipped span.events.Length
+    | _ -> return Propulsion.Streams.SpanResult.AllProcessed, Outcome.NotApplicable span.events.Length }

--- a/propulsion-cosmos-reactor/Reactor.fsproj
+++ b/propulsion-cosmos-reactor/Reactor.fsproj
@@ -20,6 +20,7 @@
         <PackageReference Include="Argu" Version="6.1.1" />
         <PackageReference Include="Destructurama.FSharp" Version="1.1.1-dev-00035" />
         <PackageReference Include="Microsoft.Azure.Cosmos" Version="[3.20.0-preview]" />
+        <PackageReference Include="Equinox.CosmosStore.Prometheus" Version="3.0.1" />
         <PackageReference Include="Propulsion.CosmosStore" Version="2.11.0-rc2" />
         <PackageReference Include="Serilog.Sinks.Console" Version="3.1.1" />
     </ItemGroup>

--- a/propulsion-cosmos-reactor/Reactor.fsproj
+++ b/propulsion-cosmos-reactor/Reactor.fsproj
@@ -4,7 +4,7 @@
         <OutputType>Exe</OutputType>
         <TargetFramework>netcoreapp3.1</TargetFramework>
         <WarningLevel>5</WarningLevel>
-	</PropertyGroup>
+    </PropertyGroup>
 
     <ItemGroup>
         <None Include="README.md" />
@@ -19,7 +19,8 @@
     <ItemGroup>
         <PackageReference Include="Argu" Version="6.1.1" />
         <PackageReference Include="Destructurama.FSharp" Version="1.1.1-dev-00035" />
-		<PackageReference Include="Propulsion.CosmosStore" Version="2.11.0-rc2" />
+        <PackageReference Include="Microsoft.Azure.Cosmos" Version="[3.20.0-preview]" />
+        <PackageReference Include="Propulsion.CosmosStore" Version="2.11.0-rc2" />
         <PackageReference Include="Serilog.Sinks.Console" Version="3.1.1" />
     </ItemGroup>
 </Project>

--- a/propulsion-cosmos-reactor/Reactor.fsproj
+++ b/propulsion-cosmos-reactor/Reactor.fsproj
@@ -1,0 +1,26 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <OutputType>Exe</OutputType>
+        <TargetFramework>netcoreapp3.1</TargetFramework>
+        <WarningLevel>5</WarningLevel>
+		<!--<DefineConstants>changeFeedOnly;kafka</DefineConstants>-->
+	</PropertyGroup>
+
+    <ItemGroup>
+        <None Include="README.md" />
+        <Compile Include="Infrastructure.fs" />
+        <Compile Include="Todo.fs" />
+        <Compile Include="Contract.fs" />
+        <Compile Include="TodoSummary.fs" />
+        <Compile Include="Reactor.fs" />
+        <Compile Include="Program.fs" />
+    </ItemGroup>
+
+    <ItemGroup>
+        <PackageReference Include="Argu" Version="6.1.1" />
+        <PackageReference Include="Destructurama.FSharp" Version="1.1.1-dev-00035" />
+		<PackageReference Include="Propulsion.CosmosStore" Version="2.11.0-rc2" />
+        <PackageReference Include="Serilog.Sinks.Console" Version="3.1.1" />
+    </ItemGroup>
+</Project>

--- a/propulsion-cosmos-reactor/Reactor.fsproj
+++ b/propulsion-cosmos-reactor/Reactor.fsproj
@@ -4,7 +4,6 @@
         <OutputType>Exe</OutputType>
         <TargetFramework>netcoreapp3.1</TargetFramework>
         <WarningLevel>5</WarningLevel>
-		<!--<DefineConstants>changeFeedOnly;kafka</DefineConstants>-->
 	</PropertyGroup>
 
     <ItemGroup>

--- a/propulsion-cosmos-reactor/Todo.fs
+++ b/propulsion-cosmos-reactor/Todo.fs
@@ -59,7 +59,7 @@ type Service internal (resolve : ClientId -> Equinox.Decider<Events.Event, Fold.
         // Establish the present state of the Stream, project from that (using QueryEx so we can determine the version in effect)
         decider.QueryEx(fun c -> c.Version, render c.State)
 
-let create resolveStream =
+let private create resolveStream =
     let resolve = streamName >> resolveStream >> Equinox.createDecider
     Service(resolve)
 

--- a/propulsion-cosmos-reactor/Todo.fs
+++ b/propulsion-cosmos-reactor/Todo.fs
@@ -1,0 +1,74 @@
+module ReactorTemplate.Todo
+
+let [<Literal>] Category = "Todos"
+let streamName (clientId: ClientId) = FsCodec.StreamName.create Category (ClientId.toString clientId)
+
+// NB - these types and the union case names reflect the actual storage formats and hence need to be versioned with care
+module Events =
+
+    type ItemData =     { id : int; order : int; title : string; completed : bool }
+    type DeletedData =  { id : int }
+    type ClearedData =  { nextId : int }
+    type SnapshotData = { nextId : int; items : ItemData[] }
+    type Event =
+        | Added         of ItemData
+        | Updated       of ItemData
+        | Deleted       of DeletedData
+        | Cleared       of ClearedData
+        | Snapshotted   of SnapshotData
+        interface TypeShape.UnionContract.IUnionContract
+    let codec = FsCodec.NewtonsoftJson.Codec.Create<Event>()
+    let (|Decode|) (stream, span : Propulsion.Streams.StreamSpan<_>) =
+        span.events |> Array.choose (EventCodec.tryDecode codec stream)
+    let (|MatchesCategory|_|) = function
+        | FsCodec.StreamName.CategoryAndId (Category, ClientId.Parse clientId) -> Some clientId
+        | _ -> None
+    let (|Match|_|) = function
+        | (MatchesCategory clientId, _) & (Decode events) -> Some (clientId, events)
+        | _ -> None
+
+/// Types and mapping logic used maintain relevant State based on Events observed on the Todo List Stream
+module Fold =
+
+    /// Present state of the Todo List as inferred from the Events we've seen to date
+    type State = { items : Events.ItemData list; nextId : int }
+    /// State implied by the absence of any events on this stream
+    let initial = { items = []; nextId = 0 }
+    /// Compute State change implied by a giveC:\Users\f0f00db\Projects\dotnet-templates\propulsion-summary-projector\Todo.fsn Event
+    let evolve s = function
+        | Events.Added item -> { s with items = item :: s.items; nextId = s.nextId + 1 }
+        | Events.Updated value -> { s with items = s.items |> List.map (function { id = id } when id = value.id -> value | item -> item) }
+        | Events.Deleted e -> { s with items = s.items  |> List.filter (fun x -> x.id <> e.id) }
+        | Events.Cleared e -> { nextId = e.nextId; items = [] }
+        | Events.Snapshotted s -> { nextId = s.nextId; items = List.ofArray s.items }
+    /// Folds a set of events from the store into a given `state`
+    let fold : State -> Events.Event seq -> State = Seq.fold evolve
+    /// Determines whether a given event represents a checkpoint that implies we don't need to see any preceding events
+    let isOrigin = function Events.Cleared _ | Events.Snapshotted _ -> true | _ -> false
+    /// Prepares an Event that encodes all relevant aspects of a State such that `evolve` can rehydrate a complete State from it
+    let snapshot state = Events.Snapshotted { nextId = state.nextId; items = Array.ofList state.items }
+    /// Allows us to skip producing summaries for events that we know won't result in an externally discernable change to the summary output
+    let impliesStateChange = function Events.Snapshotted _ -> false | _ -> true
+
+/// Defines operations that a Controller or Projector can perform on a Todo List
+type Service internal (resolve : ClientId -> Equinox.Decider<Events.Event, Fold.State>) =
+
+    /// Load and render the state
+    member _.QueryWithVersion(clientId, render : Fold.State -> 'res) : Async<int64*'res> =
+        let decider = resolve clientId
+        // Establish the present state of the Stream, project from that (using QueryEx so we can determine the version in effect)
+        decider.QueryEx(fun c -> c.Version, render c.State)
+
+let create resolveStream =
+    let resolve = streamName >> resolveStream >> Equinox.createDecider
+    Service(resolve)
+
+module Cosmos =
+
+    open Equinox.CosmosStore
+
+    let accessStrategy = AccessStrategy.Snapshot (Fold.isOrigin, Fold.snapshot)
+    let create (context, cache) =
+        let cacheStrategy = CachingStrategy.SlidingWindow (cache, System.TimeSpan.FromMinutes 20.)
+        let cat = CosmosStoreCategory(context, Events.codec, Fold.fold, Fold.initial, cacheStrategy, accessStrategy)
+        create cat.Resolve

--- a/propulsion-cosmos-reactor/Todo.fs
+++ b/propulsion-cosmos-reactor/Todo.fs
@@ -38,7 +38,7 @@ module Fold =
     let evolve s = function
         | Events.Added item -> { s with items = item :: s.items; nextId = s.nextId + 1 }
         | Events.Updated value -> { s with items = s.items |> List.map (function { id = id } when id = value.id -> value | item -> item) }
-        | Events.Deleted e -> { s with items = s.items  |> List.filter (fun x -> x.id <> e.id) }
+        | Events.Deleted e -> { s with items = s.items |> List.filter (fun x -> x.id <> e.id) }
         | Events.Cleared e -> { nextId = e.nextId; items = [] }
         | Events.Snapshotted s -> { nextId = s.nextId; items = List.ofArray s.items }
     /// Folds a set of events from the store into a given `state`

--- a/propulsion-cosmos-reactor/TodoSummary.fs
+++ b/propulsion-cosmos-reactor/TodoSummary.fs
@@ -1,0 +1,70 @@
+module ReactorTemplate.TodoSummary
+
+let [<Literal>] Category = "TodoSummary"
+let streamName (clientId: ClientId) = FsCodec.StreamName.create Category (ClientId.toString clientId)
+
+// NB - these types and the union case names reflect the actual storage formats and hence need to be versioned with care
+module Events =
+
+    type ItemData = { id: int; order: int; title: string; completed: bool }
+    type SummaryData = { items : ItemData[] }
+    type IngestedData = { version : int64; value : SummaryData }
+    type Event =
+        | Ingested of IngestedData
+        interface TypeShape.UnionContract.IUnionContract
+    let codec = FsCodec.NewtonsoftJson.Codec.Create<Event>()
+
+module Fold =
+
+    type State = { version : int64; value : Events.SummaryData option }
+    let initial = { version = -1L; value = None }
+    let evolve _state = function
+        | Events.Ingested e -> { version = e.version; value = Some e.value }
+    let fold : State -> Events.Event seq -> State = Seq.fold evolve
+    let snapshot state = Events.Ingested { version = state.version; value = state.value.Value }
+
+// TODO collapse this unless you actually end up with >1 kind of ingestion Command
+type Command =
+    | Consume of version : int64 * value : Events.SummaryData
+
+let decide command (state : Fold.State) =
+    match command with
+    | Consume (version, value) ->
+        if state.version >= version then false, [] else
+        true, [Events.Ingested { version = version; value = value }]
+
+type Item = { id: int; order: int; title: string; completed: bool }
+let render : Fold.State -> Item[] = function
+    | { value = Some { items = xs} } ->
+        [| for x in xs ->
+            {   id = x.id
+                order = x.order
+                title = x.title
+                completed = x.completed } |]
+    | _ -> [||]
+
+/// Defines the operations that the Read side of a Controller and/or the Reactor can perform on the 'aggregate'
+type Service internal (resolve : ClientId -> Equinox.Decider<Events.Event, Fold.State>) =
+
+    /// Returns false if the ingestion was rejected due to being an older version of the data than is presently being held
+    member _.TryIngest(clientId, version, value) : Async<bool> =
+        let decider = resolve clientId
+        decider.Transact(decide (Consume (version, value)))
+
+    member _.Read clientId: Async<Item[]> =
+        let decider = resolve clientId
+        decider.Query render
+
+let create resolveStream =
+    let resolve = streamName >> resolveStream >> Equinox.createDecider
+    Service(resolve)
+
+module Cosmos =
+
+    open Equinox.CosmosStore
+
+    let accessStrategy = AccessStrategy.RollingState Fold.snapshot
+    let create (context, cache) =
+        let cacheStrategy = CachingStrategy.SlidingWindow (cache, System.TimeSpan.FromMinutes 20.)
+        let cat = CosmosStoreCategory(context, Events.codec, Fold.fold, Fold.initial, cacheStrategy, accessStrategy)
+        create cat.Resolve

--- a/propulsion-cosmos-reactor/TodoSummary.fs
+++ b/propulsion-cosmos-reactor/TodoSummary.fs
@@ -23,15 +23,9 @@ module Fold =
     let fold : State -> Events.Event seq -> State = Seq.fold evolve
     let snapshot state = Events.Ingested { version = state.version; value = state.value.Value }
 
-// TODO collapse this unless you actually end up with >1 kind of ingestion Command
-type Command =
-    | Consume of version : int64 * value : Events.SummaryData
-
-let decide command (state : Fold.State) =
-    match command with
-    | Consume (version, value) ->
-        if state.version >= version then false, [] else
-        true, [Events.Ingested { version = version; value = value }]
+let decide (version : int64, value : Events.SummaryData) (state : Fold.State) =
+    if state.version >= version then false, [] else
+    true, [Events.Ingested { version = version; value = value }]
 
 type Item = { id: int; order: int; title: string; completed: bool }
 let render : Fold.State -> Item[] = function
@@ -49,7 +43,7 @@ type Service internal (resolve : ClientId -> Equinox.Decider<Events.Event, Fold.
     /// Returns false if the ingestion was rejected due to being an older version of the data than is presently being held
     member _.TryIngest(clientId, version, value) : Async<bool> =
         let decider = resolve clientId
-        decider.Transact(decide (Consume (version, value)))
+        decider.Transact(decide (version, value))
 
     member _.Read clientId: Async<Item[]> =
         let decider = resolve clientId

--- a/propulsion-cosmos-reactor/TodoSummary.fs
+++ b/propulsion-cosmos-reactor/TodoSummary.fs
@@ -55,7 +55,7 @@ type Service internal (resolve : ClientId -> Equinox.Decider<Events.Event, Fold.
         let decider = resolve clientId
         decider.Query render
 
-let create resolveStream =
+let private create resolveStream =
     let resolve = streamName >> resolveStream >> Equinox.createDecider
     Service(resolve)
 

--- a/propulsion-reactor/Reactor.fsproj
+++ b/propulsion-reactor/Reactor.fsproj
@@ -4,7 +4,6 @@
         <OutputType>Exe</OutputType>
         <TargetFramework>netcoreapp3.1</TargetFramework>
         <WarningLevel>5</WarningLevel>
-		<!--<DefineConstants>changeFeedOnly;kafka</DefineConstants>-->
 	</PropertyGroup>
 
     <ItemGroup>

--- a/propulsion-reactor/Reactor.fsproj
+++ b/propulsion-reactor/Reactor.fsproj
@@ -4,7 +4,7 @@
         <OutputType>Exe</OutputType>
         <TargetFramework>netcoreapp3.1</TargetFramework>
         <WarningLevel>5</WarningLevel>
-	</PropertyGroup>
+    </PropertyGroup>
 
     <ItemGroup>
         <!--#if (!kafkaEventSpans) -->
@@ -35,8 +35,9 @@
         <!--#if (kafkaEventSpans) -->
         <PackageReference Include="Equinox.CosmosStore" Version="3.0.1" />
         <!--#else-->
-		<PackageReference Include="Propulsion.CosmosStore" Version="2.11.0-rc2" />
-		<!--#endif-->
+        <PackageReference Include="Microsoft.Azure.Cosmos" Version="[3.20.0-preview]" />
+        <PackageReference Include="Propulsion.CosmosStore" Version="2.11.0-rc2" />
+        <!--#endif-->
         <!--#if (multiSource) -->
         <PackageReference Include="Propulsion.EventStore" Version="2.11.0-rc2" />
         <!--#endif-->

--- a/propulsion-reactor/Todo.fs
+++ b/propulsion-reactor/Todo.fs
@@ -59,7 +59,7 @@ type Service internal (resolve : ClientId -> Equinox.Decider<Events.Event, Fold.
         // Establish the present state of the Stream, project from that (using QueryEx so we can determine the version in effect)
         decider.QueryEx(fun c -> c.Version, render c.State)
 
-let create resolveStream =
+let private create resolveStream =
     let resolve = streamName >> resolveStream >> Equinox.createDecider
     Service(resolve)
 

--- a/propulsion-reactor/Todo.fs
+++ b/propulsion-reactor/Todo.fs
@@ -38,7 +38,7 @@ module Fold =
     let evolve s = function
         | Events.Added item -> { s with items = item :: s.items; nextId = s.nextId + 1 }
         | Events.Updated value -> { s with items = s.items |> List.map (function { id = id } when id = value.id -> value | item -> item) }
-        | Events.Deleted e -> { s with items = s.items  |> List.filter (fun x -> x.id <> e.id) }
+        | Events.Deleted e -> { s with items = s.items |> List.filter (fun x -> x.id <> e.id) }
         | Events.Cleared e -> { nextId = e.nextId; items = [] }
         | Events.Snapshotted s -> { nextId = s.nextId; items = List.ofArray s.items }
     /// Folds a set of events from the store into a given `state`

--- a/propulsion-reactor/TodoSummary.fs
+++ b/propulsion-reactor/TodoSummary.fs
@@ -55,7 +55,7 @@ type Service internal (resolve : ClientId -> Equinox.Decider<Events.Event, Fold.
         let decider = resolve clientId
         decider.Query render
 
-let create resolveStream =
+let private create resolveStream =
     let resolve = streamName >> resolveStream >> Equinox.createDecider
     Service(resolve)
 

--- a/tests/Equinox.Templates.Tests/DotnetBuild.fs
+++ b/tests/Equinox.Templates.Tests/DotnetBuild.fs
@@ -75,6 +75,8 @@ type DotnetBuild(output : ITestOutputHelper, folder : EquinoxTemplatesFixture) =
     let [<Fact>] proReactorDefault ()           = run "proReactor" []
     let [<Fact>] proReactorFilter ()            = run "proReactor" ["--filter"]
 
+    let [<Fact>] proCosmosReactor ()            = run "proCosmosReactor" []
+
     interface IClassFixture<EquinoxTemplatesFixture>
 
 module Dummy = let [<EntryPoint>] main _argv = 0


### PR DESCRIPTION
Adding a new template: `proCosmosReactor` that is a stripped down derivative of the Propulsion Reactor template for a simpler exposition for:
* demonstrating usage against just Cosmos
* command processing is stripped down to use a single container both for listening and writing events to  (the full template requires the monitored and target container to be specified separately, even if you're using the same Container for both)