### PR TITLE
Lag Reporting Frequency of Cosmos consumers to 1 min

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ The `Unreleased` section name is replaced by the expected version of next releas
 
 ### Added
 ### Changed
+
+- Added defaulting of 1 min for lag reporting frequency to all Cosmos consumers [#95](https://github.com/jet/dotnet-templates/pull/95)
+
 ### Removed
 ### Fixed
 

--- a/propulsion-sync/Program.fs
+++ b/propulsion-sync/Program.fs
@@ -131,7 +131,7 @@ module Args =
                 Log.Information("Monitoring Group {leaseId} in Database {db} Container {container} with maximum document count limited to {maxDocuments}",
                     x.ConsumerGroupName, leases.Database.Id, leases.Id, srcC.MaxDocuments)
                 if srcC.FromTail then Log.Warning("(If new projector group) Skipping projection of all existing events.")
-                srcC.LagFrequency |> Option.iter<TimeSpan> (fun i -> Log.Information("ChangeFeed Lag stats interval {lagS:n0}s", i.TotalSeconds))
+                Log.Information("ChangeFeed Lag stats interval {lagS:n0}s", let f = srcC.LagFrequency in f.TotalSeconds)
                 let monitored = srcC.MonitoredContainer()
                 Choice1Of2 (monitored, leases, x.ConsumerGroupName, srcC.FromTail, srcC.MaxDocuments, srcC.LagFrequency)
             | Choice2Of2 srcE ->
@@ -165,7 +165,7 @@ module Args =
             member a.Usage = a |> function
                 | FromTail ->               "(iff the Consumer Name is fresh) - force skip to present Position. Default: Never skip an event."
                 | MaxDocuments _ ->         "maximum item count to request from feed. Default: unlimited"
-                | LagFreqM _ ->             "frequency (in minutes) to dump lag stats. Default: off"
+                | LagFreqM _ ->             "frequency (in minutes) to dump lag stats. Default: 1"
                 | LeaseContainer _ ->       "specify Container Name for Leases container. Default: `sourceContainer` + `-aux`."
 
                 | ConnectionMode _ ->       "override the connection mode. Default: Direct."
@@ -191,7 +191,7 @@ module Args =
         
         member val FromTail =               a.Contains CosmosSourceParameters.FromTail
         member val MaxDocuments =           a.TryGetResult MaxDocuments
-        member val LagFrequency =           a.TryGetResult LagFreqM |> Option.map TimeSpan.FromMinutes
+        member val LagFrequency : TimeSpan = a.GetResult(LagFreqM, 1.) |> TimeSpan.FromMinutes
         member val LeaseContainerId =       a.TryGetResult CosmosSourceParameters.LeaseContainer
         member private _.ConnectLeases containerId = connector.CreateUninitialized(database, containerId)
         member x.ConnectLeases() =          match x.LeaseContainerId with
@@ -537,7 +537,7 @@ let build (args : Args.Arguments, log, storeLog : ILogger) =
         let runPipeline =
             Propulsion.CosmosStore.CosmosStoreSource.Run(
                 Log.Logger, monitored, leases, processorName, observer, startFromTail,
-                ?maxDocuments=maxDocuments, ?lagReportFreq=lagFrequency)
+                ?maxDocuments=maxDocuments, lagReportFreq=lagFrequency)
         sink, runPipeline
     | Choice2Of2 (srcE, checkpointsContext, spec) ->
         match maybeDstCosmos with


### PR DESCRIPTION
Change to default the change feed lag report frequency to 1 min from `None`. The latter caused _both_ the logging and the emission of the Prometheus metric to not occur. It was deemed that 1 min shouldn't be too costly a default to use.