### PR TITLE
eqxShipping: Add Integration test using Cosmos+CFP

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ The `Unreleased` section name is replaced by the expected version of next releas
 ### Added
 
 - Use `module Config` pattern [#104](https://github.com/jet/dotnet-templates/pull/104)
+- `eqxShipping`: Add CFP integration test using `Propulsion.CosmosStore` [#102](https://github.com/jet/dotnet-templates/pull/102)
 
 ### Changed
 ### Removed

--- a/equinox-shipping/.template.config/template.json
+++ b/equinox-shipping/.template.config/template.json
@@ -9,7 +9,8 @@
     "Watchdog"
   ],
   "tags": {
-    "language": "F#"
+    "language": "F#",
+    "type": "project"
   },
   "identity": "Equinox.Shipping",
   "name": "Equinox Shipping Sample",

--- a/equinox-shipping/Domain.Tests/Domain.Tests.fsproj
+++ b/equinox-shipping/Domain.Tests/Domain.Tests.fsproj
@@ -19,8 +19,7 @@
     <ItemGroup>
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.2.0" />
 
-        <PackageReference Include="Equinox.MemoryStore" Version="3.0.4" />
-        <PackageReference Include="FsCheck.Xunit" Version="2.14.2" />
+        <PackageReference Include="FsCheck.Xunit" Version="3.0.0-beta1" />
         <PackageReference Include="unquote" Version="5.0.0" />
         <PackageReference Include="xunit" Version="2.4.1" />
         <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1" />

--- a/equinox-shipping/Domain.Tests/FinalizationWorkflowTests.fs
+++ b/equinox-shipping/Domain.Tests/FinalizationWorkflowTests.fs
@@ -18,9 +18,9 @@ let [<Property>] ``FinalizationWorkflow properties`` (Id transId1, Id transId2, 
         let requestedShipmentIds = Array.append shipmentIds1 shipmentIds2
         let! res1 = processManager.TryFinalizeContainer(transId1, containerId1, requestedShipmentIds)
         let expectedEvents =
-            [   "FinalizationRequested"; "ReservationCompleted"; "AssignmentCompleted"; "Completed" // Transaction
-                "Reserved"; "Assigned" // Shipment
-                "Finalized"] // Container
+            [   nameof FE.FinalizationRequested; nameof FE.ReservationCompleted; nameof FE.AssignmentCompleted; nameof FE.Completed
+                nameof Shipment.Events.Reserved; nameof Shipment.Events.Assigned
+                nameof Container.Events.Finalized] // Container
         test <@ res1 && set eventTypes = set expectedEvents @>
         let containerEvents =
             buffer.Queue(Container.streamName containerId1)
@@ -35,7 +35,7 @@ let [<Property>] ``FinalizationWorkflow properties`` (Id transId1, Id transId2, 
         buffer.Clear()
         let! res2 = processManager.TryFinalizeContainer(transId2, containerId2, Array.append shipmentIds2 [|shipment3|])
         let expectedEvents =
-            [   "FinalizationRequested"; "RevertCommenced"; "Completed" // Transaction
-                "Reserved"; "Revoked" ] // Shipment
+            [   nameof FE.FinalizationRequested; nameof FE.RevertCommenced; nameof FE.Completed
+                nameof Shipment.Events.Reserved; nameof Shipment.Events.Revoked ]
         test <@ not res2
                 && set eventTypes = set expectedEvents @> }

--- a/equinox-shipping/Domain.Tests/FinalizationWorkflowTests.fs
+++ b/equinox-shipping/Domain.Tests/FinalizationWorkflowTests.fs
@@ -7,35 +7,35 @@ open Swensen.Unquote
 
 module FE = FinalizationTransaction.Events
 
-let [<Property>] ``FinalizationWorkflow properties`` (Id transId1, Id transId2, Id containerId1, Id containerId2, IdsAtLeastOne shipmentIds1, IdsAtLeastOne shipmentIds2, Id shipment3) =
+let [<Property>] ``FinalizationWorkflow properties`` (Id transId1, Id transId2, Id containerId1, Id containerId2, IdsAtLeastOne shipmentIds1, IdsAtLeastOne shipmentIds2, Id shipment3) = async {
     let store = Equinox.MemoryStore.VolatileStore()
     let buffer = EventAccumulator()
     use __ = store.Committed.Subscribe buffer.Record
     let eventTypes = seq { for e in buffer.All() -> e.EventType }
     let processManager = FinalizationWorkflow.Config.create 16 (Config.Store.Memory store)
-    Async.RunSynchronously <| async {
-        (* First, run the happy path - should pass through all stages of the lifecycle *)
-        let requestedShipmentIds = Array.append shipmentIds1 shipmentIds2
-        let! res1 = processManager.TryFinalizeContainer(transId1, containerId1, requestedShipmentIds)
-        let expectedEvents =
-            [   nameof FE.FinalizationRequested; nameof FE.ReservationCompleted; nameof FE.AssignmentCompleted; nameof FE.Completed
-                nameof Shipment.Events.Reserved; nameof Shipment.Events.Assigned
-                nameof Container.Events.Finalized] // Container
-        test <@ res1 && set eventTypes = set expectedEvents @>
-        let containerEvents =
-            buffer.Queue(Container.streamName containerId1)
-            |> Seq.choose Container.Events.codec.TryDecode
-            |> List.ofSeq
-        test <@ match containerEvents with
-                | [ Container.Events.Finalized e ] -> e.shipmentIds = requestedShipmentIds
-                | xs -> failwithf "Unexpected %A" xs @>
-        (* Next, we run an overlapping finalize - this should
-           a) yield a fail result
-           b) result in triggering of Revert flow with associated Shipment revoke events *)
-        buffer.Clear()
-        let! res2 = processManager.TryFinalizeContainer(transId2, containerId2, Array.append shipmentIds2 [|shipment3|])
-        let expectedEvents =
-            [   nameof FE.FinalizationRequested; nameof FE.RevertCommenced; nameof FE.Completed
-                nameof Shipment.Events.Reserved; nameof Shipment.Events.Revoked ]
-        test <@ not res2
-                && set eventTypes = set expectedEvents @> }
+
+    (* First, run the happy path - should pass through all stages of the lifecycle *)
+    let requestedShipmentIds = Array.append shipmentIds1 shipmentIds2
+    let! res1 = processManager.TryFinalizeContainer(transId1, containerId1, requestedShipmentIds)
+    let expectedEvents =
+        [   nameof FE.FinalizationRequested; nameof FE.ReservationCompleted; nameof FE.AssignmentCompleted; nameof FE.Completed
+            nameof Shipment.Events.Reserved; nameof Shipment.Events.Assigned
+            nameof Container.Events.Finalized] // Container
+    test <@ res1 && set eventTypes = set expectedEvents @>
+    let containerEvents =
+        buffer.Queue(Container.streamName containerId1)
+        |> Seq.choose Container.Events.codec.TryDecode
+        |> List.ofSeq
+    test <@ match containerEvents with
+            | [ Container.Events.Finalized e ] -> e.shipmentIds = requestedShipmentIds
+            | xs -> failwith $"Unexpected %A{xs}" @>
+    (* Next, we run an overlapping finalize - this should
+       a) yield a fail result
+       b) result in triggering of Revert flow with associated Shipment revoke events *)
+    buffer.Clear()
+    let! res2 = processManager.TryFinalizeContainer(transId2, containerId2, Array.append shipmentIds2 [|shipment3|])
+    let expectedEvents =
+        [   nameof FE.FinalizationRequested; nameof FE.RevertCommenced; nameof FE.Completed
+            nameof Shipment.Events.Reserved; nameof Shipment.Events.Revoked ]
+    test <@ not res2
+            && set eventTypes = set expectedEvents @> }

--- a/equinox-shipping/Domain.Tests/FinalizationWorkflowTests.fs
+++ b/equinox-shipping/Domain.Tests/FinalizationWorkflowTests.fs
@@ -10,7 +10,7 @@ module FE = FinalizationTransaction.Events
 let [<Property>] ``FinalizationWorkflow properties`` (Id transId1, Id transId2, Id containerId1, Id containerId2, IdsAtLeastOne shipmentIds1, IdsAtLeastOne shipmentIds2, Id shipment3) = async {
     let store = Equinox.MemoryStore.VolatileStore()
     let buffer = EventAccumulator()
-    use __ = store.Committed.Subscribe buffer.Record
+    use _ = store.Committed.Subscribe buffer.Record
     let eventTypes = seq { for e in buffer.All() -> e.EventType }
     let processManager = FinalizationWorkflow.Config.create 16 (Config.Store.Memory store)
 

--- a/equinox-shipping/Domain/Types.fs
+++ b/equinox-shipping/Domain/Types.fs
@@ -29,12 +29,12 @@ module Config =
 
     module Category =
 
-        let create codec initial fold accessStrategy (context, cache) =
-            let cacheStrategy = Equinox.CosmosStore.CachingStrategy.SlidingWindow (cache, System.TimeSpan.FromMinutes 20.)
-            Equinox.CosmosStore.CosmosStoreCategory(context, codec, fold, initial, cacheStrategy, accessStrategy)
-
         let createMemory codec initial fold store =
             Equinox.MemoryStore.MemoryStoreCategory(store, codec, fold, initial)
+
+        let private create codec initial fold accessStrategy (context, cache) =
+            let cacheStrategy = Equinox.CosmosStore.CachingStrategy.SlidingWindow (cache, System.TimeSpan.FromMinutes 20.)
+            Equinox.CosmosStore.CosmosStoreCategory(context, codec, fold, initial, cacheStrategy, accessStrategy)
 
         let createSnapshotted codec initial fold (isOrigin, toSnapshot) (context, cache) =
             let accessStrategy = Equinox.CosmosStore.AccessStrategy.Snapshot (isOrigin, toSnapshot)

--- a/equinox-shipping/Watchdog.Integration/CosmosStoreConnector.fs
+++ b/equinox-shipping/Watchdog.Integration/CosmosStoreConnector.fs
@@ -1,0 +1,38 @@
+namespace Shipping.Watchdog.Integration
+
+open Shipping.Watchdog
+open System
+
+type CosmosStoreConfiguration(?tryGet) =
+    let tryGet = defaultArg tryGet EnvVar.tryGet
+    let get key =
+        match tryGet key with
+        | Some value -> value
+        | None -> failwith $"Missing Argument/Environment Variable %s{key}"
+    member _.CosmosConnection =         get "EQUINOX_COSMOS_CONNECTION"
+    member _.CosmosDatabase =           get "EQUINOX_COSMOS_DATABASE"
+    member _.CosmosContainer =          get "EQUINOX_COSMOS_CONTAINER"
+
+type CosmosStoreConnector(?c : CosmosStoreConfiguration) =
+    let c = match c with Some c -> c | None -> CosmosStoreConfiguration()
+    let discovery =                     c.CosmosConnection |> Equinox.CosmosStore.Discovery.ConnectionString
+    let timeout =                       5. |> TimeSpan.FromSeconds
+    let retries, maxRetryWaitTime =     1, 5. |> TimeSpan.FromSeconds
+    let connectionMode =                Microsoft.Azure.Cosmos.ConnectionMode.Gateway
+    let connector =                     Equinox.CosmosStore.CosmosStoreConnector(discovery, timeout, retries, maxRetryWaitTime, connectionMode)
+    let containerId =                   c.CosmosContainer
+    let leaseContainerId =              containerId + "-aux"
+    let connectLeases () =              connector.CreateUninitialized(c.CosmosDatabase, leaseContainerId)
+    member private _.ConnectStoreAndMonitored() = connector.ConnectStoreAndMonitored(c.CosmosDatabase, containerId)
+    member _.ConnectLeases() =
+        let leases : Microsoft.Azure.Cosmos.Container = connectLeases()
+        // Just as ConnectStoreAndMonitored references the global Logger, so do we -> see SerilogLogFixture, _dummy
+        Serilog.Log.Information("ChangeFeed Leases Database {db} Container {container}", leases.Database.Id, leases.Id)
+        leases
+    member x.Connect() =
+        let client, monitored = x.ConnectStoreAndMonitored()
+        let storeCfg =
+            let context = client |> CosmosStoreContext.create
+            let cache = Equinox.Cache ("Tests", sizeMb = 10)
+            Config.Store.Cosmos (context, cache)
+        storeCfg, monitored

--- a/equinox-shipping/Watchdog.Integration/ReactorFixture.fs
+++ b/equinox-shipping/Watchdog.Integration/ReactorFixture.fs
@@ -61,12 +61,12 @@ type CosmosReactorFixture(messageSink) =
 
     member val Log = Serilog.Log.Logger
     member val ProcessManager = processManager
-    member val StoreConfig = storeCfg
     member val RunTimeout = TimeSpan.FromSeconds 2.
 
     /// As this is a Collection Fixture, it will outlive an individual instantiation of a Test Class
     /// This enables us to tee the output that normally goes to the Test Runner Diagnostic Sink to the test output of the (by definition, single) current test
     member _.CaptureSerilogLog(testOutput) = serilogLog.CaptureSerilogLog testOutput
+    member _.DumpStats() = stats.DumpStats()
 
     /// Stops the projector, emitting the final stats to the log
     interface IDisposable with

--- a/equinox-shipping/Watchdog.Integration/Watchdog.Integration.fsproj
+++ b/equinox-shipping/Watchdog.Integration/Watchdog.Integration.fsproj
@@ -13,6 +13,7 @@
         <Compile Include="SerilogLogFixture.fs" />
         <Compile Include="MemoryStoreFixture.fs" />
         <Compile Include="MemoryStoreProjector.fs" />
+        <Compile Include="CosmosStoreConnector.fs" />
         <Compile Include="ReactorFixture.fs" />
         <Compile Include="WatchdogIntegrationTests.fs" />
     </ItemGroup>

--- a/equinox-shipping/Watchdog.Integration/Watchdog.Integration.fsproj
+++ b/equinox-shipping/Watchdog.Integration/Watchdog.Integration.fsproj
@@ -16,6 +16,9 @@
         <Compile Include="CosmosStoreConnector.fs" />
         <Compile Include="ReactorFixture.fs" />
         <Compile Include="WatchdogIntegrationTests.fs" />
+        <Content Include="xunit.runner.json">
+            <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+        </Content>
     </ItemGroup>
 
     <ItemGroup>

--- a/equinox-shipping/Watchdog.Integration/WatchdogIntegrationTests.fs
+++ b/equinox-shipping/Watchdog.Integration/WatchdogIntegrationTests.fs
@@ -21,3 +21,23 @@ type MemoryProperties(testOutput) =
 
         reactor.Log.Information("Awaiting batches: {counts} ({timeouts}/{total} timeouts)", counts, timeouts, counts.Count)
         do! reactor.AwaitWithStopOnCancellation() }
+
+[<Xunit.Collection "CosmosReactor">]
+type CosmosProperties(reactor : CosmosReactorFixture, testOutput) =
+    let logReg = reactor.CaptureSerilogLog testOutput
+
+    [<Property(StartSize=1000, MaxTest=1)>]
+    let run (AtLeastOne batches) = async {
+        let counts = System.Collections.Generic.Stack()
+        let mutable timeouts = 0
+        for Id tid, Id cid, IdsAtLeastOne shipmentIds in batches do
+            counts.Push shipmentIds.Length
+            try let! _ = reactor.ProcessManager.TryFinalizeContainer(tid, cid, shipmentIds)
+                         |> Async.timeoutAfter reactor.RunTimeout
+                ()
+            with :? TimeoutException -> timeouts <- timeouts + 1
+        reactor.Log.Information("Awaiting batches: {counts} ({timeouts}/{total} timeouts)", counts, timeouts, counts.Count)
+        // TODO figure out how to best validate that all requests got completed either directly or with help of the watchdog
+    }
+
+    interface IDisposable with member _.Dispose() = logReg.Dispose()

--- a/equinox-shipping/Watchdog.Integration/WatchdogIntegrationTests.fs
+++ b/equinox-shipping/Watchdog.Integration/WatchdogIntegrationTests.fs
@@ -24,7 +24,7 @@ type MemoryProperties(testOutput) =
 
 [<Xunit.Collection "CosmosReactor">]
 type CosmosProperties(reactor : CosmosReactorFixture, testOutput) =
-    let logReg = reactor.CaptureSerilogLog testOutput
+    let logSub = reactor.CaptureSerilogLog testOutput
 
     [<Property(StartSize=1000, MaxTest=1)>]
     let run (AtLeastOne batches) = async {
@@ -36,8 +36,7 @@ type CosmosProperties(reactor : CosmosReactorFixture, testOutput) =
                          |> Async.timeoutAfter reactor.RunTimeout
                 ()
             with :? TimeoutException -> timeouts <- timeouts + 1
-        reactor.Log.Information("Awaiting batches: {counts} ({timeouts}/{total} timeouts)", counts, timeouts, counts.Count)
+        reactor.Log.Information("Awaiting batches: {counts} ({timeouts}/{total} timeouts)", counts, timeouts, counts.Count) }
         // TODO figure out how to best validate that all requests got completed either directly or with help of the watchdog
-    }
 
-    interface IDisposable with member _.Dispose() = logReg.Dispose()
+    interface IDisposable with member _.Dispose() = logSub.Dispose()

--- a/equinox-shipping/Watchdog.Integration/xunit.runner.json
+++ b/equinox-shipping/Watchdog.Integration/xunit.runner.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "https://xunit.net/schema/current/xunit.runner.schema.json",
+  "diagnosticMessages": true
+}

--- a/equinox-shipping/Watchdog/Program.fs
+++ b/equinox-shipping/Watchdog/Program.fs
@@ -115,12 +115,12 @@ let startWatchdog log (processingTimeout, stats : Handler.Stats) (maxReadAhead, 
 let build (args : Args.Arguments) =
     let processorName, maxReadAhead, maxConcurrentStreams = args.ProcessorParams()
     let storeClient, monitored = args.Cosmos.ConnectStoreAndMonitored()
-    let storeCfg =
-        let context = storeClient |> CosmosStoreContext.create
-        let cache = Equinox.Cache (AppName, sizeMb = 10)
-        Config.Store.Cosmos (context, cache)
     let sink =
-        let processManager = Shipping.Domain.FinalizationWorkflow.Config.create args.ProcessManagerMaxDop storeCfg
+        let processManager =
+            let context = CosmosStoreContext.create storeClient
+            let cache = Equinox.Cache(AppName, sizeMb=10)
+            let store = Config.Store.Cosmos (context, cache)
+            Shipping.Domain.FinalizationWorkflow.Config.create args.ProcessManagerMaxDop store
         let stats = Handler.Stats(Log.Logger, statsInterval=args.StatsInterval, stateInterval=args.StateInterval)
         startWatchdog Log.Logger (args.ProcessingTimeout, stats) (maxReadAhead, maxConcurrentStreams) processManager.Pump
     let pipeline =


### PR DESCRIPTION
In which I sync changes/simplifications I've worked out in using these techniques in a set of tests I'm developing atm
- [x] Update FsCheck to v3 beta
- [x] use Domain Config pattern 
- [x] Extend logging in Store and Projector pipelines
- [x] Extract MemoryReactorFixture
- [x] Add Cosmos Integration test to go with the existing MemoryStore test