### PR TITLE
Remove usage of Command DUs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ The `Unreleased` section name is replaced by the expected version of next releas
 
 ### Added
 ### Changed
+
+- Remove usage of `type Command` DUs [#103](https://github.com/jet/dotnet-templates/pull/103)
+
 ### Removed
 ### Fixed
 

--- a/equinox-web/Domain/Aggregate.fs
+++ b/equinox-web/Domain/Aggregate.fs
@@ -25,12 +25,8 @@ module Fold =
     let isOrigin = function Events.Snapshotted _ -> true | _ -> false
     let snapshot state = Events.Snapshotted { happened = state.happened }
 
-type Command =
-    | MakeItSo
-
-let interpret c (state : Fold.State) =
-    match c with
-    | MakeItSo -> if state.happened then [] else [Events.Happened]
+let interpretMarkDone (state : Fold.State) =
+    if state.happened then [] else [Events.Happened]
 
 type View = { sorted : bool }
 
@@ -42,10 +38,10 @@ type Service internal (resolve : string -> Equinox.Decider<Events.Event, Fold.St
         let decider = resolve clientId
         decider.Query(fun s -> { sorted = s.happened })
 
-    /// Execute the specified command 
-    member _.Execute(clientId, command) : Async<unit> =
+    /// Execute the specified command
+    member _.MarkDone(clientId, command) : Async<unit> =
         let decider = resolve clientId
-        decider.Transact(interpret command)
+        decider.Transact(interpretMarkDone)
 
 let create resolveStream =
     let resolve = streamName >> resolveStream >> Equinox.createDecider

--- a/equinox-web/Web/Controllers/TodosController.fs
+++ b/equinox-web/Web/Controllers/TodosController.fs
@@ -56,8 +56,8 @@ type TodosController(service: Todo.Service) =
 
     [<HttpDelete "{id}">]
     member _.Delete([<FromClientIdHeader>]clientId : ClientId, id): Async<unit> =
-        service.Execute(clientId, Todo.Delete id)
+        service.Delete(clientId, id)
 
     [<HttpDelete>]
     member _.DeleteAll([<FromClientIdHeader>]clientId : ClientId): Async<unit> =
-        service.Execute(clientId, Todo.Clear)
+        service.Clear(clientId)

--- a/propulsion-reactor/TodoSummary.fs
+++ b/propulsion-reactor/TodoSummary.fs
@@ -23,15 +23,9 @@ module Fold =
     let fold : State -> Events.Event seq -> State = Seq.fold evolve
     let snapshot state = Events.Ingested { version = state.version; value = state.value.Value }
 
-// TODO collapse this unless you actually end up with >1 kind of ingestion Command
-type Command =
-    | Consume of version : int64 * value : Events.SummaryData
-
-let decide command (state : Fold.State) =
-    match command with
-    | Consume (version, value) ->
-        if state.version >= version then false, [] else
-        true, [Events.Ingested { version = version; value = value }]
+let ingest version value (state : Fold.State) =
+    if state.version >= version then false, [] else
+    true, [Events.Ingested { version = version; value = value }]
 
 type Item = { id: int; order: int; title: string; completed: bool }
 let render : Fold.State -> Item[] = function
@@ -49,9 +43,9 @@ type Service internal (resolve : ClientId -> Equinox.Decider<Events.Event, Fold.
     /// Returns false if the ingestion was rejected due to being an older version of the data than is presently being held
     member _.TryIngest(clientId, version, value) : Async<bool> =
         let decider = resolve clientId
-        decider.Transact(decide (Consume (version, value)))
+        decider.Transact(ingest version value)
 
-    member _.Read clientId: Async<Item[]> =
+    member _.Read(clientId) : Async<Item[]> =
         let decider = resolve clientId
         decider.Query render
 


### PR DESCRIPTION
While there are poster child cases where a DU fits the bill and enables things, experience has shown that while 90% of demo apps have it, only toy real world streams benefit from attempting to follow it to that same degree.

Hereby trusting people won't forget about the pattern, for cases of Decider Services where a Command is the right tool for the job.