### PR TITLE
proReactorCosmos: Reactor metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ The `Unreleased` section name is replaced by the expected version of next releas
 ### Added
 
 - Use `module Config` pattern [#104](https://github.com/jet/dotnet-templates/pull/104)
+- `proReactorCosmos`: Add `ReactorMetrics` [#106](https://github.com/jet/dotnet-templates/pull/106)
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -89,6 +89,8 @@ The specific behaviors carried out in reaction to incoming events often use `Equ
 
     - For applications where the reactions using the same Container, credentials etc as the one being Monitored by the change feed processor (simpler config wiring and less argument processing)
 
+    - includes full wiring for Prometheus metrics emission from the Handler outcomes
+
 <a name="eqxShipping"></a>
 - [`eqxShipping`](equinox-shipping/README.md) - Example demonstrating the implementation of a [Process Manager](https://www.enterpriseintegrationpatterns.com/patterns/messaging/ProcessManager.html) using [`Equinox`](https://github.com/jet/equinox) that manages the enlistment of a set of `Shipment` Aggregate items into a separated `Container` Aggregate as an atomic operation. :pray: [@Kimserey](https://github.com/Kimserey).
  

--- a/propulsion-cosmos-reactor/Reactor.fsproj
+++ b/propulsion-cosmos-reactor/Reactor.fsproj
@@ -13,6 +13,7 @@
         <Compile Include="Todo.fs" />
         <Compile Include="Contract.fs" />
         <Compile Include="TodoSummary.fs" />
+        <Compile Include="ReactorMetrics.fs" />
         <Compile Include="Reactor.fs" />
         <Compile Include="Program.fs" />
     </ItemGroup>

--- a/propulsion-cosmos-reactor/ReactorMetrics.fs
+++ b/propulsion-cosmos-reactor/ReactorMetrics.fs
@@ -1,0 +1,32 @@
+module ReactorTemplate.Metrics
+
+let baseName stat = "ReactorTemplate_reactor_" + stat
+let baseDesc desc = "ReactorTemplate: Reactor " + desc
+
+module private Counter =
+
+    let private make (config : Prometheus.CounterConfiguration) name desc =
+        let ctr = Prometheus.Metrics.CreateCounter(name, desc, config)
+        fun tagValues (c : float) -> ctr.WithLabels(tagValues).Inc(c)
+
+    let create (tagNames, tagValues) stat desc =
+        let config = Prometheus.CounterConfiguration(LabelNames = tagNames)
+        make config (baseName stat) (baseDesc desc) tagValues
+
+let observeOutcomeStatus s =        Counter.create  ([| "status" |],[| s |])    "outcome_total"     "Outcome"
+
+[<RequireQualifiedAccess>]
+type Outcome =
+    /// Handler processed the span, with counts of used vs unused known event types
+    | Ok of used : int * unused : int
+    /// Handler processed the span, but idempotency checks resulted in no writes being applied; includes count of decoded events
+    | Skipped of count : int
+    /// Handler determined the events were not relevant to its duties and performed no actions
+    /// e.g. wrong category, events that dont imply a state change
+    | NotApplicable of count : int
+
+let observeReactorOutcome = function
+    | Outcome.Ok (used, unused) ->  observeOutcomeStatus "ok"               (float used)
+                                    observeOutcomeStatus "unused"           (float unused)
+    | Outcome.Skipped c ->          observeOutcomeStatus "skipped"          (float c)
+    | Outcome.NotApplicable c ->    observeOutcomeStatus "notApplicable"    (float c)


### PR DESCRIPTION
Adds explicit metrics to surface outcomes of handlers
As the Reactor is already plumbed for generic Propulsion and Equinox metrics, the incremental infra cost of having business level metrics like this is minimal