### PR TITLE
Demonstrate TransactWith impl pattern

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ The `Unreleased` section name is replaced by the expected version of next releas
 ## [Unreleased]
 
 ### Added
+
+- Demonstrate `TransactWith` implementation 'pattern' [#113](https://github.com/jet/dotnet-templates/pull/113) 
+
 ### Changed
 
 - Target `Propulsion` v `2.12.0-rc.3` [#111](https://github.com/jet/dotnet-templates/pull/111)

--- a/equinox-web/Domain/Infrastructure.fs
+++ b/equinox-web/Domain/Infrastructure.fs
@@ -12,7 +12,8 @@ and [<Measure>] clientId
 module ClientId =
     let toString (value : ClientId) : string = Guid.toStringN %value
 
-
+/// For particularly common patterns used within a given app, sometimes it can make sense to name the pattern locally
+/// There are definitely trade-offs to this - one person's great intention revealing name is another's layer of obfuscation
 [<AutoOpen>]
 module DeciderExtensions =
 

--- a/equinox-web/Domain/Infrastructure.fs
+++ b/equinox-web/Domain/Infrastructure.fs
@@ -11,3 +11,12 @@ type ClientId = Guid<clientId>
 and [<Measure>] clientId
 module ClientId =
     let toString (value : ClientId) : string = Guid.toStringN %value
+
+
+[<AutoOpen>]
+module DeciderExtensions =
+
+    type Equinox.Decider<'e, 's> with
+
+         member x.TransactWithPostState(decide, mapResult) =
+            x.TransactEx((fun c -> async { let events = decide c.State in return (), events }), fun () c -> mapResult c.State)

--- a/equinox-web/Domain/Todo.fs
+++ b/equinox-web/Domain/Todo.fs
@@ -68,14 +68,14 @@ let decideClear (state : Fold.State) =
 /// A single Item in the Todo List
 type View = { id: int; order: int; title: string; completed: bool }
 
+let private render (item: Events.ItemData) : View =
+    {   id = item.id
+        order = item.order
+        title = item.title
+        completed = item.completed }
+
 /// Defines operations that a Controller can perform on a Todo List
 type Service internal (resolve : ClientId -> Equinox.Decider<Events.Event, Fold.State>) =
-
-    let render (item: Events.ItemData) : View =
-        {   id = item.id
-            order = item.order
-            title = item.title
-            completed = item.completed }
 
     (* READ *)
 


### PR DESCRIPTION
While there can be a place for a DRY `let`-bound helper in a `type Service`, in general it makes more sense to codify a specific `Transact` or `Query` pattern common within a particular category, domain or app as an extension method on `Decider`, rather than as a local helper.

cc @ahjohannessen