### PR TITLE
Update to use Propulsion 2.12.1 Prometheus wiring

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ The `Unreleased` section name is replaced by the expected version of next releas
 
 ### Changed
 
-- Target `Propulsion` v `2.12.0-rc.3` [#111](https://github.com/jet/dotnet-templates/pull/111)
+- Target `Propulsion` v `2.12.1`, `Equinox` v `3.0.6` [#111](https://github.com/jet/dotnet-templates/pull/111) [#114](https://github.com/jet/dotnet-templates/pull/114)
 - `eqxPatterns`: Extract `ExactlyOnceIngester` [#110](https://github.com/jet/dotnet-templates/pull/110)
 - Target `FsCodec.SystemTextJson`.* v `2.3.0` [#112](https://github.com/jet/dotnet-templates/pull/112)
 

--- a/equinox-patterns/Domain/Domain.fsproj
+++ b/equinox-patterns/Domain/Domain.fsproj
@@ -16,8 +16,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Equinox.MemoryStore" Version="3.0.5" />
-    <PackageReference Include="Equinox.CosmosStore" Version="3.0.5" />
+    <PackageReference Include="Equinox.MemoryStore" Version="3.0.6" />
+    <PackageReference Include="Equinox.CosmosStore" Version="3.0.6" />
     <PackageReference Include="FsCodec.SystemTextJson" Version="2.3.0" />
   </ItemGroup>
 

--- a/equinox-shipping/Domain.Tests/Domain.Tests.fsproj
+++ b/equinox-shipping/Domain.Tests/Domain.Tests.fsproj
@@ -18,7 +18,7 @@
     <ItemGroup>
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.2.0" />
 
-        <PackageReference Include="Equinox.MemoryStore" Version="3.0.5" />
+        <PackageReference Include="Equinox.MemoryStore" Version="3.0.6" />
         <PackageReference Include="FsCheck.Xunit" Version="3.0.0-beta1" />
         <PackageReference Include="unquote" Version="5.0.0" />
         <PackageReference Include="xunit" Version="2.4.1" />

--- a/equinox-shipping/Domain/Domain.fsproj
+++ b/equinox-shipping/Domain/Domain.fsproj
@@ -17,8 +17,8 @@
     </ItemGroup>
 
     <ItemGroup>
-      <PackageReference Include="Equinox.CosmosStore" Version="3.0.5" />
-      <PackageReference Include="Equinox.MemoryStore" Version="3.0.5" />
+      <PackageReference Include="Equinox.CosmosStore" Version="3.0.6" />
+      <PackageReference Include="Equinox.MemoryStore" Version="3.0.6" />
       <PackageReference Include="FsCodec.SystemTextJson" Version="2.3.0" />
     </ItemGroup>
 

--- a/equinox-shipping/Watchdog/Watchdog.fsproj
+++ b/equinox-shipping/Watchdog/Watchdog.fsproj
@@ -16,7 +16,7 @@
     <ItemGroup>
         <PackageReference Include="Argu" Version="6.1.1" />
         <PackageReference Include="Destructurama.FSharp" Version="1.2.0" />
-        <PackageReference Include="Propulsion.CosmosStore" Version="2.12.0-rc.3" />
+        <PackageReference Include="Propulsion.CosmosStore" Version="2.12.1" />
         <PackageReference Include="Serilog.Sinks.Console" Version="4.0.0" />
     </ItemGroup>
 

--- a/equinox-testbed/Testbed.fsproj
+++ b/equinox-testbed/Testbed.fsproj
@@ -18,10 +18,10 @@
   <ItemGroup>
     <PackageReference Include="Argu" Version="6.1.1" />
     <PackageReference Include="Destructurama.FSharp" Version="1.2.0" />
-    <PackageReference Include="Equinox.CosmosStore" Version="3.0.5" />
-    <PackageReference Include="Equinox.EventStore" Version="3.0.5" />
-    <PackageReference Include="Equinox.MemoryStore" Version="3.0.5" />
-    <PackageReference Include="Equinox.Tools.TestHarness" Version="3.0.5" />
+    <PackageReference Include="Equinox.CosmosStore" Version="3.0.6" />
+    <PackageReference Include="Equinox.EventStore" Version="3.0.6" />
+    <PackageReference Include="Equinox.MemoryStore" Version="3.0.6" />
+    <PackageReference Include="Equinox.Tools.TestHarness" Version="3.0.6" />
     <PackageReference Include="FsCodec.SystemTextJson" Version="2.3.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="3.1.3" />
     <PackageReference Include="Serilog.Sinks.Console" Version="4.0.0" />

--- a/equinox-web-csharp/Domain/Domain.csproj
+++ b/equinox-web-csharp/Domain/Domain.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Equinox" Version="3.0.5" />
+    <PackageReference Include="Equinox" Version="3.0.6" />
     <PackageReference Include="FsCodec" Version="2.0.1" />
     <PackageReference Include="FSharp.Core" Version="4.5.4" />
     <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />

--- a/equinox-web-csharp/Web/Web.csproj
+++ b/equinox-web-csharp/Web/Web.csproj
@@ -5,10 +5,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Equinox.CosmosStore" Version="3.0.5" />
-    <PackageReference Include="Equinox.CosmosStore.Prometheus" Version="3.0.5" />
-    <PackageReference Include="Equinox.EventStore" Version="3.0.5" />
-    <PackageReference Include="Equinox.MemoryStore" Version="3.0.5" />
+    <PackageReference Include="Equinox.CosmosStore" Version="3.0.6" />
+    <PackageReference Include="Equinox.CosmosStore.Prometheus" Version="3.0.6" />
+    <PackageReference Include="Equinox.EventStore" Version="3.0.6" />
+    <PackageReference Include="Equinox.MemoryStore" Version="3.0.6" />
     <PackageReference Include="FsCodec.SystemTextJson" Version="2.3.0" />
     <PackageReference Include="prometheus-net.AspNetCore" Version="3.6.0" />
     <PackageReference Include="Serilog.AspNetCore" Version="3.2.0" />

--- a/equinox-web/Domain/Domain.fsproj
+++ b/equinox-web/Domain/Domain.fsproj
@@ -19,9 +19,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Equinox.CosmosStore" Version="3.0.5" />
-    <PackageReference Include="Equinox.EventStore" Version="3.0.5" />
-    <PackageReference Include="Equinox.MemoryStore" Version="3.0.5" />
+    <PackageReference Include="Equinox.CosmosStore" Version="3.0.6" />
+    <PackageReference Include="Equinox.EventStore" Version="3.0.6" />
+    <PackageReference Include="Equinox.MemoryStore" Version="3.0.6" />
     <PackageReference Include="FsCodec.SystemTextJson" Version="2.3.0" />
   </ItemGroup>
 

--- a/equinox-web/Web/Web.fsproj
+++ b/equinox-web/Web/Web.fsproj
@@ -11,7 +11,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Equinox.CosmosStore.Prometheus" Version="3.0.5" />
+    <PackageReference Include="Equinox.CosmosStore.Prometheus" Version="3.0.6" />
     <PackageReference Include="prometheus-net.AspNetCore" Version="3.6.0" />
     <PackageReference Include="Serilog.AspNetCore" Version="3.2.0" />
     <PackageReference Include="Serilog.Sinks.Console" Version="4.0.0" />

--- a/feed-consumer/FeedConsumer.fsproj
+++ b/feed-consumer/FeedConsumer.fsproj
@@ -17,11 +17,11 @@
   <ItemGroup>
     <PackageReference Include="Argu" Version="6.1.1" />
     <PackageReference Include="Destructurama.FSharp" Version="1.2.0" />
-    <PackageReference Include="Equinox.CosmosStore" Version="3.0.5" />
-    <PackageReference Include="Equinox.CosmosStore.Prometheus" Version="3.0.5" />
+    <PackageReference Include="Equinox.CosmosStore" Version="3.0.6" />
+    <PackageReference Include="Equinox.CosmosStore.Prometheus" Version="3.0.6" />
     <PackageReference Include="FsCodec.SystemTextJson" Version="2.3.0" />
-    <PackageReference Include="Propulsion.CosmosStore" Version="2.12.0-rc.3" />
-    <PackageReference Include="Propulsion.Feed" Version="2.12.0-rc.3" />
+    <PackageReference Include="Propulsion.CosmosStore" Version="2.12.1" />
+    <PackageReference Include="Propulsion.Feed" Version="2.12.1" />
     <PackageReference Include="Serilog.Sinks.Async" Version="1.5.0" />
     <PackageReference Include="Serilog.Sinks.Console" Version="4.0.0" />
   </ItemGroup>

--- a/feed-source/Domain/Domain.fsproj
+++ b/feed-source/Domain/Domain.fsproj
@@ -14,8 +14,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Equinox.CosmosStore" Version="3.0.5" />
-    <PackageReference Include="Equinox.MemoryStore" Version="3.0.5" />
+    <PackageReference Include="Equinox.CosmosStore" Version="3.0.6" />
+    <PackageReference Include="Equinox.MemoryStore" Version="3.0.6" />
     <PackageReference Include="FsCodec.SystemTextJson" Version="2.3.0" />
   </ItemGroup>
 

--- a/feed-source/FeedApi/FeedApi.fsproj
+++ b/feed-source/FeedApi/FeedApi.fsproj
@@ -20,7 +20,7 @@
   <ItemGroup>
     <PackageReference Include="Argu" Version="6.1.1" />
     <PackageReference Include="Destructurama.FSharp" Version="1.2.0" />
-    <PackageReference Include="Equinox.CosmosStore.Prometheus" Version="3.0.5" />
+    <PackageReference Include="Equinox.CosmosStore.Prometheus" Version="3.0.6" />
     <PackageReference Include="prometheus-net.AspNetCore" Version="3.6.0" />
     <PackageReference Include="Serilog.Sinks.Async" Version="1.5.0" />
     <PackageReference Include="Serilog.AspNetCore" Version="3.2.0" />

--- a/periodic-ingester/PeriodicIngester.fsproj
+++ b/periodic-ingester/PeriodicIngester.fsproj
@@ -18,11 +18,11 @@
   <ItemGroup>
     <PackageReference Include="Argu" Version="6.1.1" />
     <PackageReference Include="Destructurama.FSharp" Version="1.2.0" />
-    <PackageReference Include="Equinox.CosmosStore.Prometheus" Version="3.0.5" />
+    <PackageReference Include="Equinox.CosmosStore.Prometheus" Version="3.0.6" />
     <PackageReference Include="FsCodec.SystemTextJson" Version="2.3.0" />
     <PackageReference Include="prometheus-net.AspNetCore" Version="3.6.0" />
-    <PackageReference Include="Propulsion.CosmosStore" Version="2.12.0-rc.3" />
-    <PackageReference Include="Propulsion.Feed" Version="2.12.0-rc.3" />
+    <PackageReference Include="Propulsion.CosmosStore" Version="2.12.1" />
+    <PackageReference Include="Propulsion.Feed" Version="2.12.1" />
     <PackageReference Include="Serilog.Sinks.Async" Version="1.5.0" />
     <PackageReference Include="Serilog.Sinks.Console" Version="4.0.0" />
   </ItemGroup>

--- a/propulsion-archiver/Archiver.fsproj
+++ b/propulsion-archiver/Archiver.fsproj
@@ -15,8 +15,8 @@
   <ItemGroup>
     <PackageReference Include="Argu" Version="6.1.1" />
     <PackageReference Include="Destructurama.FSharp" Version="1.2.0" />
-    <PackageReference Include="Equinox.CosmosStore.Prometheus" Version="3.0.5" />
-	<PackageReference Include="Propulsion.CosmosStore" Version="2.12.0-rc.3" />
+    <PackageReference Include="Equinox.CosmosStore.Prometheus" Version="3.0.6" />
+	<PackageReference Include="Propulsion.CosmosStore" Version="2.12.1" />
 	<PackageReference Include="prometheus-net.AspNetCore" Version="3.6.0" />
     <PackageReference Include="Serilog.Sinks.Async" Version="1.5.0" />
     <PackageReference Include="Serilog.Sinks.Console" Version="4.0.0" />

--- a/propulsion-archiver/Program.fs
+++ b/propulsion-archiver/Program.fs
@@ -213,8 +213,7 @@ let run (args : Args.Arguments) = async {
 [<EntryPoint>]
 let main argv =
     try let args = Args.parse EnvVar.tryGet argv
-        let appName = sprintf "archiver:%s" args.ProcessorName
-        try Log.Logger <- LoggerConfiguration().Configure(appName, args.Verbose, args.SyncLogging).CreateLogger()
+        try Log.Logger <- LoggerConfiguration().Configure(AppName, args.Verbose, args.SyncLogging).CreateLogger()
             try run args |> Async.RunSynchronously; 0
             with e when not (e :? MissingArg) -> Log.Fatal(e, "Exiting"); 2
         finally Log.CloseAndFlush()

--- a/propulsion-consumer/Consumer.fsproj
+++ b/propulsion-consumer/Consumer.fsproj
@@ -17,7 +17,7 @@
     <PackageReference Include="Argu" Version="6.1.1" />
     <PackageReference Include="Destructurama.FSharp" Version="1.2.0" />
     <PackageReference Include="FsCodec.SystemTextJson" Version="2.3.0" />
-    <PackageReference Include="Propulsion.Kafka" Version="2.12.0-rc.3" />
+    <PackageReference Include="Propulsion.Kafka" Version="2.12.1" />
     <PackageReference Include="Serilog.Sinks.Console" Version="4.0.0" />
   </ItemGroup>
 

--- a/propulsion-cosmos-reactor/Reactor.fsproj
+++ b/propulsion-cosmos-reactor/Reactor.fsproj
@@ -21,10 +21,10 @@
     <ItemGroup>
         <PackageReference Include="Argu" Version="6.1.1" />
         <PackageReference Include="Destructurama.FSharp" Version="1.2.0" />
-        <PackageReference Include="Equinox.CosmosStore.Prometheus" Version="3.0.5" />
+        <PackageReference Include="Equinox.CosmosStore.Prometheus" Version="3.0.6" />
         <PackageReference Include="FsCodec.SystemTextJson" Version="2.3.0" />
         <PackageReference Include="prometheus-net.AspNetCore" Version="3.6.0" />
-        <PackageReference Include="Propulsion.CosmosStore" Version="2.12.0-rc.3" />
+        <PackageReference Include="Propulsion.CosmosStore" Version="2.12.1" />
         <PackageReference Include="Serilog.Sinks.Async" Version="1.5.0" />
         <PackageReference Include="Serilog.Sinks.Console" Version="4.0.0" />
     </ItemGroup>

--- a/propulsion-projector/Projector.fsproj
+++ b/propulsion-projector/Projector.fsproj
@@ -17,21 +17,21 @@
     <PackageReference Include="Argu" Version="6.1.1" />
     <PackageReference Include="Destructurama.FSharp" Version="1.2.0" />
     <!--#if (esdb)-->
-    <PackageReference Include="Equinox.CosmosStore" Version="3.0.5" />
+    <PackageReference Include="Equinox.CosmosStore" Version="3.0.6" />
     <!--#endif-->
     <PackageReference Include="FsCodec.SystemTextJson" Version="2.3.0" />
     <!--#if cosmos-->
-    <PackageReference Include="Propulsion.CosmosStore" Version="2.12.0-rc.3" />
+    <PackageReference Include="Propulsion.CosmosStore" Version="2.12.1" />
     <!--#endif-->
     <!--#if (esdb)-->
-    <PackageReference Include="Propulsion.EventStore" Version="2.12.0-rc.3" />
+    <PackageReference Include="Propulsion.EventStore" Version="2.12.1" />
     <!--#endif-->
     <!--#if (sss)-->
-    <PackageReference Include="Equinox.SqlStreamStore.MsSql" Version="3.0.5" />
-    <PackageReference Include="Propulsion.SqlStreamStore" Version="2.12.0-rc.3" />
+    <PackageReference Include="Equinox.SqlStreamStore.MsSql" Version="3.0.6" />
+    <PackageReference Include="Propulsion.SqlStreamStore" Version="2.12.1" />
     <!--#endif-->
     <!--#if kafka-->
-    <PackageReference Include="Propulsion.Kafka" Version="2.12.0-rc.3" />
+    <PackageReference Include="Propulsion.Kafka" Version="2.12.1" />
     <!--#endif-->
     <PackageReference Include="Serilog.Sinks.Console" Version="4.0.0" />
   </ItemGroup>

--- a/propulsion-pruner/Program.fs
+++ b/propulsion-pruner/Program.fs
@@ -202,8 +202,7 @@ let run (args : Args.Arguments) = async {
 [<EntryPoint>]
 let main argv =
     try let args = Args.parse EnvVar.tryGet argv
-        let appName = sprintf "pruner:%s" args.ProcessorName
-        try Log.Logger <- LoggerConfiguration().Configure(appName, args.Verbose, args.Source.Verbose).CreateLogger()
+        try Log.Logger <- LoggerConfiguration().Configure(AppName, args.Verbose, args.Source.Verbose).CreateLogger()
             try run args |> Async.RunSynchronously; 0
             with e when not (e :? MissingArg) -> Log.Fatal(e, "Exiting"); 2
         finally Log.CloseAndFlush()

--- a/propulsion-pruner/Program.fs
+++ b/propulsion-pruner/Program.fs
@@ -188,18 +188,22 @@ let startMetricsServer port : IDisposable =
 
 open Propulsion.CosmosStore.Infrastructure // AwaitKeyboardInterruptAsTaskCancelledException
 
-let run args = async {
-    let log = Log.ForContext<Propulsion.Streams.Scheduling.StreamSchedulingEngine>()
+let run (args : Args.Arguments) = async {
+    let log = (Log.forGroup args.ProcessorName).ForContext<Propulsion.Streams.Scheduling.StreamSchedulingEngine>()
     let sink, source = build (args, log)
     use _metricsServer : IDisposable = args.PrometheusPort |> Option.map startMetricsServer |> Option.toObj
-    return! Async.Parallel [ Async.AwaitKeyboardInterruptAsTaskCancelledException(); source.AwaitWithStopOnCancellation(); sink.AwaitWithStopOnCancellation() ] |> Async.Ignore<unit[]>
+    return! Async.Parallel [
+        Async.AwaitKeyboardInterruptAsTaskCancelledException()
+        source.AwaitWithStopOnCancellation()
+        sink.AwaitWithStopOnCancellation()
+    ] |> Async.Ignore<unit[]>
 }
 
 [<EntryPoint>]
 let main argv =
     try let args = Args.parse EnvVar.tryGet argv
         let appName = sprintf "pruner:%s" args.ProcessorName
-        try Log.Logger <- LoggerConfiguration().Configure(appName, args.ProcessorName, args.Verbose, args.Source.Verbose).CreateLogger()
+        try Log.Logger <- LoggerConfiguration().Configure(appName, args.Verbose, args.Source.Verbose).CreateLogger()
             try run args |> Async.RunSynchronously; 0
             with e when not (e :? MissingArg) -> Log.Fatal(e, "Exiting"); 2
         finally Log.CloseAndFlush()

--- a/propulsion-pruner/Pruner.fsproj
+++ b/propulsion-pruner/Pruner.fsproj
@@ -15,9 +15,9 @@
   <ItemGroup>
     <PackageReference Include="Argu" Version="6.1.1" />
     <PackageReference Include="Destructurama.FSharp" Version="1.2.0" />
-    <PackageReference Include="Equinox.CosmosStore.Prometheus" Version="3.0.5" />
+    <PackageReference Include="Equinox.CosmosStore.Prometheus" Version="3.0.6" />
     <PackageReference Include="prometheus-net.AspNetCore" Version="3.6.0" />
-    <PackageReference Include="Propulsion.CosmosStore" Version="2.12.0-rc.3" />
+    <PackageReference Include="Propulsion.CosmosStore" Version="2.12.1" />
     <PackageReference Include="Serilog.Sinks.Async" Version="1.5.0" />
     <PackageReference Include="Serilog.Sinks.Console" Version="4.0.0" />
     <PackageReference Include="Serilog.Sinks.Seq" Version="4.0.0" />

--- a/propulsion-reactor/Reactor.fsproj
+++ b/propulsion-reactor/Reactor.fsproj
@@ -34,16 +34,16 @@
         <PackageReference Include="Argu" Version="6.1.1" />
         <PackageReference Include="Destructurama.FSharp" Version="1.2.0" />
         <!--#if (kafkaEventSpans) -->
-        <PackageReference Include="Equinox.CosmosStore" Version="3.0.5" />
+        <PackageReference Include="Equinox.CosmosStore" Version="3.0.6" />
         <!--#else-->
-        <PackageReference Include="Propulsion.CosmosStore" Version="2.12.0-rc.3" />
+        <PackageReference Include="Propulsion.CosmosStore" Version="2.12.1" />
         <!--#endif-->
         <PackageReference Include="FsCodec.SystemTextJson" Version="2.3.0" />
         <!--#if (multiSource) -->
-        <PackageReference Include="Propulsion.EventStore" Version="2.12.0-rc.3" />
+        <PackageReference Include="Propulsion.EventStore" Version="2.12.1" />
         <!--#endif-->
         <!--#if (kafka || kafkaEventSpans) -->
-        <PackageReference Include="Propulsion.Kafka" Version="2.12.0-rc.3" />
+        <PackageReference Include="Propulsion.Kafka" Version="2.12.1" />
         <!--#endif-->
         <PackageReference Include="Serilog.Sinks.Console" Version="4.0.0" />
     </ItemGroup>

--- a/propulsion-summary-consumer/SummaryConsumer.fsproj
+++ b/propulsion-summary-consumer/SummaryConsumer.fsproj
@@ -18,9 +18,9 @@
   <ItemGroup>
     <PackageReference Include="Argu" Version="6.1.1" />
     <PackageReference Include="Destructurama.FSharp" Version="1.2.0" />
-    <PackageReference Include="Equinox.CosmosStore" Version="3.0.5" />
+    <PackageReference Include="Equinox.CosmosStore" Version="3.0.6" />
     <PackageReference Include="FsCodec.SystemTextJson" Version="2.3.0" />
-    <PackageReference Include="Propulsion.Kafka" Version="2.12.0-rc.3" />
+    <PackageReference Include="Propulsion.Kafka" Version="2.12.1" />
     <PackageReference Include="Serilog.Sinks.Console" Version="4.0.0" />
   </ItemGroup>
 

--- a/propulsion-sync/Infrastructure.fs
+++ b/propulsion-sync/Infrastructure.fs
@@ -7,7 +7,7 @@ open System
 
 module Config =
 
-    let log = Serilog.Log.ForContext("isMetric", true)
+    let log = Log.ForContext("isMetric", true)
 
 module EnvVar =
 
@@ -17,6 +17,8 @@ module Log =
 
     /// Allow logging to filter out emission of log messages whose information is also surfaced as metrics
     let isStoreMetrics e = Filters.Matching.WithProperty("isMetric").Invoke e
+    /// The Propulsion.Streams.Prometheus LogSink uses this well-known property to identify consumer group associated with the Scheduler
+    let forGroup group = Log.ForContext("group", group)
 
 type Equinox.CosmosStore.CosmosStoreConnector with
 

--- a/propulsion-sync/Program.fs
+++ b/propulsion-sync/Program.fs
@@ -565,8 +565,8 @@ let build (args : Args.Arguments, log) =
                 args.MaxReadAhead, args.StatsInterval)
         [ runPipeline; sink.AwaitWithStopOnCancellation() ]
 
-let run args =
-    let log = Log.ForContext<Propulsion.Streams.Scheduling.StreamSchedulingEngine>()
+let run (args : Args.Arguments) =
+    let log = (Log.forGroup args.ProcessorName).ForContext<Propulsion.Streams.Scheduling.StreamSchedulingEngine>()
     build (args, log) |> Async.Parallel |> Async.Ignore<unit[]>
 
 [<EntryPoint>]

--- a/propulsion-sync/Sync.fsproj
+++ b/propulsion-sync/Sync.fsproj
@@ -16,7 +16,7 @@
     <PackageReference Include="Argu" Version="6.1.1" />
     <PackageReference Include="Destructurama.FSharp" Version="1.2.0" />
     <PackageReference Include="Propulsion.EventStore" Version="2.10.0" />
-    <PackageReference Include="Propulsion.CosmosStore" Version="2.12.0-rc.3" />
+    <PackageReference Include="Propulsion.CosmosStore" Version="2.12.1" />
     <!--#if (kafka)-->
     <PackageReference Include="Propulsion.Kafka" Version="2.10.0" />
     <!--#endif-->

--- a/propulsion-tracking-consumer/TrackingConsumer.fsproj
+++ b/propulsion-tracking-consumer/TrackingConsumer.fsproj
@@ -18,9 +18,9 @@
   <ItemGroup>
     <PackageReference Include="Argu" Version="6.1.1" />
     <PackageReference Include="Destructurama.FSharp" Version="1.2.0" />
-	<PackageReference Include="Equinox.CosmosStore" Version="3.0.5" />
+	<PackageReference Include="Equinox.CosmosStore" Version="3.0.6" />
 	<PackageReference Include="FsCodec.SystemTextJson" Version="2.3.0" />
-	<PackageReference Include="Propulsion.Kafka" Version="2.12.0-rc.3" />
+	<PackageReference Include="Propulsion.Kafka" Version="2.12.1" />
     <PackageReference Include="Serilog.Sinks.Console" Version="4.0.0" />
   </ItemGroup>
 


### PR DESCRIPTION
- Facilitate >1 Projector instance per process supplying metrics to Prometheus with correct `group` label values.
- removed Pruner+Archiver hack of embedding consumer group into `appName`  to allow pruners and archivers to be separated - the Grafana dashboards in #108 should instead include use the `group` label to enable them to be filtered/split  