### PR TITLE
Shipping: Apply Process Patterns

### DIFF
--- a/equinox-shipping/Domain.Tests/Domain.Tests.fsproj
+++ b/equinox-shipping/Domain.Tests/Domain.Tests.fsproj
@@ -12,7 +12,7 @@
         <Compile Include="ContainerTests.fs" />
         <Compile Include="ShipmentTests.fs" />
         <Compile Include="FinalizationTransactionTests.fs" />
-        <Compile Include="FinalizationWorkflowTests.fs" />
+        <Compile Include="FinalizationProcessTests.fs" />
     </ItemGroup>
 
     <ItemGroup>

--- a/equinox-shipping/Domain.Tests/FinalizationProcessTests.fs
+++ b/equinox-shipping/Domain.Tests/FinalizationProcessTests.fs
@@ -1,4 +1,4 @@
-module Shipping.Domain.Tests.FinalizationWorkflowTests
+module Shipping.Domain.Tests.FinalizationProcessTests
 
 open Shipping.Domain
 
@@ -20,14 +20,14 @@ type Custom =
 
 module FE = FinalizationTransaction.Events
 
-let [<Property>] ``FinalizationWorkflow properties``
+let [<Property>] properties
     (   GuidStringN transId1, GuidStringN transId2, GuidStringN containerId1, GuidStringN containerId2,
         NonEmptyArray (Ids shipmentIds1), NonEmptyArray (Ids shipmentIds2), GuidStringN shipment3) = async {
     let store = Equinox.MemoryStore.VolatileStore()
     let buffer = EventAccumulator()
     use __ = store.Committed.Subscribe buffer.Record
     let eventTypes = seq { for e in buffer.All() -> e.EventType }
-    let engine = FinalizationWorkflow.Config.createEngine 16 (Config.Store.Memory store)
+    let engine = FinalizationProcess.Config.createEngine 16 (Config.Store.Memory store)
 
     (* First, run the happy path - should pass through all stages of the lifecycle *)
     let requestedShipmentIds = Array.append shipmentIds1 shipmentIds2

--- a/equinox-shipping/Domain.Tests/FinalizationWorkflowTests.fs
+++ b/equinox-shipping/Domain.Tests/FinalizationWorkflowTests.fs
@@ -27,11 +27,11 @@ let [<Property>] ``FinalizationWorkflow properties``
     let buffer = EventAccumulator()
     use __ = store.Committed.Subscribe buffer.Record
     let eventTypes = seq { for e in buffer.All() -> e.EventType }
-    let processManager = FinalizationWorkflow.Config.create 16 (Config.Store.Memory store)
+    let engine = FinalizationWorkflow.Config.createEngine 16 (Config.Store.Memory store)
 
     (* First, run the happy path - should pass through all stages of the lifecycle *)
     let requestedShipmentIds = Array.append shipmentIds1 shipmentIds2
-    let! res1 = processManager.TryFinalizeContainer(transId1, containerId1, requestedShipmentIds)
+    let! res1 = engine.TryFinalizeContainer(transId1, containerId1, requestedShipmentIds)
     let expectedEvents =
         [   nameof(FE.FinalizationRequested); nameof(FE.ReservationCompleted); nameof(FE.AssignmentCompleted); nameof(FE.Completed) // Transaction
             nameof(Shipment.Events.Reserved); nameof(FE.Assigned) // Shipment
@@ -48,7 +48,7 @@ let [<Property>] ``FinalizationWorkflow properties``
        a) yield a fail result
        b) result in triggering of Revert flow with associated Shipment revoke events *)
     buffer.Clear()
-    let! res2 = processManager.TryFinalizeContainer(transId2, containerId2, Array.append shipmentIds2 [|shipment3|])
+    let! res2 = engine.TryFinalizeContainer(transId2, containerId2, Array.append shipmentIds2 [|shipment3|])
     let expectedEvents =
         [   nameof(FE.FinalizationRequested); nameof(FE.RevertCommenced); nameof(FE.Completed) // Transaction
             nameof(Shipment.Events.Reserved); nameof(Shipment.Events.Revoked) ] // Shipment

--- a/equinox-shipping/Domain/Domain.fsproj
+++ b/equinox-shipping/Domain/Domain.fsproj
@@ -12,7 +12,7 @@
         <Compile Include="Shipment.fs" />
         <Compile Include="Container.fs" />
         <Compile Include="FinalizationTransaction.fs" />
-        <Compile Include="FinalizationWorkflow.fs" />
+        <Compile Include="FinalizationProcess.fs" />
         <Compile Include="TransactionWatchdog.fs" />
     </ItemGroup>
 

--- a/equinox-shipping/Domain/FinalizationProcess.fs
+++ b/equinox-shipping/Domain/FinalizationProcess.fs
@@ -1,4 +1,4 @@
-module Shipping.Domain.FinalizationWorkflow
+module Shipping.Domain.FinalizationProcess
 
 open FinalizationTransaction
 

--- a/equinox-shipping/Domain/FinalizationTransaction.fs
+++ b/equinox-shipping/Domain/FinalizationTransaction.fs
@@ -72,7 +72,7 @@ module Flow =
         | Fold.State.Assigning s -> Action.AssignShipments   (s.shipments, s.container)
         | Fold.State.Assigned s ->  Action.FinalizeContainer (s.container, s.shipments)
         | Fold.State.Completed r -> Action.Finish             r.success
-        // As all state transitions are driven by members on the FinalizationWorkflow, we can rule this out
+        // As all state transitions are driven by FinalizationProcess, we can rule this out
         | Fold.State.Initial as s      -> failwith (sprintf "Cannot interpret state %A" s)
 
     let isValidTransition (event : Events.Event) (state : Fold.State) =

--- a/equinox-shipping/Watchdog.Integration/ReactorFixture.fs
+++ b/equinox-shipping/Watchdog.Integration/ReactorFixture.fs
@@ -21,11 +21,11 @@ type MemoryReactorFixture(testOutput) =
             | x -> failwith $"unexpected store config %A{x}"
         projectorStoreSubscription, projector, stats
     let processingTimeout, maxDop = TimeSpan.FromSeconds 1., 4
-    let engine = Shipping.Domain.FinalizationProcess.Config.createEngine maxDop store.Config
-    let handle = Handler.createHandler processingTimeout engine
+    let manager = Shipping.Domain.FinalizationProcess.Config.create maxDop store.Config
+    let handle = Handler.createHandler processingTimeout manager
     let storeSub, projector, stats = buildProjector Handler.isRelevant handle
 
-    member val Engine = engine
+    member val ProcessManager = manager
     member val RunTimeout = TimeSpan.FromSeconds 0.1
     member val Log = log
 

--- a/equinox-shipping/Watchdog.Integration/ReactorFixture.fs
+++ b/equinox-shipping/Watchdog.Integration/ReactorFixture.fs
@@ -21,7 +21,7 @@ type MemoryReactorFixture(testOutput) =
             | x -> failwith $"unexpected store config %A{x}"
         projectorStoreSubscription, projector, stats
     let processingTimeout, maxDop = TimeSpan.FromSeconds 1., 4
-    let engine = Shipping.Domain.FinalizationWorkflow.Config.createEngine maxDop store.Config
+    let engine = Shipping.Domain.FinalizationProcess.Config.createEngine maxDop store.Config
     let handle = Handler.createHandler processingTimeout engine
     let storeSub, projector, stats = buildProjector Handler.isRelevant handle
 

--- a/equinox-shipping/Watchdog.Integration/WatchdogIntegrationTests.fs
+++ b/equinox-shipping/Watchdog.Integration/WatchdogIntegrationTests.fs
@@ -14,7 +14,7 @@ type MemoryProperties(testOutput) =
         let mutable timeouts = 0
         for GuidStringN tid, GuidStringN cid, IdsAtLeastOne shipmentIds in batches do
             counts.Push shipmentIds.Length
-            try let! _ = reactor.ProcessManager.TryFinalizeContainer(tid, cid, shipmentIds)
+            try let! _ = reactor.Engine.TryFinalizeContainer(tid, cid, shipmentIds)
                          |> Async.timeoutAfter reactor.RunTimeout
                 ()
             with :? TimeoutException -> timeouts <- timeouts + 1

--- a/equinox-shipping/Watchdog.Integration/WatchdogIntegrationTests.fs
+++ b/equinox-shipping/Watchdog.Integration/WatchdogIntegrationTests.fs
@@ -6,7 +6,7 @@ open System
 
 type MemoryProperties(testOutput) =
 
-    [<Property(StartSize=1000, MaxTest=5)>]
+    [<Property(StartSize = 1000, MaxTest = 5)>]
     let run (NonEmptyArray batches) = async {
 
         use reactor = new MemoryReactorFixture(testOutput) // Run under debugger and/or adjust XunitLogger.minLevel to see events in test output
@@ -14,7 +14,7 @@ type MemoryProperties(testOutput) =
         let mutable timeouts = 0
         for GuidStringN tid, GuidStringN cid, IdsAtLeastOne shipmentIds in batches do
             counts.Push shipmentIds.Length
-            try let! _ = reactor.Engine.TryFinalizeContainer(tid, cid, shipmentIds)
+            try let! _ = reactor.ProcessManager.TryFinalizeContainer(tid, cid, shipmentIds)
                          |> Async.timeoutAfter reactor.RunTimeout
                 ()
             with :? TimeoutException -> timeouts <- timeouts + 1

--- a/equinox-shipping/Watchdog/Handler.fs
+++ b/equinox-shipping/Watchdog/Handler.fs
@@ -57,5 +57,5 @@ let handle
     | other ->
         return failwithf "Span from unexpected category %A" other }
 
-let createHandler processingTimeout (engine : FinalizationWorkflow.Engine) =
+let createHandler processingTimeout (engine : FinalizationProcess.Engine) =
     handle processingTimeout engine.Pump

--- a/equinox-shipping/Watchdog/Handler.fs
+++ b/equinox-shipping/Watchdog/Handler.fs
@@ -56,3 +56,6 @@ let handle
             return Propulsion.Streams.SpanResult.AllProcessed, Outcome.Resolved success
     | other ->
         return failwithf "Span from unexpected category %A" other }
+
+let createHandler processingTimeout (engine : FinalizationWorkflow.Engine) =
+    handle processingTimeout engine.Pump

--- a/equinox-shipping/Watchdog/Handler.fs
+++ b/equinox-shipping/Watchdog/Handler.fs
@@ -57,5 +57,5 @@ let handle
     | other ->
         return failwithf "Span from unexpected category %A" other }
 
-let createHandler processingTimeout (engine : FinalizationProcess.Engine) =
+let createHandler processingTimeout (engine : FinalizationProcess.Manager) =
     handle processingTimeout engine.Pump

--- a/equinox-shipping/Watchdog/Infrastructure.fs
+++ b/equinox-shipping/Watchdog/Infrastructure.fs
@@ -43,7 +43,7 @@ module CosmosStoreContext =
     /// Create with default packing and querying policies. Search for other `module CosmosStoreContext` impls for custom variations
     let create (storeClient : Equinox.CosmosStore.CosmosStoreClient) =
         let maxEvents = 256
-        Equinox.CosmosStore.CosmosStoreContext(storeClient, tipMaxEvents=maxEvents)
+        Equinox.CosmosStore.CosmosStoreContext(storeClient, tipMaxEvents = maxEvents)
 
 [<System.Runtime.CompilerServices.Extension>]
 type Logging() =
@@ -55,4 +55,4 @@ type Logging() =
             .Enrich.FromLogContext()
         |> fun c -> if verbose = Some true then c.MinimumLevel.Debug() else c
         |> fun c -> let t = "[{Timestamp:HH:mm:ss} {Level:u3}] {Message:lj} {NewLine}{Exception}"
-                    c.WriteTo.Console(theme=Sinks.SystemConsole.Themes.AnsiConsoleTheme.Code, outputTemplate=t)
+                    c.WriteTo.Console(theme = Sinks.SystemConsole.Themes.AnsiConsoleTheme.Code, outputTemplate = t)

--- a/equinox-shipping/Watchdog/Program.fs
+++ b/equinox-shipping/Watchdog/Program.fs
@@ -102,7 +102,7 @@ module Args =
     /// Parse the commandline; can throw exceptions in response to missing arguments and/or `-h`/`--help` args
     let parse tryGetConfigValue argv : Arguments =
         let programName = System.Reflection.Assembly.GetEntryAssembly().GetName().Name
-        let parser = ArgumentParser.Create<Parameters>(programName=programName)
+        let parser = ArgumentParser.Create<Parameters>(programName = programName)
         Arguments(Configuration tryGetConfigValue, parser.ParseCommandLine argv)
 
 let [<Literal>] AppName = "Watchdog"
@@ -118,8 +118,8 @@ let build (args : Args.Arguments) =
         let cache = Equinox.Cache (AppName, sizeMb = 10)
         Shipping.Domain.Config.Store.Cosmos (context, cache)
     let sink =
-        let engine = Shipping.Domain.FinalizationProcess.Config.createEngine args.ProcessManagerMaxDop store
-        let handle = Handler.createHandler args.ProcessingTimeout engine
+        let manager = Shipping.Domain.FinalizationProcess.Config.create args.ProcessManagerMaxDop store
+        let handle = Handler.createHandler args.ProcessingTimeout manager
         let stats = Handler.Stats(Log.Logger, statsInterval = args.StatsInterval, stateInterval = args.StateInterval)
         createProjector Log.Logger (maxReadAhead, maxConcurrentStreams) handle stats
     let source =
@@ -140,7 +140,7 @@ let run args =
 [<EntryPoint>]
 let main argv =
     try let args = Args.parse EnvVar.tryGet argv
-        try Log.Logger <- LoggerConfiguration().Configure(verbose=args.Verbose).CreateLogger()
+        try Log.Logger <- LoggerConfiguration().Configure(verbose = args.Verbose).CreateLogger()
             try run args |> Async.RunSynchronously; 0
             with e when not (e :? MissingArg) -> Log.Fatal(e, "Exiting"); 2
         finally Log.CloseAndFlush()

--- a/equinox-shipping/Watchdog/Program.fs
+++ b/equinox-shipping/Watchdog/Program.fs
@@ -118,7 +118,7 @@ let build (args : Args.Arguments) =
         let cache = Equinox.Cache (AppName, sizeMb = 10)
         Shipping.Domain.Config.Store.Cosmos (context, cache)
     let sink =
-        let engine = Shipping.Domain.FinalizationWorkflow.Config.createEngine args.ProcessManagerMaxDop store
+        let engine = Shipping.Domain.FinalizationProcess.Config.createEngine args.ProcessManagerMaxDop store
         let handle = Handler.createHandler args.ProcessingTimeout engine
         let stats = Handler.Stats(Log.Logger, statsInterval = args.StatsInterval, stateInterval = args.StateInterval)
         createProjector Log.Logger (maxReadAhead, maxConcurrentStreams) handle stats


### PR DESCRIPTION
This applies some cleanup, chiefly of naming, to the `equinox-shipping` based on patterns observed in implementations:
- [x] Rename `Workflow` -> `Process`
- [x] Split Process into two parts:
   1. `Service`, which routes commands
   2. `Manager`, which maps Flow Actions to Commands
- [x] Improve alignment between Reactor Test Fixtures and the Program 