### PR TITLE
Cleanup projector/reactor sinks

### DIFF
--- a/propulsion-projector/Args.fs
+++ b/propulsion-projector/Args.fs
@@ -66,6 +66,7 @@ module Checkpoints =
 open Argu
 
 //#if (esdb || sss || cosmos)
+
 module Cosmos =
 
     type [<NoEquality; NoComparison>] Parameters =
@@ -99,9 +100,10 @@ module Cosmos =
         let container =                     p.TryGetResult Container |> Option.defaultWith (fun () -> c.CosmosContainer)
         member val Verbose =                p.Contains Verbose
         member _.Connect() =                connector.ConnectStore("Target", database, container)
+//#endif
 
-//#endif // cosmos
-//#if (esdb || sss || dynamo)
+// #if (esdb || sss || dynamo)
+
 module Dynamo =
 
     type [<NoEquality; NoComparison>] Parameters =
@@ -147,4 +149,4 @@ module Dynamo =
         member _.Connect() =                connector.LogConfiguration()
                                             let client = connector.CreateClient()
                                             client.ConnectStore("Main", table)
-//#endif // dynamo
+// #endif

--- a/propulsion-projector/Args.fs
+++ b/propulsion-projector/Args.fs
@@ -147,5 +147,4 @@ module Dynamo =
         member _.Connect() =                connector.LogConfiguration()
                                             let client = connector.CreateClient()
                                             client.ConnectStore("Main", table)
-
 //#endif // dynamo

--- a/propulsion-projector/Projector.fsproj
+++ b/propulsion-projector/Projector.fsproj
@@ -10,10 +10,10 @@
     <None Include="README.md" />
     <Compile Include="Infrastructure.fs" />
     <Compile Include="Config.fs" />
-    <Compile Include="Args.fs" />
-    <Compile Include="SourceArgs.fs" />
     <Compile Include="SourceConfig.fs" />
     <Compile Include="Handler.fs" />
+    <Compile Include="Args.fs" />
+    <Compile Include="SourceArgs.fs" />
     <Compile Include="Program.fs" />
   </ItemGroup>
 

--- a/propulsion-projector/README.md
+++ b/propulsion-projector/README.md
@@ -139,7 +139,7 @@ This project was generated using:
         # (either add environment variables as per step 0 or use -c to specify them)
 
         # generate a SQL Table to store checkpoints in
-        propulsion init ms
+        propulsion init ~~~~ms
 //#endif // sss         
          
 2. To run an instance of the Projector:
@@ -174,8 +174,8 @@ This project was generated using:
 //#if   sss
         # `-g default` defines the Projector Group identity - each id has a separate checkpoint in the Checkpoints Table
         # `-t topic0` identifies the Kafka topic to which the Projector should write
-        # ms specifies the source details (if you have specified SQLSTREAMSTORE_CONNECTION and/or SQLSTREAMSTORE_CONNECTION_CHECKPOINTS environment vars, no arguments are needed)
-        dotnet run -- -g default -t topic0 ms
+        # sqlms specifies the source details (if you have specified SQLSTREAMSTORE_CONNECTION and/or SQLSTREAMSTORE_CONNECTION_CHECKPOINTS environment vars, no arguments are needed)
+        dotnet run -- -g default -t topic0 sqlms
 //#endif // kafka && sss
 
 3. To create a Consumer, use `dotnet new proConsumer` or `dotnet new proReactor --source kafkaEventSpans`
@@ -202,7 +202,7 @@ This project was generated using:
         # (either add environment variables as per step 0 or use -c/-p to specify them)
         
         # `-g default` defines the Projector Group identity - each id has a separate checkpoint in the Checkpoints Table
-        # ms specifies the source details (if you have specified SQLSTREAMSTORE_CONNECTION and/or SQLSTREAMSTORE_CONNECTION_CHECKPOINTS environment vars, no arguments are needed)
-        dotnet run -- -g default ms
+        # sqlms specifies the source details (if you have specified SQLSTREAMSTORE_CONNECTION and/or SQLSTREAMSTORE_CONNECTION_CHECKPOINTS environment vars, no arguments are needed)
+        dotnet run -- -g default sqlms
 //#endif // !kafka && sss
 //#endif // !kafka

--- a/propulsion-projector/SourceArgs.fs
+++ b/propulsion-projector/SourceArgs.fs
@@ -197,10 +197,10 @@ module Esdb =
             Args.Checkpoints.createCheckpointStore (group, checkpointInterval, store) 
         member x.ConnectTarget(cache) : Config.Store =
             match p.GetSubCommand() with
-            | TargetStoreArgs.Cosmos a ->
+            | Cosmos a ->
                 let context = a.Connect() |> Async.RunSynchronously |> CosmosStoreContext.create
                 Config.Store.Cosmos (context, cache)
-            | TargetStoreArgs.Dynamo a ->
+            | Dynamo a ->
                 let context = a.Connect() |> DynamoStoreContext.create
                 Config.Store.Dynamo (context, cache)
             | _ -> Args.missingArg "Must specify `cosmos` or `dynamo` target store when source is `esdb`"

--- a/propulsion-projector/SourceArgs.fs
+++ b/propulsion-projector/SourceArgs.fs
@@ -198,12 +198,12 @@ module Esdb =
         member x.ConnectTarget(cache) : Config.Store =
             match p.GetSubCommand() with
             | Cosmos a ->
-                let context = a.Connect() |> Async.RunSynchronously |> CosmosStoreContext.create
+                let context = (Args.Cosmos.Arguments a).Connect() |> Async.RunSynchronously |> CosmosStoreContext.create
                 Config.Store.Cosmos (context, cache)
             | Dynamo a ->
-                let context = a.Connect() |> DynamoStoreContext.create
+                let context = (Args.Dynamo.Arguments a).Connect() |> DynamoStoreContext.create
                 Config.Store.Dynamo (context, cache)
-            | _ -> Args.missingArg "Must specify `cosmos` or `dynamo` target store when source is `esdb`"
+            | _ -> Args.missingArg "Must specify `cosmos` or `dynamo` checkpoint store when source is `esdb`"
 
 #endif // esdb
 #if sss

--- a/propulsion-projector/SourceArgs.fs
+++ b/propulsion-projector/SourceArgs.fs
@@ -198,10 +198,10 @@ module Esdb =
         member x.ConnectTarget(cache) : Config.Store =
             match p.GetSubCommand() with
             | Cosmos a ->
-                let context = (Args.Cosmos.Arguments a).Connect() |> Async.RunSynchronously |> CosmosStoreContext.create
+                let context = (Args.Cosmos.Arguments(c, a)).Connect() |> Async.RunSynchronously |> CosmosStoreContext.create
                 Config.Store.Cosmos (context, cache)
             | Dynamo a ->
-                let context = (Args.Dynamo.Arguments a).Connect() |> DynamoStoreContext.create
+                let context = (Args.Dynamo.Arguments(c, a)).Connect() |> DynamoStoreContext.create
                 Config.Store.Dynamo (context, cache)
             | _ -> Args.missingArg "Must specify `cosmos` or `dynamo` checkpoint store when source is `esdb`"
 

--- a/propulsion-reactor/Contract.fs
+++ b/propulsion-reactor/Contract.fs
@@ -30,7 +30,7 @@ module Input =
     open Propulsion.Internal
     let (|Decode|) (stream, span : Propulsion.Streams.StreamSpan<_>) =
         span |> Array.chooseV (EventCodec.tryDecode codec stream)
-    let [<return: Struct>](|StreamName|_|) = function FsCodec.StreamName.CategoryAndId (Category, ClientId.Parse clientId) -> ValueSome clientId | _ -> ValueNone
+    let [<return: Struct>] (|StreamName|_|) = function FsCodec.StreamName.CategoryAndId (Category, ClientId.Parse clientId) -> ValueSome clientId | _ -> ValueNone
     let [<return: Struct>] (|Parse|_|) = function
         | (StreamName clientId, _) & Decode events -> ValueSome struct (clientId, events)
         | _ -> ValueNone

--- a/propulsion-reactor/Program.fs
+++ b/propulsion-reactor/Program.fs
@@ -249,7 +249,7 @@ let build (args : Args.Arguments) =
 
     (* ESTABLISH stats, handle *)
     
-#if kafka // kafka 
+#if kafka
     let broker, topic = sinkParams.BuildTargetParams()
     let producer = Propulsion.Kafka.Producer(Log.Logger, AppName, broker, Confluent.Kafka.Acks.All, topic)
     let produceSummary (x : Propulsion.Codec.NewtonsoftJson.RenderedSummary) =

--- a/propulsion-reactor/README.md
+++ b/propulsion-reactor/README.md
@@ -48,10 +48,10 @@ This project was generated using:
         $env:PROPULSION_KAFKA_BROKER="instance.kafka.example.com:9092" # or use -b
 
         # `-g default` defines the Projector Group identity - each id has separated state in the checkpoints store (`Sync-default` in the cited `cosmos` store)
+        # `-t topic0` identifies the Kafka topic to which the Projector should write
         # `-c $env:EQUINOX_COSMOS_CONTAINER ` specifies the source (if you have specified 2x EQUINOX_COSMOS_* environment vars, no connection/database arguments are needed, but the monitored (source) container must be specified explicitly)
         # the second `cosmos` specifies the target store for the reactions (if you have specified 3x EQUINOX_COSMOS_* environment vars, no arguments are needed)
-        # `-t topic0` identifies the Kafka topic to which the Projector should write
-        dotnet run -- -g default cosmos -c $env:EQUINOX_COSMOS_CONTAINER cosmos kafka -t topic0
+        dotnet run -- -g default kafka -t topic0 cosmos -c $env:EQUINOX_COSMOS_CONTAINER cosmos
 //#else
         # `-g default` defines the Projector Group identity - each id has separated state in the checkpoints store (`Sync-default` in the cited `cosmos` store)
         # `-c $env:EQUINOX_COSMOS_CONTAINER ` specifies the source (if you have specified EQUINOX_COSMOS_* environment vars, no connection/database arguments are needed, but the monitored (source) container must be specified explicitly)
@@ -71,10 +71,10 @@ This project was generated using:
         $env:PROPULSION_KAFKA_BROKER="instance.kafka.example.com:9092" # or use -b
 
         # `-g default` defines the Projector Group identity - each id has separated state in the checkpoints store (`Sync-default` in the cited `cosmos` store)
+        # `-t topic0` identifies the Kafka topic to which the Projector should write
         # `es` specifies the source (if you have specified 3x EQUINOX_ES_* environment vars, no arguments are needed)
         # `cosmos` specifies the checkpoint store (if you have specified 3x EQUINOX_COSMOS_* environment vars, no arguments are needed)
-        # `-t topic0` identifies the Kafka topic to which the Projector should write
-        dotnet run -- -g default es cosmos kafka -t topic0
+        dotnet run -- -g default kafka -t topic0 es cosmos
 //#else
         # `-g default` defines the Projector Group identity - each id has separated state in the checkpoints store (`Sync-default` in the cited `cosmos` store)
         # `es` specifies the source (if you have specified 3x EQUINOX_ES_* environment vars, no arguments are needed)

--- a/propulsion-reactor/Reactor.fsproj
+++ b/propulsion-reactor/Reactor.fsproj
@@ -12,6 +12,7 @@
         <!--#endif-->
         <Compile Include="Infrastructure.fs" />
         <Compile Include="Config.fs" />
+        <Compile Include="SourceConfig.fs" />
         <!--#if (!blank) -->
         <Compile Include="Todo.fs" />
         <!--#endif-->
@@ -21,15 +22,14 @@
         <!--#if (!kafka && !blank) -->
         <Compile Include="TodoSummary.fs" />
         <!--#endif-->
-        <Compile Include="Args.fs" />
-        <Compile Include="SourceArgs.fs" />
-        <Compile Include="SourceConfig.fs" />
         <!--#if (!kafka) -->
         <Compile Include="Ingester.fs" />
         <!--#endif-->
         <!--#if (!sourceKafka || kafka) -->
         <Compile Include="Handler.fs" />
         <!--#endif-->
+        <Compile Include="Args.fs" />
+        <Compile Include="SourceArgs.fs" />
         <Compile Include="Program.fs" />
     </ItemGroup>
 

--- a/propulsion-reactor/SourceArgs.fs
+++ b/propulsion-reactor/SourceArgs.fs
@@ -20,7 +20,7 @@ type Configuration(tryGet) =
 
 #endif
 
-#if !(sourceKafka && blank && kafka) 
+#if !(kafka && blank) 
 type [<RequireQualifiedAccess; NoComparison; NoEquality>]
     TargetStoreArgs =
     | Cosmos of Args.Cosmos.Arguments
@@ -67,13 +67,13 @@ module Kafka =
         member x.BuildSourceParams() =      x.Broker, x.Topic
 
 #if !(kafka && blank)
-        member private _.TargetStoreArgs : Args.TargetStoreArgs =
+        member private _.TargetStoreArgs : TargetStoreArgs =
             match p.GetSubCommand() with
-            | Cosmos cosmos -> Args.TargetStoreArgs.Cosmos (Args.Cosmos.Arguments(c, cosmos))
-            | Dynamo dynamo -> Args.TargetStoreArgs.Dynamo (Args.Dynamo.Arguments(c, dynamo))
+            | Cosmos cosmos -> TargetStoreArgs.Cosmos (Args.Cosmos.Arguments(c, cosmos))
+            | Dynamo dynamo -> TargetStoreArgs.Dynamo (Args.Dynamo.Arguments(c, dynamo))
             | _ -> Args.missingArg "Must specify `cosmos` or `dynamo` target store when source is `kafka`"
         member x.ConnectTarget(cache) : Config.Store =
-            Args.TargetStoreArgs.connectTarget x.TargetStoreArgs cache
+            TargetStoreArgs.connectTarget x.TargetStoreArgs cache
 #endif
 #else // !sourceKafka
 module Cosmos =

--- a/tests/Equinox.Templates.Tests/DotnetBuild.fs
+++ b/tests/Equinox.Templates.Tests/DotnetBuild.fs
@@ -45,7 +45,7 @@ type DotnetBuild(output : ITestOutputHelper, folder : EquinoxTemplatesFixture) =
         Dotnet.build [folder]
 
     #if DEBUG // Use this one to trigger an individual test
-    let [<Fact>] ``*pending*`` ()               = run "proProjector" ["--source cosmos"; "--kafka"]
+    let [<Fact>] ``*pending*`` ()               = run "proProjector" ["--source eventStore"; "--kafka"]
     #endif
     let [<Fact>] eqxPatterns ()                 = run "eqxPatterns" []
     let [<Fact>] eqxTestbed ()                  = run "eqxTestbed" []

--- a/tests/Equinox.Templates.Tests/DotnetBuild.fs
+++ b/tests/Equinox.Templates.Tests/DotnetBuild.fs
@@ -45,7 +45,7 @@ type DotnetBuild(output : ITestOutputHelper, folder : EquinoxTemplatesFixture) =
         Dotnet.build [folder]
 
     #if DEBUG // Use this one to trigger an individual test
-    let [<Fact>] ``*pending*`` ()               = run "proReactor" ["--source kafkaEventSpans"]
+    let [<Fact>] ``*pending*`` ()               = run "proProjector" ["--source eventStore"]
     #endif
     let [<Fact>] eqxPatterns ()                 = run "eqxPatterns" []
     let [<Fact>] eqxTestbed ()                  = run "eqxTestbed" []

--- a/tests/Equinox.Templates.Tests/DotnetBuild.fs
+++ b/tests/Equinox.Templates.Tests/DotnetBuild.fs
@@ -45,7 +45,7 @@ type DotnetBuild(output : ITestOutputHelper, folder : EquinoxTemplatesFixture) =
         Dotnet.build [folder]
 
     #if DEBUG // Use this one to trigger an individual test
-    let [<Fact>] ``*pending*`` ()               = run "eqxwebcs" ["--todos"; "--cosmos"]
+    let [<Fact>] ``*pending*`` ()               = run "proReactor" ["--source kafkaEventSpans"]
     #endif
     let [<Fact>] eqxPatterns ()                 = run "eqxPatterns" []
     let [<Fact>] eqxTestbed ()                  = run "eqxTestbed" []

--- a/tests/Equinox.Templates.Tests/DotnetBuild.fs
+++ b/tests/Equinox.Templates.Tests/DotnetBuild.fs
@@ -45,7 +45,7 @@ type DotnetBuild(output : ITestOutputHelper, folder : EquinoxTemplatesFixture) =
         Dotnet.build [folder]
 
     #if DEBUG // Use this one to trigger an individual test
-    let [<Fact>] ``*pending*`` ()               = run "proProjector" ["--source eventStore"]
+    let [<Fact>] ``*pending*`` ()               = run "proProjector" ["--source cosmos"; "--kafka"]
     #endif
     let [<Fact>] eqxPatterns ()                 = run "eqxPatterns" []
     let [<Fact>] eqxTestbed ()                  = run "eqxTestbed" []


### PR DESCRIPTION
Changes the parameter order in proReactor to make the source specification be the last argument
This removes a lot of mess from the templates, most critically, `proReactor`