### PR TITLE
refactor: Tidy Argu processing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ The `Unreleased` section name is replaced by the expected version of next releas
 ### Changed
 
 - Target `Equinox` v `4.0.0-rc.14.5`, `Propulsion` v `3.0.0-rc.9.11`, `FsCodec` v `3.0.0-rc.14.1` [#131](https://github.com/jet/dotnet-templates/pull/131)
+- Target `Argu` v `6.0.14` [#135](https://github.com/jet/dotnet-templates/pull/135)
 
 ### Removed 
  

--- a/README.md
+++ b/README.md
@@ -353,10 +353,9 @@ let main argv =
     try let args = Args.parse EnvVar.tryGet argv
         try Log.Logger <- LoggerConfiguration().Configure(verbose=args.Verbose).CreateLogger()
             try run args |> Async.RunSynchronously; 0
-            with e when not (e :? MissingArg) -> Log.Fatal(e, "Exiting"); 2
+            with e when not (e :? System.Threading.Tasks.TaskCanceledException) -> Log.Fatal(e, "Exiting"); 2
         finally Log.CloseAndFlush()
-    with MissingArg msg -> eprintfn "%s" msg; 1
-        | :? Argu.ArguParseException as e -> eprintfn "%s" e.Message; 1
+    with :? Argu.ArguParseException as e -> eprintfn "%s" e.Message; 1
         | e -> eprintf "Exception %s" e.Message; 1
 ```
 

--- a/equinox-shipping/Watchdog.Lambda/Function.fs
+++ b/equinox-shipping/Watchdog.Lambda/Function.fs
@@ -13,7 +13,7 @@ open System
 type Configuration(appName, ?tryGet) =
     let envVarTryGet = Environment.GetEnvironmentVariable >> Option.ofObj
     let tryGet = defaultArg tryGet envVarTryGet
-    let get key = match tryGet key with Some value -> value | None -> failwithf "Missing Argument/Environment Variable %s" key
+    let get key = match tryGet key with Some value -> value | None -> failwithf $"Missing Argument/Environment Variable %s{key}"
 
     member _.DynamoRegion =             tryGet Propulsion.DynamoStore.Lambda.Args.Dynamo.REGION
     member _.DynamoServiceUrl =         get Propulsion.DynamoStore.Lambda.Args.Dynamo.SERVICE_URL

--- a/equinox-shipping/Watchdog/Watchdog.fsproj
+++ b/equinox-shipping/Watchdog/Watchdog.fsproj
@@ -17,7 +17,7 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="Argu" Version="6.1.1" />
+        <PackageReference Include="Argu" Version="6.1.4" />
         <PackageReference Include="Propulsion.CosmosStore" Version="3.0.0-rc.9.11" />
         <PackageReference Include="Propulsion.DynamoStore" Version="3.0.0-rc.9.11" />
         <PackageReference Include="Propulsion.EventStoreDb" Version="3.0.0-rc.9.11" />

--- a/equinox-testbed/Testbed.fsproj
+++ b/equinox-testbed/Testbed.fsproj
@@ -16,7 +16,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Argu" Version="6.1.1" />
+    <PackageReference Include="Argu" Version="6.1.4" />
     <PackageReference Include="Equinox.CosmosStore" Version="4.0.0-rc.14.5" />
     <PackageReference Include="Equinox.EventStoreDb" Version="4.0.0-rc.14.5" />
     <PackageReference Include="Equinox.MemoryStore" Version="4.0.0-rc.14.5" />

--- a/feed-consumer/FeedConsumer.fsproj
+++ b/feed-consumer/FeedConsumer.fsproj
@@ -15,7 +15,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Argu" Version="6.1.1" />
+    <PackageReference Include="Argu" Version="6.1.4" />
     <PackageReference Include="Equinox.CosmosStore" Version="4.0.0-rc.14.5" />
     <PackageReference Include="Equinox.CosmosStore.Prometheus" Version="4.0.0-rc.14.5" />
     <PackageReference Include="FsCodec.SystemTextJson" Version="3.0.0-rc.14.1" />

--- a/feed-source/FeedApi/FeedApi.fsproj
+++ b/feed-source/FeedApi/FeedApi.fsproj
@@ -18,7 +18,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Argu" Version="6.1.1" />
+    <PackageReference Include="Argu" Version="6.1.4" />
     <PackageReference Include="Equinox.CosmosStore.Prometheus" Version="4.0.0-rc.14.5" />
     <PackageReference Include="prometheus-net.AspNetCore" Version="3.6.0" />
     <PackageReference Include="Serilog.Sinks.Async" Version="1.5.0" />

--- a/periodic-ingester/PeriodicIngester.fsproj
+++ b/periodic-ingester/PeriodicIngester.fsproj
@@ -16,7 +16,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Argu" Version="6.1.1" />
+    <PackageReference Include="Argu" Version="6.1.4" />
     <PackageReference Include="Equinox.CosmosStore.Prometheus" Version="4.0.0-rc.14.5" />
     <PackageReference Include="FsCodec.SystemTextJson" Version="3.0.0-rc.14.1" />
     <PackageReference Include="prometheus-net.AspNetCore" Version="3.6.0" />

--- a/propulsion-archiver/Archiver.fsproj
+++ b/propulsion-archiver/Archiver.fsproj
@@ -13,7 +13,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Argu" Version="6.1.1" />
+    <PackageReference Include="Argu" Version="6.1.4" />
     <PackageReference Include="Equinox.CosmosStore.Prometheus" Version="4.0.0-rc.14.5" />
     <PackageReference Include="Propulsion.CosmosStore" Version="3.0.0-rc.9.11" />
     <PackageReference Include="prometheus-net.AspNetCore" Version="3.6.0" />

--- a/propulsion-archiver/Program.fs
+++ b/propulsion-archiver/Program.fs
@@ -4,12 +4,9 @@ open Propulsion.CosmosStore
 open Serilog
 open System
 
-exception MissingArg of message: string with override this.Message = this.message
-let missingArg msg = raise (MissingArg msg)
-
 type Configuration(tryGet) =
 
-    let get key = match tryGet key with Some value -> value | None -> missingArg $"Missing Argument/Environment Variable %s{key}"
+    let get key = match tryGet key with Some value -> value | None -> failwith $"Missing Argument/Environment Variable %s{key}"
 
     member _.CosmosConnection =             get "EQUINOX_COSMOS_CONNECTION"
     member _.CosmosDatabase =               get "EQUINOX_COSMOS_DATABASE"
@@ -18,7 +15,7 @@ type Configuration(tryGet) =
 module Args =
 
     open Argu
-    [<NoEquality; NoComparison>]
+    [<NoEquality; NoComparison; RequireSubcommand>]
     type Parameters =
         | [<AltCommandLine "-V"; Unique>]   Verbose
         | [<AltCommandLine "-S"; Unique>]   SyncVerbose
@@ -28,7 +25,7 @@ module Args =
         | [<AltCommandLine "-w"; Unique>]   MaxWriters of int
         | [<AltCommandLine "-t"; Unique>]   RuThreshold of float
         | [<AltCommandLine "-k"; Unique>]   MaxKib of int
-        | [<CliPrefix(CliPrefix.None); AltCommandLine "cosmos"; Unique(*ExactlyOnce is not supported*); Last>] SrcCosmos of ParseResults<CosmosSourceParameters>
+        | [<CliPrefix(CliPrefix.None); AltCommandLine "cosmos">] SrcCosmos of ParseResults<CosmosSourceParameters>
         interface IArgParserTemplate with
             member p.Usage = p |> function
                 | Verbose ->                "request Verbose Logging. Default: off"
@@ -53,14 +50,14 @@ module Args =
         member val Source: CosmosSourceArguments =
             match p.GetSubCommand() with
             | SrcCosmos cosmos -> CosmosSourceArguments(c, cosmos)
-            | _ -> missingArg "Must specify cosmos for SrcCosmos"
+            | _ -> p.Raise "Must specify cosmos for SrcCosmos"
         member x.DestinationArchive = x.Source.Archive
         member x.Parameters() =
             Log.Information("Archiving... {dop} writers, max {maxReadAhead} batches read ahead, max write batch {maxKib} KiB",
                             x.MaxWriters, x.MaxReadAhead, x.MaxBytes / 1024)
             x.ProcessorName, x.MaxReadAhead, x.MaxWriters, x.MaxBytes
         
-    and [<NoEquality; NoComparison>] CosmosSourceParameters =
+    and [<NoEquality; NoComparison; RequireSubcommand>] CosmosSourceParameters =
         | [<AltCommandLine "-V"; Unique>]   Verbose
         | [<AltCommandLine "-Z"; Unique>]   FromTail
         | [<AltCommandLine "-b"; Unique>]   MaxItems of int
@@ -75,7 +72,7 @@ module Args =
         | [<AltCommandLine "-r">]           Retries of int
         | [<AltCommandLine "-rt">]          RetriesWaitTime of float
 
-        | [<CliPrefix(CliPrefix.None); AltCommandLine "cosmos"; Unique(*ExactlyOnce is not supported*); Last>] DstCosmos of ParseResults<CosmosSinkParameters>
+        | [<CliPrefix(CliPrefix.None); AltCommandLine "cosmos">] DstCosmos of ParseResults<CosmosSinkParameters>
         interface IArgParserTemplate with
             member p.Usage = p |> function
                 | Verbose ->                "request Verbose Change Feed Processor Logging. Default: off"
@@ -94,13 +91,13 @@ module Args =
 
                 | DstCosmos _ ->            "CosmosDb Sink parameters."
     and CosmosSourceArguments(c: Configuration, p: ParseResults<CosmosSourceParameters>) =
-        let discovery =                     p.TryGetResult CosmosSourceParameters.Connection |> Option.defaultWith (fun () -> c.CosmosConnection) |> Equinox.CosmosStore.Discovery.ConnectionString
+        let discovery =                     p.GetResult(CosmosSourceParameters.Connection, fun () -> c.CosmosConnection) |> Equinox.CosmosStore.Discovery.ConnectionString
         let mode =                          p.TryGetResult CosmosSourceParameters.ConnectionMode
         let timeout =                       p.GetResult(CosmosSourceParameters.Timeout, 5.) |> TimeSpan.FromSeconds
         let retries =                       p.GetResult(CosmosSourceParameters.Retries, 5)
         let maxRetryWaitTime =              p.GetResult(CosmosSourceParameters.RetriesWaitTime, 30.) |> TimeSpan.FromSeconds
         let connector =                     Equinox.CosmosStore.CosmosStoreConnector(discovery, timeout, retries, maxRetryWaitTime, ?mode = mode)
-        let database =                      p.TryGetResult CosmosSourceParameters.Database |> Option.defaultWith (fun () -> c.CosmosDatabase)
+        let database =                      p.GetResult(CosmosSourceParameters.Database, fun () -> c.CosmosDatabase)
         let fromTail =                      p.Contains CosmosSourceParameters.FromTail
         let maxItems =                      p.TryGetResult MaxItems
         let lagFrequency: TimeSpan =        p.GetResult(LagFreqM, 1.) |> TimeSpan.FromMinutes
@@ -114,7 +111,7 @@ module Args =
         member val Archive: CosmosSinkArguments =
             match p.GetSubCommand() with
             | DstCosmos cosmos -> CosmosSinkArguments(c, cosmos)
-            | _ -> missingArg "Must specify cosmos for Sink"
+            | _ -> p.Raise "Must specify cosmos for Sink"
     and [<NoEquality; NoComparison>] CosmosSinkParameters =
         | [<AltCommandLine "-m">]           ConnectionMode of Microsoft.Azure.Cosmos.ConnectionMode
         | [<AltCommandLine "-s">]           Connection of string
@@ -135,14 +132,14 @@ module Args =
                 | Retries _ ->              "specify operation retries. Default: 0."
                 | RetriesWaitTime _ ->      "specify max wait-time for retry when being throttled by Cosmos in seconds. Default: 5."
     and CosmosSinkArguments(c: Configuration, p: ParseResults<CosmosSinkParameters>) =
-        let discovery =                     p.TryGetResult Connection |> Option.defaultWith (fun () -> c.CosmosConnection) |> Equinox.CosmosStore.Discovery.ConnectionString
+        let discovery =                     p.GetResult(Connection, fun () -> c.CosmosConnection) |> Equinox.CosmosStore.Discovery.ConnectionString
         let mode =                          p.TryGetResult ConnectionMode
         let timeout =                       p.GetResult(Timeout, 5.) |> TimeSpan.FromSeconds
         let retries =                       p.GetResult(Retries, 0)
         let maxRetryWaitTime =              p.GetResult(RetriesWaitTime, 5.) |> TimeSpan.FromSeconds
         let connector =                     Equinox.CosmosStore.CosmosStoreConnector(discovery, timeout, retries, maxRetryWaitTime, ?mode = mode)
-        let container =                     p.TryGetResult Container |> Option.defaultWith (fun () -> c.CosmosContainer)
-        let databaseId =                    p.TryGetResult Database |> Option.defaultWith (fun () -> c.CosmosDatabase)
+        let container =                     p.GetResult(Container, fun () -> c.CosmosContainer)
+        let databaseId =                    p.GetResult(Database, fun () -> c.CosmosDatabase)
         let leaseContainerId =              p.TryGetResult LeaseContainer
         member val MaybeLeasesContainer: Microsoft.Azure.Cosmos.Container option = leaseContainerId |> Option.map (fun id -> connector.LeasesContainer(databaseId, id))
         member x.Connect() = async {        // while the default maxJsonBytes is 30000 - we are prepared to incur significant extra write RU charges in order to maximize packing
@@ -196,8 +193,7 @@ let main argv =
     try let args = Args.parse EnvVar.tryGet argv
         try Log.Logger <- LoggerConfiguration().Configure(AppName, args.Verbose, args.SyncLogging).CreateLogger()
             try run args |> Async.RunSynchronously; 0
-            with e when not (e :? MissingArg) && not (e :? System.Threading.Tasks.TaskCanceledException) -> Log.Fatal(e, "Exiting"); 2
+            with e when not (e :? System.Threading.Tasks.TaskCanceledException) -> Log.Fatal(e, "Exiting"); 2
         finally Log.CloseAndFlush()
-    with MissingArg msg -> eprintfn "%s" msg; 1
-        | :? Argu.ArguParseException as e -> eprintfn "%s" e.Message; 1
-        | e -> eprintf "Exception %s" e.Message; 1
+    with :? Argu.ArguParseException as e -> eprintfn $"%s{e.Message}"; 1
+        | e -> eprintf $"Exception %s{e.Message}"; 1

--- a/propulsion-consumer/Consumer.fsproj
+++ b/propulsion-consumer/Consumer.fsproj
@@ -14,7 +14,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Argu" Version="6.1.1" />
+    <PackageReference Include="Argu" Version="6.1.4" />
     <PackageReference Include="FsCodec.SystemTextJson" Version="3.0.0-rc.14.1" />
     <PackageReference Include="Propulsion.Kafka" Version="3.0.0-rc.9.11" />
     <PackageReference Include="Serilog.Sinks.Console" Version="4.0.1" />

--- a/propulsion-hotel/Reactor/Args.fs
+++ b/propulsion-hotel/Reactor/Args.fs
@@ -1,9 +1,6 @@
 /// Commandline arguments and/or secrets loading specifications
 module Args
 
-exception MissingArg of message: string with override this.Message = this.message
-let missingArg msg = raise (MissingArg msg)
-
 module Configuration =
 
     module Dynamo =
@@ -24,7 +21,7 @@ module Configuration =
 type Configuration(tryGet: string -> string option) =
 
     member val tryGet =                     tryGet
-    member _.get key =                      match tryGet key with Some value -> value | None -> missingArg $"Missing Argument/Environment Variable %s{key}"
+    member _.get key =                      match tryGet key with Some value -> value | None -> failwith $"Missing Argument/Environment Variable %s{key}"
 
 
     member x.DynamoRegion =                 tryGet Configuration.Dynamo.REGION

--- a/propulsion-hotel/Reactor/Reactor.fsproj
+++ b/propulsion-hotel/Reactor/Reactor.fsproj
@@ -17,7 +17,7 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="Argu" Version="6.1.1" />
+        <PackageReference Include="Argu" Version="6.1.4" />
         <PackageReference Include="Equinox.DynamoStore.Prometheus" Version="4.0.0-rc.14.5" />
         <PackageReference Include="prometheus-net.AspNetCore" Version="3.6.0" />
         <PackageReference Include="Propulsion.DynamoStore" Version="3.0.0-rc.9.11" />

--- a/propulsion-indexer/App/Configuration.fs
+++ b/propulsion-indexer/App/Configuration.fs
@@ -1,8 +1,5 @@
 module App.Args
 
-exception MissingArg of message: string with override this.Message = this.message
-let missingArg msg = raise (MissingArg msg)
-
 let [<Literal>] CONNECTION =                "EQUINOX_COSMOS_CONNECTION"
 let [<Literal>] DATABASE =                  "EQUINOX_COSMOS_DATABASE"
 let [<Literal>] CONTAINER =                 "EQUINOX_COSMOS_CONTAINER"
@@ -10,7 +7,7 @@ let [<Literal>] VIEWS =                     "EQUINOX_COSMOS_VIEWS"
 
 type Configuration(tryGet: string -> string option) =
 
-    let get key = match tryGet key with Some value -> value | None -> missingArg $"Missing Argument/Environment Variable %s{key}"
+    let get key = match tryGet key with Some value -> value | None -> failwith $"Missing Argument/Environment Variable %s{key}"
 
     member _.CosmosConnection =             get CONNECTION
     member _.CosmosDatabase =               get DATABASE

--- a/propulsion-indexer/Indexer/Indexer.fsproj
+++ b/propulsion-indexer/Indexer/Indexer.fsproj
@@ -16,7 +16,7 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="Argu" Version="6.1.1" />
+        <PackageReference Include="Argu" Version="6.1.4" />
     </ItemGroup>
 
     <ItemGroup>

--- a/propulsion-projector/Projector.fsproj
+++ b/propulsion-projector/Projector.fsproj
@@ -18,7 +18,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Argu" Version="6.1.1" />
+    <PackageReference Include="Argu" Version="6.1.4" />
     <!--#if (esdb)-->
     <PackageReference Include="Equinox.CosmosStore" Version="4.0.0-rc.14.5" />
     <PackageReference Include="Equinox.DynamoStore" Version="4.0.0-rc.14.5" />

--- a/propulsion-pruner/Pruner.fsproj
+++ b/propulsion-pruner/Pruner.fsproj
@@ -13,7 +13,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Argu" Version="6.1.1" />
+    <PackageReference Include="Argu" Version="6.1.4" />
     <PackageReference Include="Equinox.CosmosStore.Prometheus" Version="4.0.0-rc.14.5" />
     <PackageReference Include="prometheus-net.AspNetCore" Version="3.6.0" />
     <PackageReference Include="Propulsion.CosmosStore" Version="3.0.0-rc.9.11" />

--- a/propulsion-reactor/Args.fs
+++ b/propulsion-reactor/Args.fs
@@ -3,9 +3,6 @@ module ReactorTemplate.Args
 
 open System
 
-exception MissingArg of message: string with override this.Message = this.message
-let missingArg msg = raise (MissingArg msg)
-
 #if !(sourceKafka && blank && kafka) 
 let [<Literal>] REGION =                    "EQUINOX_DYNAMO_REGION"
 let [<Literal>] SERVICE_URL =               "EQUINOX_DYNAMO_SERVICE_URL"
@@ -18,7 +15,7 @@ let [<Literal>] INDEX_TABLE =               "EQUINOX_DYNAMO_TABLE_INDEX"
 type Configuration(tryGet: string -> string option) =
 
     member val tryGet =                     tryGet
-    member _.get key =                      match tryGet key with Some value -> value | None -> missingArg $"Missing Argument/Environment Variable %s{key}"
+    member _.get key =                      match tryGet key with Some value -> value | None -> failwith $"Missing Argument/Environment Variable %s{key}"
 
 #if !(sourceKafka && blank && kafka) 
     member x.CosmosConnection =             x.get "EQUINOX_COSMOS_CONNECTION"
@@ -65,15 +62,15 @@ module Cosmos =
                 | RetriesWaitTime _ ->      "specify max wait-time for retry when being throttled by Cosmos in seconds (default: 5)"
                 
     type Arguments(c: Configuration, p: ParseResults<Parameters>) =
-        let connection =                    p.TryGetResult Connection |> Option.defaultWith (fun () -> c.CosmosConnection)
+        let connection =                    p.GetResult(Connection, fun () -> c.CosmosConnection)
         let discovery =                     Equinox.CosmosStore.Discovery.ConnectionString connection
         let mode =                          p.TryGetResult ConnectionMode
         let timeout =                       p.GetResult(Timeout, 5.) |> TimeSpan.FromSeconds
         let retries =                       p.GetResult(Retries, 1)
         let maxRetryWaitTime =              p.GetResult(RetriesWaitTime, 5.) |> TimeSpan.FromSeconds
         let connector =                     Equinox.CosmosStore.CosmosStoreConnector(discovery, timeout, retries, maxRetryWaitTime, ?mode = mode)
-        let database =                      p.TryGetResult Database |> Option.defaultWith (fun () -> c.CosmosDatabase)
-        let container =                     p.TryGetResult Container |> Option.defaultWith (fun () -> c.CosmosContainer)
+        let database =                      p.GetResult(Database, fun () -> c.CosmosDatabase)
+        let container =                     p.GetResult(Container, fun () -> c.CosmosContainer)
         member _.Connect() =                connector.ConnectContext("Target", database, container)
 
 module Dynamo =
@@ -106,9 +103,9 @@ module Dynamo =
                                             | Some systemName ->
                                                 Choice1Of2 systemName
                                             | None ->
-                                                let serviceUrl =  p.TryGetResult ServiceUrl |> Option.defaultWith (fun () -> c.DynamoServiceUrl)
-                                                let accessKey =   p.TryGetResult AccessKey  |> Option.defaultWith (fun () -> c.DynamoAccessKey)
-                                                let secretKey =   p.TryGetResult SecretKey  |> Option.defaultWith (fun () -> c.DynamoSecretKey)
+                                                let serviceUrl =  p.GetResult(ServiceUrl, fun () -> c.DynamoServiceUrl)
+                                                let accessKey =   p.GetResult(AccessKey, fun () -> c.DynamoAccessKey)
+                                                let secretKey =   p.GetResult(SecretKey, fun () -> c.DynamoSecretKey)
                                                 Choice2Of2 (serviceUrl, accessKey, secretKey)
         let connector =                     let timeout = p.GetResult(RetriesTimeoutS, 5.) |> TimeSpan.FromSeconds
                                             let retries = p.GetResult(Retries, 1)
@@ -117,6 +114,6 @@ module Dynamo =
                                                 Equinox.DynamoStore.DynamoStoreConnector(systemName, timeout, retries)
                                             | Choice2Of2 (serviceUrl, accessKey, secretKey) ->
                                                 Equinox.DynamoStore.DynamoStoreConnector(serviceUrl, accessKey, secretKey, timeout, retries)
-        let table =                         p.TryGetResult Table      |> Option.defaultWith (fun () -> c.DynamoTable)
+        let table =                         p.GetResult(Table, fun () -> c.DynamoTable)
         member _.Connect() =                connector.CreateClient().CreateContext("Main", table)
 #endif            

--- a/propulsion-reactor/Reactor.fsproj
+++ b/propulsion-reactor/Reactor.fsproj
@@ -34,7 +34,7 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="Argu" Version="6.1.1" />
+        <PackageReference Include="Argu" Version="6.1.4" />
         <PackageReference Include="Equinox.SqlStreamStore.MsSql" Version="4.0.0-rc.14.5" />
         <PackageReference Include="Propulsion.CosmosStore" Version="3.0.0-rc.9.11" />
         <PackageReference Include="Propulsion.DynamoStore" Version="3.0.0-rc.9.11" />

--- a/propulsion-summary-consumer/SummaryConsumer.fsproj
+++ b/propulsion-summary-consumer/SummaryConsumer.fsproj
@@ -16,7 +16,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Argu" Version="6.1.1" />
+    <PackageReference Include="Argu" Version="6.1.4" />
     <PackageReference Include="Equinox.CosmosStore" Version="4.0.0-rc.14.5" />
     <PackageReference Include="FsCodec.SystemTextJson" Version="3.0.0-rc.14.1" />
     <PackageReference Include="Propulsion.Kafka" Version="3.0.0-rc.9.11" />

--- a/propulsion-sync/Sync.fsproj
+++ b/propulsion-sync/Sync.fsproj
@@ -13,7 +13,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Argu" Version="6.1.1" />
+    <PackageReference Include="Argu" Version="6.1.4" />
     <PackageReference Include="Propulsion.EventStore" Version="3.0.0-rc.9.11" />
     <PackageReference Include="Propulsion.CosmosStore" Version="3.0.0-rc.9.11" />
     <!--#if (kafka || marveleqx)-->

--- a/propulsion-tracking-consumer/TrackingConsumer.fsproj
+++ b/propulsion-tracking-consumer/TrackingConsumer.fsproj
@@ -16,7 +16,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Argu" Version="6.1.1" />
+    <PackageReference Include="Argu" Version="6.1.4" />
 	<PackageReference Include="Equinox.CosmosStore" Version="4.0.0-rc.14.5" />
 	<PackageReference Include="FsCodec.SystemTextJson" Version="3.0.0-rc.14.1" />
 	<PackageReference Include="Propulsion.Kafka" Version="3.0.0-rc.9.11" />


### PR DESCRIPTION
Tidying argument processing:
- Using [Argu's new GetResult](https://github.com/fsprojects/Argu/pull/187)
- Removing noise via `RequireSubcommand`
- Replace `MissingArg` with `p.Raise`